### PR TITLE
SCE-343: Enable pid namespaces for sshd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,5 @@ cleanup:
 	rm -f misc/snap-plugin-collector-mutilate/????-??-??_snap-plugin-collector-mutilate.log
 	rm -f misc/snap-plugin-collector-mutilate/????-??-??_snap-plugin-collector-mutilate.test.log
 	rm -f misc/snap-plugin-collector-mutilate/mutilate/????-??-??_mutilate.test.log
+	rm -rf integration_tests/pkg/executor/remote_memcached_*
+	rm -fr integration_tests/pkg/snap/local_snapd_*

--- a/experiments/memcached/baseline_local/memcached.go
+++ b/experiments/memcached/baseline_local/memcached.go
@@ -1,15 +1,16 @@
 package main
 
 import (
+	"os"
+	"path"
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	"github.com/intelsdi-x/swan/pkg/workloads/mutilate"
 	"github.com/shopspring/decimal"
-	"os"
-	"path"
-	"time"
 )
 
 const (

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,14 @@
+Integration tests prerequisites
+===============================
+
+pkg/executor/remote_test.go
+---------------------------
+
+This test is intended to pass while connecting to Centos 7 host.
+
+You need to provide following environment variables on your host:
+* `REMOTE_EXECUTOR_TEST_HOST` - hostname or IP address of the host that executor should SSH.
+* `REMOTE_EXECUTOR_USER` - username to be used to establish SSH connection.
+* `REMOTE_EXECUTOR_SSH_KEY` - key (in PEM format) to be used for SSH authentication.
+* `REMOTE_EXECUTOR_MEMCACHED_BIN_PATH` - path to memcached binary on the host.
+* `REMOTE_EXECUTOR_MEMCACHED_USER` - user to run memcached with (-u option).

--- a/integration_tests/pkg/executor/remote_test.go
+++ b/integration_tests/pkg/executor/remote_test.go
@@ -1,0 +1,147 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/workloads"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	EnvHost          = "REMOTE_EXECUTOR_TEST_HOST"
+	EnvUser          = "REMOTE_EXECUTOR_USER"
+	EnvKey           = "REMOTE_EXECUTOR_SSH_KEY"
+	EnvMemcachedPath = "REMOTE_EXECUTOR_MEMCACHED_BIN_PATH"
+	EnvMemcachedUser = "REMOTE_EXECUTOR_MEMCACHED_USER"
+)
+
+var terminal ssh.TerminalModes
+
+func init() {
+	terminal = ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}
+}
+
+func TestRemoteProcessPidIsolation(t *testing.T) {
+	if isEnvironmentReady() {
+		Convey("When I create remote executor for memcached", t, testRemoteProcessPidIsolation)
+	} else {
+		SkipConvey("When I create remote executor for memcached", t, testRemoteProcessPidIsolation)
+	}
+}
+
+func isEnvironmentReady() bool {
+	ready := true
+	if value := os.Getenv(EnvHost); value == "" {
+		ready = false
+	}
+	if value := os.Getenv(EnvUser); value == "" {
+		ready = false
+	}
+
+	if value := os.Getenv(EnvKey); value == "" {
+		ready = false
+	}
+	if value := os.Getenv(EnvMemcachedPath); value == "" {
+		ready = false
+	}
+	if value := os.Getenv(EnvMemcachedUser); value == "" {
+		ready = false
+	}
+
+	return ready
+}
+
+func testRemoteProcessPidIsolation() {
+	clientConfig, cErr := executor.NewClientConfig(os.Getenv(EnvUser), os.Getenv(EnvKey))
+	So(cErr, ShouldBeNil)
+	sshConfig := executor.NewSSHConfig(clientConfig, os.Getenv(EnvHost), 22)
+	launcher := newMultipleMemcached(*sshConfig)
+
+	Convey("I should be able to execute remote command and see the processes running", func() {
+		task, err := launcher.Launch()
+
+		client, err := ssh.Dial("tcp", os.Getenv(EnvHost)+":22", clientConfig)
+		So(err, ShouldBeNil)
+		defer client.Close()
+		pids := soProcessesAreRunning(client, "memcached", 2)
+
+		Convey("I should be able to stop remote task and all the processes should be terminated",
+			func() {
+				err := task.Stop()
+				So(err, ShouldBeNil)
+				_, err = task.ExitCode()
+				So(err, ShouldBeNil)
+				soProcessIsNotRunning(client, pids[0])
+				soProcessIsNotRunning(client, pids[1])
+			})
+	})
+
+}
+
+func newMultipleMemcached(sshConfig executor.SSHConfig) workloads.Launcher {
+	decors := isolation.Decorators{}
+	unshare, _ := isolation.NewNamespace(syscall.CLONE_NEWPID)
+	decors = append(decors, unshare)
+	exec := executor.NewRemote(sshConfig, decors)
+
+	return multipleMemcached{exec}
+}
+
+type multipleMemcached struct {
+	executor executor.Executor
+}
+
+func (m multipleMemcached) Launch() (executor.TaskHandle, error) {
+	bin := os.Getenv(EnvMemcachedPath)
+	username := os.Getenv(EnvMemcachedUser)
+	return m.executor.Execute(
+		fmt.Sprintf("/bin/bash -c \"%s -u %s -d && %s -u %s -p 54321\"", bin, username, bin, username))
+}
+
+func soProcessesAreRunning(client *ssh.Client, processName string, noOfPids int) (pids []string) {
+	session, err := client.NewSession()
+	So(err, ShouldBeNil)
+	defer session.Close()
+	err = session.RequestPty("xterm", 80, 40, terminal)
+	So(err, ShouldBeNil)
+
+	output, err := session.Output("pgrep " + processName)
+	So(err, ShouldBeNil)
+	pids = strings.Split(strings.Trim(string(output), "\n\r"), "\n")
+	So(pids, ShouldHaveLength, noOfPids)
+
+	for k, pid := range pids {
+		pid = strings.Trim(pid, "\n\r")
+		_, err = strconv.Atoi(pid)
+		So(err, ShouldBeNil)
+		pids[k] = pid
+
+	}
+
+	return pids
+}
+
+func soProcessIsNotRunning(client *ssh.Client, pid string) {
+	session, err := client.NewSession()
+	So(err, ShouldBeNil)
+	defer session.Close()
+	err = session.RequestPty("xterm", 80, 40, terminal)
+	So(err, ShouldBeNil)
+	_, err = session.Output("sudo cat /proc/" + pid + "/cmdline")
+	So(err, ShouldNotBeNil)
+	So(err.Error(), ShouldStartWith, "Process exited with: 1")
+
+}

