### PR TITLE
SCE-365: Adds CentOS vagrant setup for local development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,18 @@ Repository for automated experiments and data collection targeted enhanced perfo
 For now, the first supported workload is memcached. Memcached is stressed with the mutilate load generator.
 First, you must build memcached and mutilate from source. Go to the [memcached](workloads/data_caching/memcached) workload directory for instructions.
 
+**Local development**
+
 ```
 $ go get github.com/intelsdi-x/swan
 $ make deps
 $ make
 ```
+
+**Vagrant (Virtualbox) development environment**
+
+Follow the [Vagrant instructions](misc/dev/vagrant/singlenode/README.md) to
+create a Linux virtual machine pre-configured for developing Swan.
 
 ## Contributing
 

--- a/misc/dev/vagrant/singlenode/.gitignore
+++ b/misc/dev/vagrant/singlenode/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/misc/dev/vagrant/singlenode/README.md
+++ b/misc/dev/vagrant/singlenode/README.md
@@ -1,0 +1,48 @@
+# Local single-node development using Vagrant and Virtualbox
+
+## Quick start
+
+```sh
+$ git clone git@github.com:intelsdi-x/swan.git
+$ cd swan/misc/dev/vagrant/singlenode
+$ vagrant plugin install vagrant-vbguest  # automatic guest additions
+$ vagrant box update
+$ vagrant up  # takes a few minutes
+$ vagrant ssh
+> cd swan
+> make deps
+> make
+```
+
+## Prerequisites
+
+- [Vagrant](https://vagrantup.com)
+- [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
+
+## What's provided "out of the box"
+
+- CentOS 7 virtual machine with the following additional software packages:
+  - docker
+  - gengetopt
+  - git
+  - golang 1.6
+  - libcgroup-tools
+  - libevent-devel
+  - perf
+  - scons
+  - tree
+  - vim
+  - wget
+
+## Notes
+
+- The project directory is mounted in the guest file system: edit with your
+  preferred tools in the host OS!
+
+## Troubleshooting
+
+- If you get a connection error when attempting to SSH into the guest
+  VM and you're behind a proxy you may need to add an override rule to ignore
+  SSH traffic to localhost.
+- To re-run the VM provisioning shell scripts, do
+  `vagrant up --provision`

--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -1,0 +1,76 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "centos/7"
+  config.vm.box_check_update = false
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "10.141.141.10"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../../../..", "/home/vagrant/go/src/github.com/intelsdi-x/swan"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = false
+
+    vb.cpus = 2       # NOTE: integration tests fail with less than 2
+    vb.memory = 4096  # NOTE: integration tests tend to crash with less (gcc)
+  end
+
+  $install_packages = <<SCRIPT
+    echo Adding the docker yum repository
+    tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+    echo Updating package lists
+    yum update -y
+    echo Installing packages
+    yum install -y \
+      docker-engine \
+      gengetopt \
+      git \
+      libcgroup-tools \
+      libevent-devel \
+      perf \
+      scons \
+      tree \
+      vim \
+      wget
+    wget -P /tmp https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
+    tar xvf /tmp/go1.6.linux-amd64.tar.gz -C /usr/local
+SCRIPT
+
+  $configure_docker = <<SCRIPT
+    echo Configuring Docker
+    systemctl enable docker
+    gpasswd -a vagrant docker
+    systemctl restart docker
+SCRIPT
+
+  $setup_user_env = <<SCRIPT
+    echo Setting up user environment
+    chown -R vagrant:vagrant /home/vagrant/go
+    ln -s /home/vagrant/go/src/github.com/intelsdi-x/swan /home/vagrant/
+    echo 'export GOPATH="/home/vagrant/go"' >> /home/vagrant/.bash_profile
+    echo 'export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"' >> /home/vagrant/.bash_profile
+SCRIPT
+
+  config.vm.provision "shell", inline: $install_packages
+  config.vm.provision "shell", inline: $configure_docker
+  config.vm.provision "shell", inline: $setup_user_env
+end


### PR DESCRIPTION
Addresses issue SCE-365 (first in series)

Summary of changes:
- Adds vagrant and virtualbox config for local development.
- Added docs to explain how to get up and running using the vagrant config.

Summary of non-changes:
- The integration test suite does not currently pass inside the virtual machine. I plan to address the required updates in a follow-up PR to make the changes easier to review.
- Doesn't add support for multiple operating systems (just one for now).

Testing done:
- `vagrant destroy && vagrant up`, then build swan and run the unit tests inside the VM following the instructions in the help doc.
