### PR TITLE
SCE-328: Wrong assumption on array content

### DIFF
--- a/misc/snap-plugin-collector-mutilate/mutilate/mutilate_test.go
+++ b/misc/snap-plugin-collector-mutilate/mutilate/mutilate_test.go
@@ -92,11 +92,18 @@ func TestMutilatePlugin(t *testing.T) {
 			}
 
 			for i := range metrics {
+				containsMetric := false
 				for _, expectedMetric := range expectedMetricsValues {
 					if strings.Contains(metrics[i].Namespace().String(), expectedMetric.namespace) {
 						soValidMetric(metrics[i], expectedMetric.namespace, expectedMetric.value,
 							expectedMetric.date)
+						containsMetric = true
+						break
 					}
+				}
+				if !containsMetric {
+					t.Error("Expected metrics do not contain given metric " +
+						metrics[i].Namespace().String())
 				}
 			}
 


### PR DESCRIPTION
Change tests in mutilate as they were based on assumption that order of
metrics is fixed.

Array returned by CollectMetrics does not have guaranteed order of metrics and
tests for hardcoded order fail.
With this change different metrics returned in any order are tested.