--- a/integration_tests/pkg/snap/session_test.go
+++ b/integration_tests/pkg/snap/session_test.go
@@ -2,17 +2,19 @@ package snap
 
 import (
 	"fmt"
-	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/scheduler/wmap"
-	"github.com/intelsdi-x/swan/pkg/experiment/phase"
-	"github.com/intelsdi-x/swan/pkg/snap"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/intelsdi-x/snap/mgmt/rest/client"
+	"github.com/intelsdi-x/swan/pkg/experiment/phase"
+	"github.com/intelsdi-x/swan/pkg/snap"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/intelsdi-x/snap/scheduler/wmap"
 )
 
 const (
@@ -114,9 +116,7 @@ func TestSnap(t *testing.T) {
 
 						Convey("Contacting snap to get the task status", func() {
 							status, err := s.Status()
-
 							So(err, ShouldBeNil)
-
 							So(status, ShouldEqual, "Running")
 
 							Convey("Reading samples from file", func() {

--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -1,15 +1,16 @@
 package workloads
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -173,7 +173,7 @@ func testExecutor(t *testing.T, executor Executor) {
 	})
 
 	Convey("When command which does not exists is executed", func() {
-		taskHandle, err := executor.Execute("commandThatDoesNotExists")
+		taskHandle, err := executor.Execute("/bin/sh -c commandThatDoesNotExists")
 		So(err, ShouldBeNil)
 
 		defer taskHandle.Stop()

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -8,19 +8,22 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/isolation"
 	"golang.org/x/crypto/ssh"
 )
 
 // Remote provisioning is responsible for providing the execution environment
 // on remote machine via ssh.
 type Remote struct {
-	sshConfig SSHConfig
+	sshConfig         SSHConfig
+	commandDecorators isolation.Decorator
 }
 
 // NewRemote returns a Local instance.
-func NewRemote(sshConfig SSHConfig) *Remote {
+func NewRemote(sshConfig SSHConfig, decorator isolation.Decorator) *Remote {
 	return &Remote{
 		sshConfig,
+		decorator,
 	}
 }
 
@@ -65,7 +68,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 	session.Stdout = stdoutFile
 	session.Stderr = stderrFile
 
-	err = session.Start(command)
+	err = session.Start(remote.commandDecorators.Decorate(command))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/remote_test.go
+++ b/pkg/executor/remote_test.go
@@ -1,13 +1,16 @@
 package executor
 
 import (
-	log "github.com/Sirupsen/logrus"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"os"
 	"os/user"
 	"regexp"
+	"syscall"
 	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/isolation"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 // This tests required following setup:
@@ -70,9 +73,11 @@ func TestRemote(t *testing.T) {
 
 			Convey("And while using Remote Shell and connection to localhost", func() {
 				sshConfig := NewSSHConfig(clientConfig, "localhost", 22)
+				isolationPid, err := isolation.NewNamespace(syscall.CLONE_NEWPID)
+				So(err, ShouldBeNil)
 
 				Convey("The generic Executor test should pass", func() {
-					testExecutor(t, NewRemote(*sshConfig))
+					testExecutor(t, NewRemote(*sshConfig, isolationPid))
 				})
 			})
 		})

--- a/pkg/isolation/cpu.go
+++ b/pkg/isolation/cpu.go
@@ -18,9 +18,9 @@ func NewCPUShares(name string, shares int) Isolation {
 	return &CPUShares{name: name, shares: shares}
 }
 
-// Prefix returns the command prefix to run with this isolation mechanism.
-func (cpu *CPUShares) Prefix() string {
-	return "cgexec -g cpu:" + cpu.name
+// Decorate implements Decorator interface
+func (cpu *CPUShares) Decorate(command string) string {
+	return "cgexec -g cpu:" + cpu.name + " " + command
 }
 
 // Clean removes the specified cgroup

--- a/pkg/isolation/cpu_set.go
+++ b/pkg/isolation/cpu_set.go
@@ -24,9 +24,9 @@ func NewCPUSet(name string, cpus Set, mems Set) Isolation {
 	}
 }
 
-// Prefix returns the command prefix to run with this isolation mechanism.
-func (cpuSet *CPUSet) Prefix() string {
-	return "cgexec -g cpuset:" + cpuSet.name
+// Decorate implements Decorator interface
+func (cpuSet *CPUSet) Decorate(command string) string {
+	return "cgexec -g cpuset:" + cpuSet.name + " " + command
 }
 
 // Clean removes specified cgroup.

--- a/pkg/isolation/decorator.go
+++ b/pkg/isolation/decorator.go
@@ -1,0 +1,18 @@
+package isolation
+
+//Decorator allows to decorate launcher output.
+type Decorator interface {
+	Decorate(string) string
+}
+
+//Decorators represents array of Decorator implementations.
+type Decorators []Decorator
+
+//Decorate uses all available decorators to modify the command
+//(and implements Decorator interface).
+func (d Decorators) Decorate(command string) string {
+	for _, decorator := range d {
+		command = decorator.Decorate(command)
+	}
+	return command
+}

--- a/pkg/isolation/isolation.go
+++ b/pkg/isolation/isolation.go
@@ -2,8 +2,8 @@ package isolation
 
 //Isolation of resources exposes these interfaces
 type Isolation interface {
+	Decorator
 	Create() error
 	Isolate(PID int) error
 	Clean() error
-	Prefix() string
 }

--- a/pkg/isolation/memory_size.go
+++ b/pkg/isolation/memory_size.go
@@ -21,9 +21,9 @@ func NewMemorySize(name string, size int) Isolation {
 	}
 }
 
-// Prefix returns the command prefix to run with this isolation mechanism.
-func (memorySize *MemorySize) Prefix() string {
-	return "cgexec -g memory:" + memorySize.name
+// Decorate implements Decorator interface.
+func (memorySize *MemorySize) Decorate(command string) string {
+	return "cgexec -g memory:" + memorySize.name + " " + command
 }
 
 // Clean removes specified cgroup.

--- a/pkg/isolation/namespace.go
+++ b/pkg/isolation/namespace.go
@@ -1,0 +1,40 @@
+package isolation
+
+import (
+	"errors"
+	"strings"
+	"syscall"
+)
+
+type namespace struct {
+	ns         int
+	nsToOption map[int]string
+}
+
+// NewNamespace creates new instance of namespace isolation; see: man 7 namespaces.
+func NewNamespace(mask int) (Decorator, error) {
+	if mask&(syscall.CLONE_NEWIPC|syscall.CLONE_NEWNET|syscall.CLONE_NEWNS|syscall.CLONE_NEWPID|syscall.CLONE_NEWUSER|syscall.CLONE_NEWUTS) == 0 {
+		return nil, errors.New("Invalid namespace mask")
+	}
+	optionMap := make(map[int]string)
+	optionMap[syscall.CLONE_NEWPID] = "--fork --pid --mount-proc"
+	optionMap[syscall.CLONE_NEWIPC] = "--ipc"
+	optionMap[syscall.CLONE_NEWNS] = "--mount"
+	optionMap[syscall.CLONE_NEWUTS] = "--uts"
+	optionMap[syscall.CLONE_NEWNET] = "--net"
+	optionMap[syscall.CLONE_NEWUSER] = "--user"
+	return &namespace{ns: mask, nsToOption: optionMap}, nil
+}
+
+// Decorate implements Decorator.
+func (n *namespace) Decorate(command string) (decorated string) {
+	var namespaces []string
+
+	for namespace, option := range n.nsToOption {
+		if n.ns&namespace == namespace {
+			namespaces = append(namespaces, option)
+		}
+	}
+
+	return "unshare " + strings.Join(namespaces, " ") + " " + command
+}

--- a/pkg/isolation/namespace_test.go
+++ b/pkg/isolation/namespace_test.go
@@ -1,0 +1,66 @@
+package isolation
+
+import (
+	"syscall"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNamespaceDecorator(t *testing.T) {
+	Convey("When I pass invalid namespace definition then decorator should not be instantiated", t, func() {
+		decorator, err := NewNamespace(666)
+		So(decorator, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("When I pass valid namespace definition then decorator should be instantiated", t, func() {
+		decorator, err := NewNamespace(syscall.CLONE_NEWPID)
+		So(decorator, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		Convey("When I decorate with PID namespace then I should see correct string prepended to the command", func() {
+			command := "Some random command"
+			decorated := decorator.Decorate(command)
+			So(decorated, ShouldEqual, "unshare --fork --pid --mount-proc Some random command")
+		})
+	})
+
+	Convey("Wnen I pass definition of multiple namespace then decorator should be instantiated", t, func() {
+		namespace := syscall.CLONE_NEWIPC | syscall.CLONE_NEWNET | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID | syscall.CLONE_NEWUSER | syscall.CLONE_NEWUTS
+		decorator, err := NewNamespace(namespace)
+		So(decorator, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+
+		Convey("When I decorate with multiple namespaces then decorator should work as expected", func() {
+			command := "All the namespaces are all I want!"
+			decorated := decorator.Decorate(command)
+			So(decorated, ShouldContainSubstring, " --fork --pid --mount-proc ")
+			So(decorated, ShouldContainSubstring, " --ipc ")
+			So(decorated, ShouldContainSubstring, " --mount ")
+			So(decorated, ShouldContainSubstring, " --uts ")
+			So(decorated, ShouldContainSubstring, " --net ")
+			So(decorated, ShouldContainSubstring, " --user ")
+			So(decorated, ShouldStartWith, "unshare ")
+			So(decorated, ShouldEndWith, " All the namespaces are all I want!")
+		})
+	})
+
+	Convey("When I run multiple decorators then I should receive decorated command with expected ordering", t, func() {
+		isolationNet, _ := NewNamespace(syscall.CLONE_NEWNET)
+		isolationIpc, _ := NewNamespace(syscall.CLONE_NEWIPC)
+		var decorators Decorators
+		decorators = append(decorators, isolationNet, isolationIpc)
+
+		decorated := decorators.Decorate("Some random command")
+		So(decorated, ShouldEqual, "unshare --ipc unshare --net Some random command")
+	})
+
+	Convey("When I use empty array of decorators then I should receive unmodified command", t, func() {
+		var decorators Decorators
+
+		decorated := decorators.Decorate("This comand should be left intact")
+		So(decorated, ShouldEqual, "This comand should be left intact")
+	})
+
+}

--- a/pkg/workloads/memcached/memcached_test.go
+++ b/pkg/workloads/memcached/memcached_test.go
@@ -2,11 +2,13 @@ package memcached
 
 import (
 	"errors"
+	"syscall"
 	"testing"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor/mocks"
+	"github.com/intelsdi-x/swan/pkg/isolation"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -27,90 +29,96 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 		expectedCommand = "test -p 11211 -u memcached -t 4 -m 64 -c 1024"
 		expectedHost    = "127.0.0.1"
 	)
+	Convey("When I create PID namespace isolation", t, func() {
+		mockedExecutor := new(mocks.Executor)
+		mockedTaskHandle := new(mocks.TaskHandle)
+		var decorators []isolation.Decorator
+		unshare, err := isolation.NewNamespace(syscall.CLONE_NEWPID)
+		So(err, ShouldBeNil)
+		decorators = append(decorators, unshare)
 
-	mockedExecutor := new(mocks.Executor)
-	mockedTaskHandle := new(mocks.TaskHandle)
+		Convey("While using Memcached launcher", func() {
+			memcachedLauncher := New(
+				mockedExecutor,
+				DefaultMemcachedConfig("test"))
+			memcachedLauncher.tryConnect = connectTimeoutSuccess
+			Convey("While simulating proper execution", func() {
+				mockedExecutor.On("Execute", expectedCommand).Return(mockedTaskHandle, nil).Once()
+				mockedTaskHandle.On("Address").Return(expectedHost)
 
-	Convey("While using Memcached launcher", t, func() {
-		memcachedLauncher := New(
-			mockedExecutor,
-			DefaultMemcachedConfig("test"))
-		memcachedLauncher.tryConnect = connectTimeoutSuccess
-		Convey("While simulating proper execution", func() {
-			mockedExecutor.On("Execute", expectedCommand).Return(mockedTaskHandle, nil).Once()
-			mockedTaskHandle.On("Address").Return(expectedHost)
-			Convey("Build command should create proper command", func() {
-				command := memcachedLauncher.buildCommand()
-				So(command, ShouldEqual, expectedCommand)
+				Convey("Build command should create proper command", func() {
+					command := memcachedLauncher.buildCommand()
+					So(command, ShouldEqual, expectedCommand)
 
-				Convey("Arguments passed to Executor should be a proper command", func() {
-					task, err := memcachedLauncher.Launch()
-					So(err, ShouldBeNil)
+					Convey("Arguments passed to Executor should be a proper command", func() {
+						task, err := memcachedLauncher.Launch()
+						So(err, ShouldBeNil)
 
-					So(task, ShouldNotBeNil)
-					So(task, ShouldEqual, mockedTaskHandle)
+						So(task, ShouldNotBeNil)
+						So(task, ShouldEqual, mockedTaskHandle)
 
-					Convey("Location of the returned task shall be 127.0.0.1", func() {
-						addr := task.Address()
-						So(addr, ShouldEqual, expectedHost)
-						mockedTaskHandle.AssertExpectations(t)
+						Convey("Location of the returned task shall be 127.0.0.1", func() {
+							addr := task.Address()
+							So(addr, ShouldEqual, expectedHost)
+							mockedTaskHandle.AssertExpectations(t)
+						})
+						mockedExecutor.AssertExpectations(t)
 					})
-					mockedExecutor.AssertExpectations(t)
-				})
-				Convey("When test connection to memcached fails task handle shall be nil and error shall be return", func() {
-					mockedTaskHandle.On("Stop").Return(nil)
-					mockedTaskHandle.On("Clean").Return(nil)
-					memcachedLauncher.tryConnect = connectTimeoutFailure
-					task, err := memcachedLauncher.Launch()
-					So(err, ShouldNotBeNil)
-					So(task, ShouldBeNil)
+					Convey("When test connection to memcached fails task handle shall be nil and error shall be return", func() {
+						mockedTaskHandle.On("Stop").Return(nil)
+						mockedTaskHandle.On("Clean").Return(nil)
+						memcachedLauncher.tryConnect = connectTimeoutFailure
+						task, err := memcachedLauncher.Launch()
+						So(err, ShouldNotBeNil)
+						So(task, ShouldBeNil)
 
-					mockedExecutor.AssertExpectations(t)
-				})
-				Convey("When test connection to memcached fails and task.Stop fails task handle shall be nil and error shall be return", func() {
-					mockedTaskHandle.On("Stop").Return(errors.New("Test error code for stop"))
-					mockedTaskHandle.On("Clean").Return(nil)
-					memcachedLauncher.tryConnect = connectTimeoutFailure
-					task, err := memcachedLauncher.Launch()
-					So(err, ShouldNotBeNil)
-					So(task, ShouldBeNil)
+						mockedExecutor.AssertExpectations(t)
+					})
+					Convey("When test connection to memcached fails and task.Stop fails task handle shall be nil and error shall be return", func() {
+						mockedTaskHandle.On("Stop").Return(errors.New("Test error code for stop"))
+						mockedTaskHandle.On("Clean").Return(nil)
+						memcachedLauncher.tryConnect = connectTimeoutFailure
+						task, err := memcachedLauncher.Launch()
+						So(err, ShouldNotBeNil)
+						So(task, ShouldBeNil)
 
-					mockedExecutor.AssertExpectations(t)
-				})
-				Convey("When test connection to memcached fails, task.Stop succeeds and task.Clean fails task handle shall be nil and error shall be return", func() {
-					mockedTaskHandle.On("Stop").Return(nil)
-					mockedTaskHandle.On("Clean").Return(errors.New("Test error code for clean"))
-					memcachedLauncher.tryConnect = connectTimeoutFailure
-					task, err := memcachedLauncher.Launch()
-					So(err, ShouldNotBeNil)
-					So(task, ShouldBeNil)
+						mockedExecutor.AssertExpectations(t)
+					})
+					Convey("When test connection to memcached fails, task.Stop succeeds and task.Clean fails task handle shall be nil and error shall be return", func() {
+						mockedTaskHandle.On("Stop").Return(nil)
+						mockedTaskHandle.On("Clean").Return(errors.New("Test error code for clean"))
+						memcachedLauncher.tryConnect = connectTimeoutFailure
+						task, err := memcachedLauncher.Launch()
+						So(err, ShouldNotBeNil)
+						So(task, ShouldBeNil)
 
-					mockedExecutor.AssertExpectations(t)
+						mockedExecutor.AssertExpectations(t)
+					})
+
+				})
+
+			})
+
+			Convey("While simulating error execution", func() {
+				mockedExecutor.On("Execute", expectedCommand).Return(nil, errors.New("test")).Once()
+
+				Convey("Build command should create proper command", func() {
+					command := memcachedLauncher.buildCommand()
+					So(command, ShouldEqual, expectedCommand)
+
+					Convey("Arguments passed to Executor should be a proper command", func() {
+						task, err := memcachedLauncher.Launch()
+						So(err, ShouldNotBeNil)
+						So(err.Error(), ShouldEqual, "test")
+
+						So(task, ShouldBeNil)
+
+						mockedExecutor.AssertExpectations(t)
+					})
 				})
 
 			})
 
 		})
-
-		Convey("While simulating error execution", func() {
-			mockedExecutor.On("Execute", expectedCommand).Return(nil, errors.New("test")).Once()
-
-			Convey("Build command should create proper command", func() {
-				command := memcachedLauncher.buildCommand()
-				So(command, ShouldEqual, expectedCommand)
-
-				Convey("Arguments passed to Executor should be a proper command", func() {
-					task, err := memcachedLauncher.Launch()
-					So(err, ShouldNotBeNil)
-					So(err.Error(), ShouldEqual, "test")
-
-					So(task, ShouldBeNil)
-
-					mockedExecutor.AssertExpectations(t)
-				})
-			})
-
-		})
-
 	})
 }


### PR DESCRIPTION
The goal of this PR is to ensure that all the processes started with remote executor (the SSH-based one) will be killed when SSH connection is closed/terminated.
