### PR TITLE
Small fix for installing snap processor plugin dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ plugins:
 	(cd build; go build ../misc/snap-plugin-collector-session-test)
 	(cd build; go build ../misc/snap-plugin-publisher-session-test)
 	(cd build; go build ../misc/snap-plugin-collector-mutilate)
+	(go install github.com/intelsdi-x/snap-plugin-processor-tag)
 
 integration_test: plugins unit_test build_workloads
 	./scripts/isolate-pid.sh go test $(TEST_OPT) ./integration_tests/...

--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -39,6 +39,7 @@ func TestMemcachedWithExecutor(t *testing.T) {
 		Convey("When memcached is launched", func() {
 			// NOTE: It is needed for memcached to have default port available.
 			taskHandle, err := memcachedLauncher.Launch()
+			So(err, ShouldBeNil)
 			So(taskHandle, ShouldNotBeNil)
 			defer taskHandle.Stop()
 			defer taskHandle.Clean()
@@ -65,7 +66,6 @@ func TestMemcachedWithExecutor(t *testing.T) {
 				})
 
 				Convey("When we check the memcached endpoint for stats after 1 second", func() {
-
 					netstatTaskHandle, netstatErr := l.Execute(netstatCommand)
 					if netstatTaskHandle != nil {
 						defer netstatTaskHandle.Stop()


### PR DESCRIPTION
Fixes issue of `snap-plugin-processor-tag` not being installed using godeps.

Summary of changes:
- Installing this processor in makefile.

Testing done:
- make everything

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
