### PR TITLE
SCE-155 - using testify to mock test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /workloads/low-level-aggressors/stream.100M
 /build
 /vendor
+**/debug.test

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ deps:
 	go get github.com/tools/godep
 	go get github.com/golang/lint/golint
 	go get github.com/GeertJohan/fgt # return exit, fgt runs any command for you and exits with exitcode 1
+	go get github.com/stretchr/testify
 	godep restore -v
 
 # testing

--- a/pkg/executor/Godeps/Readme
+++ b/pkg/executor/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/pkg/executor/mocks/executor.go
+++ b/pkg/executor/mocks/executor.go
@@ -1,0 +1,32 @@
+package mocks
+
+import "github.com/intelsdi-x/swan/pkg/executor"
+import "github.com/stretchr/testify/mock"
+
+// Executor mock
+type Executor struct {
+	mock.Mock
+}
+
+// Execute provides a mock function with given fields: command
+func (_m *Executor) Execute(command string) (executor.Task, error) {
+	ret := _m.Called(command)
+
+	var r0 executor.Task
+	if rf, ok := ret.Get(0).(func(string) executor.Task); ok {
+		r0 = rf(command)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(executor.Task)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(command)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/pkg/executor/mocks/task.go
+++ b/pkg/executor/mocks/task.go
@@ -1,0 +1,60 @@
+package mocks
+
+import "github.com/intelsdi-x/swan/pkg/executor"
+import "github.com/stretchr/testify/mock"
+
+// Task mock
+type Task struct {
+	mock.Mock
+}
+
+// Status provides a mock function with given fields:
+func (_m *Task) Status() (executor.TaskState, *executor.Status) {
+	ret := _m.Called()
+
+	var r0 executor.TaskState
+	if rf, ok := ret.Get(0).(func() executor.TaskState); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(executor.TaskState)
+	}
+
+	var r1 *executor.Status
+	if rf, ok := ret.Get(1).(func() *executor.Status); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*executor.Status)
+		}
+	}
+
+	return r0, r1
+}
+
+// Stop provides a mock function with given fields:
+func (_m *Task) Stop() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Wait provides a mock function with given fields: timeoutMs
+func (_m *Task) Wait(timeoutMs int) bool {
+	ret := _m.Called(timeoutMs)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(int) bool); ok {
+		r0 = rf(timeoutMs)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}

--- a/pkg/experiment/sensitivity/sensitivity_test.go
+++ b/pkg/experiment/sensitivity/sensitivity_test.go
@@ -2,71 +2,47 @@ package sensitivity
 
 import (
 	"testing"
-
 	"github.com/intelsdi-x/swan/pkg/executor"
+	executorMocks "github.com/intelsdi-x/swan/pkg/executor/mocks"
 	"github.com/intelsdi-x/swan/pkg/workloads"
+	workloadMocks "github.com/intelsdi-x/swan/pkg/workloads/mocks"
 	. "github.com/smartystreets/goconvey/convey"
+	"errors"
 )
 
