### PR TITLE
SCE-254 - running snapd with cassandra publisher plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /build
 /vendor
 **/debug.test
+/misc/snap-on-docker/snap/snap-plugin-publisher-cassandra

--- a/misc/snap-on-docker/README.md
+++ b/misc/snap-on-docker/README.md
@@ -1,0 +1,28 @@
+Running snapd with cassandra publisher and cassandra database
+=============================================================
+
+First of all you will need a snap-plugin-publisher-cassandra binary. As of writing you will need to compile it manually using version 0.13-beta of snap (the version number is **really important**). Once compiled it should be copied to `snap-on-docker/snap`. 
+
+Then you will be able to use the scripts described below.
+
+build.sh
+--------
+
+Builds both necessary docker images (for snapd and cassandra) and sets networking up.
+
+start.sh
+--------
+
+Starts both containers in a manner that allows them to talk to each other. It will attempt to stop containter is they are running. Container names are hardcoded to _snap_ and _cassandra-1_.
+
+It will also configure example task and will create necessary cassandra keyspace and table.
+
+stop.sh
+-------
+
+Stops _snap_ and _cassandra-1_ containers if they are running.
+
+clean.sh
+--------
+
+Cleans the environment up by deleting images and network

--- a/misc/snap-on-docker/build.sh
+++ b/misc/snap-on-docker/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker network create --driver=bridge snap-cassandra
+docker build --force-rm --tag=swan-cassandra:latest cassandra
+docker build --force-rm --tag=swan-snap:latest --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy snap

--- a/misc/snap-on-docker/cassandra/Dockerfile
+++ b/misc/snap-on-docker/cassandra/Dockerfile
@@ -1,0 +1,5 @@
+FROM cassandra:latest
+MAINTAINER Maciej Iwanowski "maciej.iwanowski@intel.com"
+
+COPY create.sh /create.sh
+RUN ["chmod","+x","/create.sh"]

--- a/misc/snap-on-docker/cassandra/create.sh
+++ b/misc/snap-on-docker/cassandra/create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+/usr/bin/cqlsh -e "CREATE KEYSPACE snap WITH replication = {'class': 'SimpleStrategy','replication_factor':1}"
+/usr/bin/cqlsh -e "CREATE TABLE snap.metrics (ns text, ver int, host text, time timestamp, valtype text, doubleVal double, boolVal boolean, strVal text, labels list<text>, tags map<text,text>, PRIMARY KEY ((ns, ver, host), time)) WITH CLUSTERING ORDER BY (time DESC);"

--- a/misc/snap-on-docker/clean.sh
+++ b/misc/snap-on-docker/clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+./stop.sh
+docker network rm snap-cassandra
+docker rmi -f swan-cassandra:latest
+docker rmi -f swan-snap:latest

--- a/misc/snap-on-docker/snap/Dockerfile
+++ b/misc/snap-on-docker/snap/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:jessie
+MAINTAINER Maciej Iwanowski "maciej.iwanowski@intel.com"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+RUN apt-get update -qq && \
+    apt-get install -qq --fix-missing -y wget && \
+    apt-get dist-upgrade -qq -y
+
+RUN mkdir -p /home/snap && \
+    echo "snap:x:1000:1000:Snap Daemon,,,:/home/snap:/bin/bash" >> /etc/passwd && \
+    echo "snap:x:1000:" >> /etc/group && \
+    chown snap:snap -R /home/snap
+
+USER snap
+ENV HOME /home/snap
+WORKDIR /home/snap
+
+RUN wget https://github.com/intelsdi-x/snap/releases/download/v0.13.0-beta/snap-v0.13.0-beta-linux-amd64.tar.gz -O snap.tar.gz -q && \
+    tar zxf snap.tar.gz && \
+    wget https://github.com/intelsdi-x/snap/releases/download/v0.13.0-beta/snap-plugins-v0.13.0-beta-linux-amd64.tar.gz -O plugins.tar.gz -q && \
+    tar zxf plugins.tar.gz && \
+    rm snap.tar.gz && \
+    rm plugins.tar.gz
+
+ENV PATH $PATH:/usr/local/go/bin
+
+COPY snap-plugin-publisher-cassandra /home/snap/snap-v0.13.0-beta/plugin/
+COPY snapd.yml /home/snap/
+COPY task.json /home/snap/
+ENV PATH $PATH:/home/snap/snap-v0.13.0-beta/bin
+
+EXPOSE 8181
+
+CMD ["/home/snap/snap-v0.13.0-beta/bin/snapd","--config","/home/snap/snapd.yml","--plugin-trust","0"]

--- a/misc/snap-on-docker/snap/snapd.yml
+++ b/misc/snap-on-docker/snap/snapd.yml
@@ -1,0 +1,9 @@
+log_level: 1
+control:
+    auto_discover_path: /home/snap/snap-v0.13.0-beta/plugin
+    max_running_plugins: 500
+plugins:
+    publisher:
+        cassandra:
+            all:
+                server: cassandra-1

--- a/misc/snap-on-docker/snap/task.json
+++ b/misc/snap-on-docker/snap/task.json
@@ -1,0 +1,29 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/psutil/load/load1": {},
+                "/intel/psutil/load/load5": {},
+                "/intel/psutil/load/load15": {},
+                "/intel/psutil/vm/available": {},
+                "/intel/psutil/vm/free": {},
+                "/intel/psutil/vm/used": {}
+            },
+            "config": {},
+            "process": null,
+            "publish": [
+                {
+                    "plugin_name": "cassandra",                            
+                    "config": {
+                        "server": "cassandra-1"
+                    }
+                }
+            ]                                            
+        }
+    }
+}

--- a/misc/snap-on-docker/start.sh
+++ b/misc/snap-on-docker/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+./stop.sh
+docker run -d --net=snap-cassandra --name=cassandra-1 --hostname=cassandra-1 swan-cassandra:latest
+IS_CASSANDRA_RUNNING=1
+echo "Waiting for cassandra to launch, it may take some time..."
+while [ $IS_CASSANDRA_RUNNING -ne 0 ]
+do
+	docker exec cassandra-1 cqlsh -e"DESC KEYSPACES;" 1>/dev/null 2>/dev/null
+	IS_CASSANDRA_RUNNING=$?
+done
+echo "Cassandra is now ready to accept connections"
+docker exec cassandra-1 /create.sh
+docker run -d --net=snap-cassandra --name=snap --hostname=snap swan-snap:latest
+IS_SNAP_RUNNING=1
+echo "Waiting for snapd to launch, it may take some time..."
+while [ $IS_SNAP_RUNNING -ne 0 ]
+do
+	docker exec snap snapctl -u http://snap:8181 task list 1>/dev/null 2>/dev/null
+	IS_SNAP_RUNNING=$?
+done
+echo "snapd is now ready to accept connections"
+docker exec snap snapctl -u http://snap:8181 task create -t /home/snap/task.json

--- a/misc/snap-on-docker/stop.sh
+++ b/misc/snap-on-docker/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker stop cassandra-1 && docker rm cassandra-1
+docker stop snap && docker rm snap


### PR DESCRIPTION
I had to launch snapd and cassandra in order to figure out if cassandra publisher works as expected. It does seem to work.

Two Dockerfiles are provided so other team members can launch the environment easily (bunch of shell scripts should help too).
