### PR TITLE
SCE-368: Added useful intset relations and tests.

### DIFF
--- a/pkg/isolation/set.go
+++ b/pkg/isolation/set.go
@@ -1,6 +1,7 @@
 package isolation
 
 import (
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -9,11 +10,78 @@ import (
 // on core and memory node ids.
 type Set map[int]struct{}
 
+// Empty returns true iff this set has exactly zero elements.
+func (as Set) Empty() bool {
+	return len(as) == 0
+}
+
+// Contains returns true if the supplied item is present in this set.
+func (as Set) Contains(item int) bool {
+	_, found := as[item]
+	return found
+}
+
+// Add mutates this set to include the supplied item.
+func (as Set) Add(item int) {
+	as[item] = struct{}{}
+}
+
+// Remove mutates this set to remove the supplied item.
+func (as Set) Remove(item int) {
+	delete(as, item) // does nothing if item does not exist
+}
+
+// Equals returns true iff the supplied set is equal to this set.
+func (as Set) Equals(bs Set) bool {
+	return reflect.DeepEqual(as, bs)
+}
+
+// Union returns a new set that contains all of the items from this set
+// and all of the items from the supplied set.
+// It does not mutate either set.
+func (as Set) Union(bs Set) Set {
+	result := NewSet()
+	for a := range as {
+		result.Add(a)
+	}
+	for b := range bs {
+		result.Add(b)
+	}
+	return result
+}
+
+// Intersection returns a new set that contains all of the items that are
+// present in both this set and the supplied set.
+// It does not mutate either set.
+func (as Set) Intersection(bs Set) Set {
+	result := NewSet()
+	for a := range as {
+		if bs.Contains(a) {
+			result.Add(a)
+		}
+	}
+	return result
+}
+
+// Difference returns a new set that contains all of the items that are
+// present in this set and not the supplied set.
+// It does not mutate either set.
+func (as Set) Difference(bs Set) Set {
+	result := NewSet()
+	for a := range as {
+		result.Add(a)
+	}
+	for b := range bs {
+		result.Remove(b)
+	}
+	return result
+}
+
 // NewSet returns a set containing the element from ids.
 func NewSet(ids ...int) Set {
 	ret := Set{}
 	for _, id := range ids {
-		ret[id] = struct{}{}
+		ret.Add(id)
 	}
 	return ret
 }
@@ -52,7 +120,7 @@ func NewSetFromRange(rangesString string) (Set, error) {
 			// And add all the ids to the set.
 			// Here, "0-5", "46-48" should become [0,1,2,3,4,5,46,47,48]
 			for id := start; id <= end; id++ {
-				ret[id] = struct{}{}
+				ret.Add(id)
 			}
 		}
 	}

--- a/pkg/isolation/set_test.go
+++ b/pkg/isolation/set_test.go
@@ -14,24 +14,93 @@ func TestSet(t *testing.T) {
 			Convey("Should have length 0", func() {
 				So(s1, ShouldHaveLength, 0)
 			})
+
+			Convey("Should be empty", func() {
+				So(s1.Empty(), ShouldBeTrue)
+			})
 		})
 
 		Convey("Creating a set with three elements", func() {
 			s1 := NewSet(1, 5, 7)
 
+			Convey("Should not be empty", func() {
+				So(s1.Empty(), ShouldBeFalse)
+			})
+
 			Convey("Should have length 3", func() {
 				So(s1, ShouldHaveLength, 3)
 
 				Convey("And the elements should be present", func() {
-					_, ok := s1[1]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[5]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[7]
-					So(ok, ShouldBeTrue)
+					So(s1.Contains(1), ShouldBeTrue)
+					So(s1.Contains(5), ShouldBeTrue)
+					So(s1.Contains(7), ShouldBeTrue)
 				})
+
+				Convey("And other elements should not be present", func() {
+					So(s1.Contains(2), ShouldBeFalse)
+					So(s1.Contains(4), ShouldBeFalse)
+					So(s1.Contains(6), ShouldBeFalse)
+				})
+			})
+		})
+
+		Convey("Creating two sets that share only one element", func() {
+			s1 := NewSet(1, 3, 5, 7)
+			s2 := NewSet(2, 4, 6, 7)
+
+			Convey("Each set should equal itself", func() {
+				So(s1.Equals(s1), ShouldBeTrue)
+				So(s2.Equals(s2), ShouldBeTrue)
+
+				Convey("But they should not equal each other", func() {
+					So(s1.Equals(s2), ShouldBeFalse)
+					So(s2.Equals(s1), ShouldBeFalse)
+				})
+			})
+
+			Convey("The difference should not include the shared element", func() {
+				diff12 := s1.Difference(s2)
+				diff21 := s2.Difference(s1)
+				So(diff12.Contains(7), ShouldBeFalse)
+				So(diff21.Contains(7), ShouldBeFalse)
+
+				Convey("But they should contain all other original elements", func() {
+					So(diff12.Contains(1), ShouldBeTrue)
+					So(diff12.Contains(3), ShouldBeTrue)
+					So(diff12.Contains(5), ShouldBeTrue)
+
+					So(diff21.Contains(2), ShouldBeTrue)
+					So(diff21.Contains(4), ShouldBeTrue)
+					So(diff21.Contains(6), ShouldBeTrue)
+				})
+
+				Convey("And difference with themselves should be the empty set", func() {
+					So(s1.Difference(s1).Empty(), ShouldBeTrue)
+					So(s2.Difference(s2).Empty(), ShouldBeTrue)
+				})
+			})
+
+			Convey("Their union should contain all items", func() {
+				union := s1.Union(s2)
+				So(len(union), ShouldEqual, 7)
+				So(union.Contains(1), ShouldBeTrue)
+				So(union.Contains(2), ShouldBeTrue)
+				So(union.Contains(3), ShouldBeTrue)
+				So(union.Contains(4), ShouldBeTrue)
+				So(union.Contains(5), ShouldBeTrue)
+				So(union.Contains(6), ShouldBeTrue)
+				So(union.Contains(7), ShouldBeTrue)
+
+				Convey("And union with themselves should equal the original", func() {
+					So(s1.Union(s1).Equals(s1), ShouldBeTrue)
+					So(s2.Union(s2).Equals(s2), ShouldBeTrue)
+				})
+			})
+
+			Convey("Their intersection should contain only the shared item", func() {
+				intersection := s1.Intersection(s2)
+				So(len(intersection), ShouldEqual, 1)
+				So(intersection.Contains(7), ShouldBeTrue)
 			})
 		})
 
