### PR TITLE
add missing dependency

### DIFF
--- a/workloads/data_caching/memcached/README.md
+++ b/workloads/data_caching/memcached/README.md
@@ -5,14 +5,14 @@
 From repo:
 
 ```
-$ sudo yum install autoconf scons gengetopt automake
+$ sudo yum install autoconf scons gengetopt automake libevent-devel
 ```
 
 Bundled binaries:
 
 ```
 $ sudo rpm -i dependencies/scons-2.4.1-1.noarch.rpm
-$ sudo rpm -i gengetopt-2.22.6-1.el7.x86_64.rpm
+$ sudo rpm -i dependencies/gengetopt-2.22.6-1.el7.x86_64.rpm
 ```
 
 ## Build memcached and mutilate


### PR DESCRIPTION
libevent-devel package is necessary to build memcached and mutilate
