### PR TITLE
Prepare build directory for "plugins" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ unit_test:
 	./scripts/isolate-pid.sh go test $(TEST_OPT) ./misc/...
 
 plugins:
+	mkdir -p build
 	(cd build; go build ../misc/snap-plugin-collector-session-test)
 	(cd build; go build ../misc/snap-plugin-processor-session-tagging)
 	(cd build; go build ../misc/snap-plugin-publisher-session-test)


### PR DESCRIPTION
This patch prepares `build` directory when it's doesn't exist. It's required for `plugins` target in case, when we run it without `build` target
