### PR TITLE
SCE-368: Addressed review comments from PR #119.

### DIFF
--- a/integration_tests/pkg/isolation/cpu_set_test.go
+++ b/integration_tests/pkg/isolation/cpu_set_test.go
@@ -22,8 +22,8 @@ func TestCpuSet(t *testing.T) {
 	}
 
 	cpusetName := "M"
-	cpus := isolation.NewSet(0, 1)
-	mems := isolation.NewSet(0)
+	cpus := isolation.NewIntSet(0, 1)
+	mems := isolation.NewIntSet(0)
 
 	cpuset := isolation.NewCPUSet(cpusetName, cpus, mems)
 	cmd := exec.Command("sleep", "1h")
@@ -46,7 +46,7 @@ func TestCpuSet(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		inputFmt := string(data[:len(data)-1])
-		set, err := isolation.NewSetFromRange(inputFmt)
+		set, err := isolation.NewIntSetFromRange(inputFmt)
 		So(err, ShouldBeNil)
 		So(set, ShouldResemble, cpus)
 	})

--- a/pkg/executor/local_test.go
+++ b/pkg/executor/local_test.go
@@ -43,7 +43,7 @@ func TestLocal(t *testing.T) {
 		}
 
 		Convey("Creating a single cgroup with cpu set for core 0 numa node 0", func() {
-			cpuset := isolation.NewCPUSet("/A", isolation.NewSet(0), isolation.NewSet(0))
+			cpuset := isolation.NewCPUSet("/A", isolation.NewIntSet(0), isolation.NewIntSet(0))
 			cpuset.Create()
 			defer cpuset.Clean()
 

--- a/pkg/isolation/cpu_set.go
+++ b/pkg/isolation/cpu_set.go
@@ -11,12 +11,12 @@ import (
 // CPUSet describes a cgroup cpuset with core ids and numa (memory) nodes.
 type CPUSet struct {
 	name string
-	cpus Set
-	mems Set
+	cpus IntSet
+	mems IntSet
 }
 
 // NewCPUSet creates an instance of input data.
-func NewCPUSet(name string, cpus Set, mems Set) Isolation {
+func NewCPUSet(name string, cpus IntSet, mems IntSet) Isolation {
 	return &CPUSet{
 		name: name,
 		cpus: cpus,

--- a/pkg/isolation/set.go
+++ b/pkg/isolation/set.go
@@ -6,90 +6,90 @@ import (
 	"strings"
 )
 
-// Set represents a traditional set type so we can do intersections, joins, etc.
+// IntSet represents a traditional set type so we can do intersections, joins, etc.
 // on core and memory node ids.
-type Set map[int]struct{}
+type IntSet map[int]struct{}
 
 // Empty returns true iff this set has exactly zero elements.
-func (as Set) Empty() bool {
-	return len(as) == 0
+func (s IntSet) Empty() bool {
+	return len(s) == 0
 }
 
-// Contains returns true if the supplied item is present in this set.
-func (as Set) Contains(item int) bool {
-	_, found := as[item]
+// Contains returns true if the supplied element is present in this set.
+func (s IntSet) Contains(elem int) bool {
+	_, found := s[elem]
 	return found
 }
 
-// Add mutates this set to include the supplied item.
-func (as Set) Add(item int) {
-	as[item] = struct{}{}
+// Add mutates this set to include the supplied element.
+func (s IntSet) Add(elem int) {
+	s[elem] = struct{}{}
 }
 
-// Remove mutates this set to remove the supplied item.
-func (as Set) Remove(item int) {
-	delete(as, item) // does nothing if item does not exist
+// Remove mutates this set to remove the supplied element.
+func (s IntSet) Remove(elem int) {
+	delete(s, elem) // does nothing if item does not exist
 }
 
 // Equals returns true iff the supplied set is equal to this set.
-func (as Set) Equals(bs Set) bool {
-	return reflect.DeepEqual(as, bs)
+func (s IntSet) Equals(t IntSet) bool {
+	return reflect.DeepEqual(s, t)
 }
 
-// Union returns a new set that contains all of the items from this set
-// and all of the items from the supplied set.
+// Union returns a new set that contains all of the elements from this set
+// and all of the elements from the supplied set.
 // It does not mutate either set.
-func (as Set) Union(bs Set) Set {
-	result := NewSet()
-	for a := range as {
-		result.Add(a)
+func (s IntSet) Union(t IntSet) IntSet {
+	result := NewIntSet()
+	for elem := range s {
+		result.Add(elem)
 	}
-	for b := range bs {
-		result.Add(b)
+	for elem := range t {
+		result.Add(elem)
 	}
 	return result
 }
 
-// Intersection returns a new set that contains all of the items that are
+// Intersection returns a new set that contains all of the elements that are
 // present in both this set and the supplied set.
 // It does not mutate either set.
-func (as Set) Intersection(bs Set) Set {
-	result := NewSet()
-	for a := range as {
-		if bs.Contains(a) {
-			result.Add(a)
+func (s IntSet) Intersection(t IntSet) IntSet {
+	result := NewIntSet()
+	for elem := range s {
+		if t.Contains(elem) {
+			result.Add(elem)
 		}
 	}
 	return result
 }
 
-// Difference returns a new set that contains all of the items that are
+// Difference returns a new set that contains all of the elements that are
 // present in this set and not the supplied set.
 // It does not mutate either set.
-func (as Set) Difference(bs Set) Set {
-	result := NewSet()
-	for a := range as {
-		result.Add(a)
+func (s IntSet) Difference(t IntSet) IntSet {
+	result := NewIntSet()
+	for elem := range s {
+		result.Add(elem)
 	}
-	for b := range bs {
-		result.Remove(b)
+	for elem := range t {
+		result.Remove(elem)
 	}
 	return result
 }
 
-// NewSet returns a set containing the element from ids.
-func NewSet(ids ...int) Set {
-	ret := Set{}
-	for _, id := range ids {
-		ret.Add(id)
+// NewIntSet returns a new set containing all of the supplied elements.
+func NewIntSet(elems ...int) IntSet {
+	result := IntSet{}
+	for _, elem := range elems {
+		result.Add(elem)
 	}
-	return ret
+	return result
 }
 
-// NewSetFromRange creates a set from traditional cgroup set representation.
+// NewIntSetFromRange creates a set from traditional cgroup set representation.
 // For example, "0-5,34,46-48"
-func NewSetFromRange(rangesString string) (Set, error) {
-	ret := Set{}
+func NewIntSetFromRange(rangesString string) (IntSet, error) {
+	result := IntSet{}
 
 	// Split ranges string:
 	// "0-5,34,46-48" becomes ["0-5", "34", "46-48"]
@@ -99,31 +99,30 @@ func NewSetFromRange(rangesString string) (Set, error) {
 
 		if len(boundaries) == 1 {
 			// Some entries may only contain one id, like "34" in our example.
-			id, err := strconv.Atoi(boundaries[0])
+			elem, err := strconv.Atoi(boundaries[0])
 			if err != nil {
-				return Set{}, err
+				return nil, err
 			}
-
-			ret[id] = struct{}{}
+			result.Add(elem)
 		} else if len(boundaries) == 2 {
 			// For ranges, we parse start and end.
 			start, err := strconv.Atoi(boundaries[0])
 			if err != nil {
-				return Set{}, err
+				return nil, err
 			}
 
 			end, err := strconv.Atoi(boundaries[1])
 			if err != nil {
-				return Set{}, err
+				return nil, err
 			}
 
 			// And add all the ids to the set.
 			// Here, "0-5", "46-48" should become [0,1,2,3,4,5,46,47,48]
-			for id := start; id <= end; id++ {
-				ret.Add(id)
+			for elem := start; elem <= end; elem++ {
+				result.Add(elem)
 			}
 		}
 	}
 
-	return ret, nil
+	return result, nil
 }

--- a/pkg/isolation/set_test.go
+++ b/pkg/isolation/set_test.go
@@ -1,15 +1,17 @@
 package isolation
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
+	"fmt"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestSet(t *testing.T) {
+func TestIntSet(t *testing.T) {
 	Convey("When testing sets", t, func() {
 
 		Convey("When creating an empty set", func() {
-			s1 := NewSet()
+			s1 := NewIntSet()
 
 			Convey("Should have length 0", func() {
 				So(s1, ShouldHaveLength, 0)
@@ -20,8 +22,68 @@ func TestSet(t *testing.T) {
 			})
 		})
 
+		Convey("After adding elements to a set", func() {
+			s := NewIntSet()
+			numItems := 1024
+			for i := 0; i < numItems; i++ {
+				s.Add(i)
+			}
+
+			Convey(fmt.Sprintf("It should have length %d", numItems), func() {
+				So(s, ShouldHaveLength, numItems)
+			})
+
+			Convey("It should contain all added elements", func() {
+				for i := 0; i < numItems; i++ {
+					So(s.Contains(i), ShouldBeTrue)
+				}
+			})
+		})
+
+		Convey("When removing elements from a set", func() {
+			s := NewIntSet()
+			numItems := 1024
+			for i := 0; i < numItems; i++ {
+				s.Add(i)
+			}
+
+			Convey(fmt.Sprintf("After adding %d elements", numItems), func() {
+				Convey(fmt.Sprintf("It should have length %d", numItems), func() {
+					So(s, ShouldHaveLength, numItems)
+				})
+
+				Convey(fmt.Sprintf("After removing %d elements", numItems/2), func() {
+					for i := 0; i < numItems; i++ {
+						if i%2 == 0 {
+							s.Remove(i)
+						}
+					}
+
+					Convey(fmt.Sprintf("It should have length %d", numItems/2), func() {
+						So(s, ShouldHaveLength, numItems/2)
+					})
+
+					Convey("It should not contain any removed elements", func() {
+						for i := 0; i < numItems; i++ {
+							if i%2 == 0 {
+								So(s.Contains(i), ShouldBeFalse)
+							}
+						}
+					})
+
+					Convey("It should contain all expected remaining elements", func() {
+						for i := 0; i < numItems; i++ {
+							if i%2 != 0 {
+								So(s.Contains(i), ShouldBeTrue)
+							}
+						}
+					})
+				})
+			})
+		})
+
 		Convey("Creating a set with three elements", func() {
-			s1 := NewSet(1, 5, 7)
+			s1 := NewIntSet(1, 5, 7)
 
 			Convey("Should not be empty", func() {
 				So(s1.Empty(), ShouldBeFalse)
@@ -45,8 +107,8 @@ func TestSet(t *testing.T) {
 		})
 
 		Convey("Creating two sets that share only one element", func() {
-			s1 := NewSet(1, 3, 5, 7)
-			s2 := NewSet(2, 4, 6, 7)
+			s1 := NewIntSet(1, 3, 5, 7)
+			s2 := NewIntSet(2, 4, 6, 7)
 
 			Convey("Each set should equal itself", func() {
 				So(s1.Equals(s1), ShouldBeTrue)
@@ -102,10 +164,15 @@ func TestSet(t *testing.T) {
 				So(len(intersection), ShouldEqual, 1)
 				So(intersection.Contains(7), ShouldBeTrue)
 			})
+
+			Convey("The union of difference and intersection should equal the original", func() {
+				So(s1.Difference(s2).Union(s1.Intersection(s2)).Equals(s1), ShouldBeTrue)
+				So(s2.Difference(s1).Union(s2.Intersection(s1)).Equals(s2), ShouldBeTrue)
+			})
 		})
 
 		Convey("Creating a set with from range string \"0-5,34,46-48\"", func() {
-			s1, err := NewSetFromRange("0-5,34,46-48")
+			s1, err := NewIntSetFromRange("0-5,34,46-48")
 			So(err, ShouldBeNil)
 
 			Convey("Should have length 10", func() {


### PR DESCRIPTION
Summary of changes:
- Renamed Set to IntSet, since it is not generic.
- Updated IntSet receiver identifier name for readability (`as` => `s`).
- Added tests to directly verify the behavior of IntSet's Add and
  Remove.

Testing done:
- `make lint`
- `go test -v ./pkg/isolation --run=TestIntSet`
