### PR TITLE
SCE-328: Wrong assumption in mutilate collector

### DIFF
--- a/misc/snap-plugin-collector-mutilate/mutilate/mutilate.go
+++ b/misc/snap-plugin-collector-mutilate/mutilate/mutilate.go
@@ -94,11 +94,10 @@ func (mutilate *plugin) CollectMetrics(metricTypes []snapPlugin.MetricType) ([]s
 			Unit_: metricType.Unit_, Version_: metricType.Version_}
 		metric.Namespace_[3].Value = hostname
 		metric.Timestamp_ = mutilate.now
-		for m := range rawMetrics {
-			rawMetricName := rawMetrics[m].name
+		for _, m := range rawMetrics {
 			// Assign value to metric for proper name.
-			if strings.Contains(metricType.Namespace().String(), rawMetricName) {
-				metric.Data_ = rawMetrics[m].value
+			if strings.Contains(metricType.Namespace().String(), m.name) {
+				metric.Data_ = m.value
 			}
 		}
 		dynamicNamespace := metric.Namespace_[len(metric.Namespace_)-2]


### PR DESCRIPTION
In mutilate collector in CollectMetrics() there was an assumption that
rawMetrics are read in the same order as metric types received from
GetMetricsTypes().

This patch fixes it by assigning value to metric (for given namespace) only
if metric name is found in this namespace.
