### PR TITLE
SCE-364: If task handle is nil, nested convey statements still gets executed

### DIFF
--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -39,11 +39,11 @@ func TestMemcachedWithExecutor(t *testing.T) {
 		Convey("When memcached is launched", func() {
 			// NOTE: It is needed for memcached to have default port available.
 			taskHandle, err := memcachedLauncher.Launch()
-			if taskHandle != nil {
-				defer taskHandle.Stop()
-				defer taskHandle.Clean()
-				defer taskHandle.EraseOutput()
-			}
+			So(taskHandle, ShouldNotBeNil)
+			defer taskHandle.Stop()
+			defer taskHandle.Clean()
+			defer taskHandle.EraseOutput()
+
 
 			Convey("There should be no error", func() {
 				stopErr := taskHandle.Stop()


### PR DESCRIPTION
Nested convey statements didn't protect against the task handle being nil. This assertion should at least fail the test instead of crashing.
