### PR TITLE
Added `-race` flag as default option for makefile tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 # Place for custom options for test commands.
-TEST_OPT?=
+TEST_OPT?=-race
 
 all: lint unit_test build
 


### PR DESCRIPTION
We want our Swan to be race-free, so let's have more restrictive Travis! (:

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