-//Implement fake Task interface
-type myTask struct {
-	state int
-}
-
-func (t myTask) Stop() error {
-	return nil
-}
-
-func (t myTask) Status() (executor.TaskState, *executor.Status) {
-	return executor.TERMINATED, &executor.Status{}
-}
-
-func (t myTask) Wait(timeoutMs int) bool {
-	return true
-}
-
-type myLaucher struct {
-	status int
-}
-
-func (l myLaucher) Launch() (executor.Task, error) {
-	return myTask{}, nil
-}
-
-// Implement fake LoadGenerator interface
-type myLoadGenerator struct {
-	status int
-}
-
-func (g myLoadGenerator) Tune(slo int, timeoutMs int) (targetQPS int, err error) {
-	return 0, nil
-}
-
-func (g myLoadGenerator) Load(qps int, durationMs int) (sli int, err error) {
-	return 0, nil
-}
-
 func TestExperiment(t *testing.T) {
-	Convey("Run new Experiment with faked launchers", t, func() {
-		var (
-			pr      workloads.Launcher
-			lgForPr workloads.LoadGenerator
-			aggrs   []workloads.Launcher
-		)
-		conf := Configuration{
-			SLO:             100,
-			TuningTimeout:   200,
-			LoadDuration:    10,
-			LoadPointsCount: 19,
+	Convey("While using sensitivity profile experiment", t, func() {
+		lcLauncher := new(workloadMocks.Launcher)
+		loadGenerator := new(workloadMocks.LoadGenerator)
+		configuration := Configuration{
+			SLO: 1,
+			TuningTimeout: 1,
+			LoadDuration: 1,
+			LoadPointsCount: 1,
 		}
+		var aggressors []workloads.Launcher
+		aggressors = append(aggressors, new(workloadMocks.Launcher))
+		sensitivityExperiment := NewExperiment(configuration, lcLauncher, loadGenerator, aggressors)
 
-		pr = myLaucher{}
-		lgForPr = myLoadGenerator{}
-		aggrs = append(aggrs, myLaucher{})
+		Convey("But production task can't be launched", func() {
+			lcLauncher.On("Launch").Return(*new(executor.Task), errors.New("Production task can't be launched"))
+			loadGenerator.AssertNotCalled(t, "Tune", 1, 1)
 
-		exp := NewExperiment(conf, pr, lgForPr, aggrs)
-		Convey("should be successful", func() {
-			So(exp.Run(), ShouldBeNil)
+			productionTaskLaunchError := sensitivityExperiment.Run()
+			So(productionTaskLaunchError.Error(), ShouldEqual, "Production task can't be launched")
+		})
+
+		Convey("And task is started successfully", func() {
+			lcTask := new(executorMocks.Task)
+			lcTask.On("Stop").Return(nil)
+			lcLauncher.On("Launch").Return(lcTask, nil)
+
+			Convey("But load generator can't be tuned", func() {
+				loadGenerator.On("Tune", 1, 1).Return(0, errors.New("Load generator can't be tuned"))
+
+				loadGeneratorTuningError := sensitivityExperiment.Run()
+				So(loadGeneratorTuningError.Error(), ShouldEqual, "Load generator can't be tuned")
+			})
 		})
 	})
 }

--- a/pkg/workloads/mocks/launcher.go
+++ b/pkg/workloads/mocks/launcher.go
@@ -1,0 +1,34 @@
+package mocks
+
+import (
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/stretchr/testify/mock"
+)
+
+// Launcher mock
+type Launcher struct {
+	mock.Mock
+}
+
+// Launch provides a mock function with given fields:
+func (_m *Launcher) Launch() (executor.Task, error) {
+	ret := _m.Called()
+
+	var r0 executor.Task
+	if rf, ok := ret.Get(0).(func() executor.Task); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(executor.Task)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/pkg/workloads/mocks/load_generator.go
+++ b/pkg/workloads/mocks/load_generator.go
@@ -1,0 +1,50 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+// LoadGenerator mock
+type LoadGenerator struct {
+	mock.Mock
+}
+
+// Load provides a mock function with given fields: qps, durationMs
+func (_m *LoadGenerator) Load(qps int, durationMs int) (int, error) {
+	ret := _m.Called(qps, durationMs)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(int, int) int); ok {
+		r0 = rf(qps, durationMs)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = rf(qps, durationMs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Tune provides a mock function with given fields: slo, timeoutMs
+func (_m *LoadGenerator) Tune(slo int, timeoutMs int) (int, error) {
+	ret := _m.Called(slo, timeoutMs)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(int, int) int); ok {
+		r0 = rf(slo, timeoutMs)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = rf(slo, timeoutMs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
Using testify to mock dependencies. As of now it does not seem to be feasible to use [mockery](https://github.com/vektra/mockery) to generate mocks during Travis builds. It might be possible to use the tool locally in order to generate mocks that are committed to the repository.
