### PR TITLE
SCE-379: Caching docker images between builds

### DIFF
--- a/.travis-cache.sh
+++ b/.travis-cache.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+CACHE_DIR=".cache"
+
+function createCacheDir() {
+    if [[ ! -d $CACHE_DIR ]]; then
+        mkdir $CACHE_DIR
+    fi
+}
+
+function buildAndExportImage()  {
+    docker build -t "swan_${1}_tests" -f "integration_tests/docker/Dockerfile_${1}" "integration_tests/docker"
+    docker save -o "$CACHE_DIR/swan_${1}_tests" "swan_${1}_tests"
+}
+
+function loadExportedImage()    {
+    if [[ -a "$CACHE_DIR/swan_${1}_tests" ]]; then
+        docker load -i "$CACHE_DIR/swan_${1}_tests"
+    fi
+}
+
+function main() {
+    createCacheDir
+    for distro in {"centos","ubuntu"}; do
+        loadExportedImage $distro
+        buildAndExportImage $distro
+    done
+}
+
+main

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,14 @@ sudo: required
 services:
 - docker
 language: go
+cache:
+  directories:
+    - .cache
 sudo: required
 go:
 - 1.6
 before_install:
+- .travis-cache.sh
 - make deps
 script:
 - make lint

--- a/integration_tests/docker/inside-docker-tests.sh
+++ b/integration_tests/docker/inside-docker-tests.sh
@@ -7,6 +7,12 @@ if [[ $(which docker) == "" ]]; then
     exit 0
 fi
 
+CACHE_GO=""
+if [[ -d ".cache" ]]; then
+    mkdir $(pwd)/../../.cache/gopath
+    CACHE_GO="-v $(pwd)/../../.cache/gopath/:/opt/gopath"
+fi
+
 GIT_TOKEN_ENV=""
 if [[ ${GIT_TOKEN} != "" ]]; then
     GIT_TOKEN_ENV="-e GIT_TOKEN=${GIT_TOKEN}"
@@ -21,7 +27,7 @@ docker build -t swan_ubuntu_tests -f Dockerfile_centos . > /dev/null
 
 echo "Running up tests"
 echo "* Running Centos based image"
-docker run --privileged $GIT_TOKEN_ENV -t -v $(pwd)/../../:/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_centos_tests
+docker run --privileged $GIT_TOKEN_ENV $CACHE_GO -t -v $(pwd)/../../:/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_centos_tests
 echo "* Running Ubuntu based image"
-docker run --privileged $GIT_TOKEN_ENV -t -v $(pwd)/../../:/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_ubuntu_tests
+docker run --privileged $GIT_TOKEN_ENV $CACHE_GO -t -v $(pwd)/../../:/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_ubuntu_tests
 


### PR DESCRIPTION
Partially fixes issue SCE-379

Summary of changes:
- Caching docker images between builds
