### PR TITLE
Sensitivity package (ExperimentDriver - Sce 155) provided

### DIFF
--- a/pkg/experiment/sensitivity/sensitivity.go
+++ b/pkg/experiment/sensitivity/sensitivity.go
@@ -2,42 +2,54 @@ package sensitivity
 
 import "github.com/intelsdi-x/swan/pkg/workloads"
 
-//Configuration
+// Configuration - set of parameters to controll the experiment.
 type Configuration struct {
-	SLO             int
-	TuningTimeout   int
-	LoadDuration    int
+	// Given SLO for the experiment.
+	SLO int
+	// Tunning time in [s].
+	TuningTimeout int
+	// Each measurement duration in [s].
+	LoadDuration int
+	// Number of load points to test.
 	LoadPointsCount int
 }
 
-//Experiment
+// Experiment is handler structure for Experiment Driver. All fields shall be
+// not visible to the experimenter.
 type Experiment struct {
-	// Latency Sensitivity workload
+	// Latency Sensitivity (Production) workload.
 	pr workloads.Launcher
-	// Workload Generator for Latency Sensitivity workload
+	// Workload Generator for Latency Sensitivity task.
 	lgForPr workloads.LoadGenerator
-	// Aggressors to be but aside to LC workload
-	be         []workloads.Launcher
-	ec         Configuration
+	// Aggressors (Best Effort) tasks to stress LC task
+	bes []workloads.Launcher
+	// Experiement configuration
+	conf Configuration
+	// Max load with SLO not violated.
 	targetLoad int
-	slis       [][]int
+	// Result SLIs in a [aggressor][loadpoint] layout.
+	slis [][]int
 }
 
-// Construct new Experiment object.
-//NewExperiment()
+// NewExperiment construct new Experiment object.
+// Input parameters:
+// configuration - Experiment configuration
+// productionTaskLauncher - Latency Critical job launcher
+// loadGeneratorForProductionTask - stresser for production task
+// aggressorTasksLaucher - Best Effort jobs launcher
 func NewExperiment(
 	configuration Configuration,
 	productionTaskLauncher workloads.Launcher,
 	loadGeneratorForProductionTask workloads.LoadGenerator,
 	aggressorTaskLaunchers []workloads.Launcher) *Experiment {
 
-	//TODO: Validate configuration.
+	// TODO(mpatelcz): Validate configuration.
 
 	return &Experiment{
 		pr:      productionTaskLauncher,
 		lgForPr: loadGeneratorForProductionTask,
-		be:      aggressorTaskLaunchers,
-		ec:      configuration,
+		bes:     aggressorTaskLaunchers,
+		conf:    configuration,
 	}
 }
 
@@ -58,7 +70,7 @@ func (e *Experiment) runMeasurement(
 	if err != nil {
 		return 0, err
 	}
-	sli, err = e.lgForPr.Load(qps, e.ec.LoadDuration)
+	sli, err = e.lgForPr.Load(qps, e.conf.LoadDuration)
 
 	agrTask.Stop()
 	return sli, err
@@ -66,9 +78,9 @@ func (e *Experiment) runMeasurement(
 
 func (e *Experiment) runPhase(
 	aggressor workloads.Launcher) (slis []int, err error) {
-	slis = make([]int, e.ec.LoadPointsCount)
+	slis = make([]int, e.conf.LoadPointsCount)
 
-	loadStep := int(e.targetLoad / e.ec.LoadPointsCount)
+	loadStep := int(e.targetLoad / e.conf.LoadPointsCount)
 
 	for load := loadStep; load < e.targetLoad; load += loadStep {
 		result, err := e.runMeasurement(aggressor, load)
@@ -87,7 +99,7 @@ func (e *Experiment) runTunning() error {
 	}
 	defer prTask.Stop()
 
-	e.targetLoad, err = e.lgForPr.Tune(e.ec.SLO, e.ec.TuningTimeout)
+	e.targetLoad, err = e.lgForPr.Tune(e.conf.SLO, e.conf.TuningTimeout)
 	if err != nil {
 		e.targetLoad = -1
 		return err
@@ -95,21 +107,23 @@ func (e *Experiment) runTunning() error {
 	return err
 }
 
-// Prints nice output. TBD
+// PrintSensitivityProfile prints in a user friendly form Experiement's
+// resutls.
 func (e *Experiment) PrintSensitivityProfile() error {
 	return nil
 }
 
+// Run runs experiment.
+// In the end it prints results to the standard output.
 func (e *Experiment) Run() error {
 	var err error
 
 	err = e.runTunning()
 	if err != nil {
-		//Stop here
 		return err
 	}
 
-	for _, aggressor := range e.be {
+	for _, aggressor := range e.bes {
 		slis, err := e.runPhase(aggressor)
 		if err != nil {
 			return err

--- a/pkg/experiment/sensitivity/sensitivity_test.go
+++ b/pkg/experiment/sensitivity/sensitivity_test.go
@@ -30,7 +30,7 @@ type myLaucher struct {
 }
 
 func (l myLaucher) Launch() (executor.Task, error) {
-	return myTask{0}, nil
+	return myTask{}, nil
 }
 
 // Implement fake LoadGenerator interface
@@ -51,7 +51,7 @@ func TestExperiment(t *testing.T) {
 		var (
 			pr      workloads.Launcher
 			lgForPr workloads.LoadGenerator
-			aggr    []workloads.Launcher
+			aggrs   []workloads.Launcher
 		)
 		conf := Configuration{
 			SLO:             100,
@@ -60,11 +60,11 @@ func TestExperiment(t *testing.T) {
 			LoadPointsCount: 19,
 		}
 
-		pr = myLaucher{0}
-		lgForPr = myLoadGenerator{0}
-		aggr = append(aggr, myLaucher{0})
+		pr = myLaucher{}
+		lgForPr = myLoadGenerator{}
+		aggrs = append(aggrs, myLaucher{})
 
-		exp := NewExperiment(conf, pr, lgForPr, aggr)
+		exp := NewExperiment(conf, pr, lgForPr, aggrs)
 		Convey("should be successful", func() {
 			So(exp.Run(), ShouldBeNil)
 		})


### PR DESCRIPTION
This PR provides initial implementation for Sensitivity Profile Experiment - specialized Experiment Driver.

Sensitivity Profile Experiment mimics the Heracles paper experiments. It launched Latency Critical job at  given Load together with Aggressors. Experiment is composed of phases - where in each phase different Aggressor is combined with LC task.

Experimenter provides input parameters of experiment: SLO, time of tuning, time of each measurement, number of measurement in phase (loadpoints).
Experimenter is responsible for providing interface types Launcher for LC task and Aggressors and LoadGenerator type for load generator for LC

Currently the way of presenting results has not yet been decided and it's stub.