@@ -43,35 +112,24 @@ func TestSet(t *testing.T) {
 				So(s1, ShouldHaveLength, 10)
 
 				Convey("And the elements should be present", func() {
-					_, ok := s1[0]
-					So(ok, ShouldBeTrue)
+					So(s1.Contains(0), ShouldBeTrue)
+					So(s1.Contains(1), ShouldBeTrue)
+					So(s1.Contains(2), ShouldBeTrue)
+					So(s1.Contains(3), ShouldBeTrue)
+					So(s1.Contains(4), ShouldBeTrue)
+					So(s1.Contains(5), ShouldBeTrue)
 
-					_, ok = s1[1]
-					So(ok, ShouldBeTrue)
+					So(s1.Contains(34), ShouldBeTrue)
 
-					_, ok = s1[2]
-					So(ok, ShouldBeTrue)
+					So(s1.Contains(46), ShouldBeTrue)
+					So(s1.Contains(47), ShouldBeTrue)
+					So(s1.Contains(48), ShouldBeTrue)
+				})
 
-					_, ok = s1[3]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[4]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[5]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[34]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[46]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[47]
-					So(ok, ShouldBeTrue)
-
-					_, ok = s1[48]
-					So(ok, ShouldBeTrue)
+				Convey("And other elements should not be present", func() {
+					So(s1.Contains(-2), ShouldBeFalse)
+					So(s1.Contains(32), ShouldBeFalse)
+					So(s1.Contains(50), ShouldBeFalse)
 				})
 			})
 		})


### PR DESCRIPTION
Summary of changes:
- Defines the following operations on the int set abstraction:
  - Add()
  - Remove()
  - Empty()
  - Contains()
  - Equals()
  - Union()
  - Intersection()
  - Difference()
- Adds tests for the above.

Testing done:
- `go test ./pkg/isolation --run=TestSet`
