### PR TITLE
Fixed bug where bytes gets computed in float instead of integer

### DIFF
--- a/integration_tests/pkg/isolation/memory_size_test.go
+++ b/integration_tests/pkg/isolation/memory_size_test.go
@@ -23,7 +23,7 @@ func TestMemorySize(t *testing.T) {
 	}
 
 	memoryName := "M"
-	memorysizeInBytes := 64 * bytefmt.MEGABYTE
+	memorysizeInBytes := int(64 * bytefmt.MEGABYTE)
 	memorysize := isolation.NewMemorySize(memoryName, memorysizeInBytes)
 
 	cmd := exec.Command("sh", "-c", "sleep 1h")


### PR DESCRIPTION
While computing the number of bytes from bytefmt.MEGABYTES, the resulting type ended up being a float instead of an int. This patch casts to int.
