### PR TITLE
SCE-230: Executor stdout and stderr are too unique

### DIFF
--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -2,13 +2,13 @@ package executor
 
 import (
 	"errors"
-	log "github.com/Sirupsen/logrus"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // Local provisioning is responsible for providing the execution environment
@@ -31,13 +31,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 	// to have ability to kill all the children processes.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// Create temporary output files.
-	currentDir, _ := os.Getwd()
-	stdoutFile, err := ioutil.TempFile(currentDir, "swan_local_executor_stdout_")
-	if err != nil {
-		return nil, err
-	}
-	stderrFile, err := ioutil.TempFile(currentDir, "swan_local_executor_stderr_")
+	stdoutFile, stderrFile, err := createExecutorOutputFiles(command, "local")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/output_files_utils.go
+++ b/pkg/executor/output_files_utils.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+func getBinaryNameFromCommand(command string) (string, error) {
+	_, name := path.Split(command)
+	nameSplit := strings.Split(name, " ")
+	if len(nameSplit) == 0 {
+		return "", fmt.Errorf("Failed to extract command name from %s", command)
+	}
+	return nameSplit[0], nil
+}
+
+func createExecutorOutputFiles(command, prefix string) (stdout, stderr *os.File, err error) {
+	if len(command) == 0 {
+		return nil, nil, errors.New("Empty command string")
+	}
+
+	commandName, err := getBinaryNameFromCommand(command)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to get working directory. Error: %s\n", err.Error())
+	}
+	outputDir, err := ioutil.TempDir(pwd, prefix+"_"+commandName+"_")
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create output directory for %s. Error: %s\n", commandName,
+			err.Error())
+	}
+
+	stdoutFileName := path.Join(outputDir, "stdout")
+	stdout, err = os.Create(stdoutFileName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stderr, err = os.Create(path.Join(outputDir, "stderr"))
+	if err != nil {
+		os.Remove(stdoutFileName)
+		return nil, nil, err
+	}
+
+	return stdout, stderr, err
+}

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -3,11 +3,11 @@ package executor
 import (
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
-	"io/ioutil"
 	"os"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 )
 
 // Remote provisioning is responsible for providing the execution environment
@@ -53,13 +53,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 		return nil, err
 	}
 
-	// Create temporary output files.
-	currentDir, _ := os.Getwd()
-	stdoutFile, err := ioutil.TempFile(currentDir, "swan_remote_executor_stdout_")
-	if err != nil {
-		return nil, err
-	}
-	stderrFile, err := ioutil.TempFile(currentDir, "swan_remote_executor_stderr_")
+	stdoutFile, stderrFile, err := createExecutorOutputFiles(command, "remote")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If we launch victim and aggressor as a result in phase directory we will
have four unique file names. Without looking at the content we are not
able to match them.
The content of the Phase repetition directory looks like following (for local executor)
PhaseName/0/
   local_executor_stdoud_aaaaaaaa
   local_executor_stdout_bbbbbbbb
   local_executor_stderr_ccccccccc
   local_executor_stderr_dddddddd

This commit changes this to:

PhaseName/0/
   local_memcached_aaaaaa/
      stdout
      stderr
   local_mutilate_bbbbbb/
      stdout
      stderr

Signed-off-by: Maciej Patelczyk maciej.patelczyk@intel.com
