### PR TITLE
SCE-229: Replaced fifo with infinitive sleep in Local Executor tests.

### DIFF
--- a/pkg/executor/local_test.go
+++ b/pkg/executor/local_test.go
@@ -13,8 +13,7 @@ func TestLocal(t *testing.T) {
 	Convey("While using Local Shell", t, func() {
 		l := NewLocal()
 
-		Convey("When blocking infinitively sleep command "+
-			"is executed", func() {
+		Convey("When blocking infinitively sleep command is executed", func() {
 			task, err := l.Execute("sleep inf")
 
 			Convey("There should be no error", func() {


### PR DESCRIPTION
Folks from K8s SDI suggest we could use sleep inf for blocking command instead of fifo setup. Less code and do the same.

Additionally refactored tests to be more readable.
