### PR TITLE
SCE-267: Remove any files/directories on EraseOutput in taskHandle.

### DIFF
--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -1,13 +1,15 @@
 package executor
 
 import (
-	log "github.com/Sirupsen/logrus"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"os"
+	"path"
 	"sync"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 // testExecutor tests the execution of process for given executor.
@@ -304,6 +306,42 @@ func testExecutor(t *testing.T, executor Executor) {
 				So(err, ShouldBeNil)
 				So(exitcode, ShouldEqual, 0)
 			})
+
+			Convey("And the output files shall remain", func() {
+				stdoutFile, err := taskHandle.StdoutFile()
+				So(err, ShouldBeNil)
+				stderrFile, err := taskHandle.StderrFile()
+				So(err, ShouldBeNil)
+				stdoutStat, stdoutErr := os.Stat(stdoutFile.Name())
+				stderrStat, stderrErr := os.Stat(stderrFile.Name())
+				So(stdoutErr, ShouldBeNil)
+				So(stderrErr, ShouldBeNil)
+				So(stdoutStat.Mode().IsRegular(), ShouldBeTrue)
+				So(stderrStat.Mode().IsRegular(), ShouldBeTrue)
+			})
 		})
+	})
+	Convey("When command `sleep 0` is executed and EraseOutput is called output files shall be removed", func() {
+		taskHandle, err := executor.Execute("sleep 0")
+		So(err, ShouldBeNil)
+
+		taskHandle.Wait(1 * time.Second)
+
+		stdoutFile, _ := taskHandle.StdoutFile()
+		stderrFile, _ := taskHandle.StderrFile()
+
+		outputDir, _ := path.Split(stdoutFile.Name())
+
+		taskHandle.Stop()
+		taskHandle.Clean()
+		taskHandle.EraseOutput()
+
+		_, stdoutErr := os.Stat(stdoutFile.Name())
+		_, stderrErr := os.Stat(stderrFile.Name())
+		_, outputDirErr := os.Stat(outputDir)
+
+		So(stdoutErr, ShouldNotBeNil)
+		So(stderrErr, ShouldNotBeNil)
+		So(outputDirErr, ShouldNotBeNil)
 	})
 }

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 	"syscall"
 	"time"
@@ -205,16 +206,12 @@ func (taskHandle *localTaskHandle) Clean() error {
 
 // EraseOutput removes task's stdout & stderr files.
 func (taskHandle *localTaskHandle) EraseOutput() error {
-	// Remove stdout file.
-	if err := os.Remove(taskHandle.stdoutFile.Name()); err != nil {
+	outputDir, _ := path.Split(taskHandle.stdoutFile.Name())
+
+	// Remove temporary directory created for stdout and stderr.
+	if err := os.RemoveAll(outputDir); err != nil {
 		return err
 	}
-
-	// Remove stderr file.
-	if err := os.Remove(taskHandle.stderrFile.Name()); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -236,16 +237,12 @@ func (taskHandle *remoteTaskHandle) Clean() error {
 
 // EraseOutput removes task's stdout & stderr files.
 func (taskHandle *remoteTaskHandle) EraseOutput() error {
-	// Remove stdout file.
-	if err := os.Remove(taskHandle.stdoutFile.Name()); err != nil {
+	outputDir, _ := path.Split(taskHandle.stdoutFile.Name())
+
+	// Remove temporary directory created for stdout and stderr.
+	if err := os.RemoveAll(outputDir); err != nil {
 		return err
 	}
-
-	// Remove stderr file.
-	if err := os.Remove(taskHandle.stderrFile.Name()); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Local & Remove executors create local temporary directory for stdout
and stderr for the executed command. TaskHandle.EraseOutput removes
stdout and stderr files while leaving the temporary directory untouched.

This commit changes EraseOutput behaviour so that it also removes the
temporary directory.

Signed-off-by: Maciej Patelczyk maciej.patelczyk@intel.com
