### PR TITLE
SCE-330: Removed incompatible, unnecessary test case from std output mutilate test.

### DIFF
--- a/misc/snap-plugin-collector-mutilate/mutilate/std_output_integration_test.go
+++ b/misc/snap-plugin-collector-mutilate/mutilate/std_output_integration_test.go
@@ -16,12 +16,6 @@ func TestStdoutParser(t *testing.T) {
 			"open /non/existing/file: no such file or directory")
 
 	})
-	Convey("Opening non-readable file should fail", t, func() {
-		data, err := parseMutilateStdout("/etc/shadow")
-
-		So(data, ShouldBeZeroValue)
-		So(err.Error(), ShouldEqual, "open /etc/shadow: permission denied")
-	})
 
 	Convey("Opening readable and correct file should provide meaningful results", t, func() {
 		data, err := parseMutilateStdout(GetCurrentDirFilePath("/mutilate.stdout"))

--- a/misc/snap-plugin-collector-session-test/session-collector/session-collector.go
+++ b/misc/snap-plugin-collector-session-test/session-collector/session-collector.go
@@ -13,8 +13,8 @@ import (
 type SessionCollector struct{}
 
 const (
-	name = "session-test"
-	version = 1
+	name       = "session-test"
+	version    = 1
 	pluginType = plugin.CollectorPluginType
 )
 

--- a/pkg/snap/session_test.go
+++ b/pkg/snap/session_test.go
@@ -194,7 +194,6 @@ func TestSnap(t *testing.T) {
 						continue
 					}
 
-
 					So(columns[0], ShouldEqual, "/intel/swan/session/metric1")
 					So(tags[0], ShouldEqual, "swan_experiment=foobar")
 					So(tags[1], ShouldEqual, "swan_phase=barbaz")


### PR DESCRIPTION
Removed unnecessary test case, since it is failing on some machines because of the bad file permissions.

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
