### PR TITLE
Create `memcached` user if it doesn't exist

### DIFF
--- a/workloads/data_caching/memcached/build.sh
+++ b/workloads/data_caching/memcached/build.sh
@@ -3,6 +3,7 @@ rm -rf memcached-1.4.25/build
 mkdir memcached-1.4.25/build
 pushd memcached-1.4.25/build
 ../configure && make
+adduser mamcached
 popd
 
 pushd mutilate


### PR DESCRIPTION
Fixes issue where `memcached` user doesn't exist

Summary of changes:
- add user adding during `memcached` compilation

During building `memcached` from sources, we doesn't create `memcached`
user. This bug could affect on running `memcached` workload.
