### PR TITLE
Added common way to get Swan directories. Moved Default workload path fetching to launchers.

### DIFF
--- a/experiments/memcached/baseline_local/memcached.go
+++ b/experiments/memcached/baseline_local/memcached.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-	"path"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -12,36 +10,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/workloads/mutilate"
 	"github.com/shopspring/decimal"
 )
-
-const (
-	defaultMemcachedPath = "workloads/data_caching/memcached/memcached-1.4.25/build/memcached"
-	defaultMutilatePath  = "workloads/data_caching/memcached/mutilate/mutilate"
-	swanPkg              = "github.com/intelsdi-x/swan"
-)
-
-func fetchMemcachedPath() string {
-	// Get optional custom Memcached path from MEMCACHED_PATH.
-	memcachedPath := os.Getenv("MEMCACHED_BIN")
-
-	if memcachedPath == "" {
-		// If custom path does not exists use default path for built memcached.
-		return path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultMemcachedPath)
-	}
-
-	return memcachedPath
-}
-
-func fetchMutilatePath() string {
-	// Get optional custom mutilate path from MUTILATE_BIN.
-	mutilatePath := os.Getenv("MUTILATE_BIN")
-
-	if mutilatePath == "" {
-		// If custom path does not exists use default path for built memcached.
-		return path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultMutilatePath)
-	}
-
-	return mutilatePath
-}
 
 // This Experiments contains:
 // - memcached as LC task on localhost
@@ -53,11 +21,12 @@ func main() {
 	local := executor.NewLocal()
 	// Init Memcached Launcher.
 	memcachedLauncher := memcached.New(local,
-		memcached.DefaultMemcachedConfig(fetchMemcachedPath()))
+		memcached.DefaultMemcachedConfig())
 	// Init Mutilate Launcher.
 	percentile, _ := decimal.NewFromString("99.9")
+
 	mutilateConfig := mutilate.Config{
-		MutilatePath:      fetchMutilatePath(),
+		MutilatePath:      mutilate.GetPathFromEnvOrDefault(),
 		MemcachedHost:     "127.0.0.1",
 		LatencyPercentile: percentile,
 		TuningTime:        1 * time.Second,

--- a/integration_tests/pkg/snap/session_test.go
+++ b/integration_tests/pkg/snap/session_test.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/intelsdi-x/snap/mgmt/rest/client"
+	"github.com/intelsdi-x/snap/scheduler/wmap"
+	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
+	"github.com/intelsdi-x/swan/pkg/experiment/phase"
+	"github.com/intelsdi-x/swan/pkg/snap"
+	"github.com/intelsdi-x/swan/pkg/swan"
+	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/scheduler/wmap"
-	"github.com/intelsdi-x/swan/pkg/experiment/phase"
-	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 )
 
 const (
@@ -52,9 +53,6 @@ func TestSnap(t *testing.T) {
 		So("plugin_running_on="+host, ShouldBeIn, tags)
 	}
 
-	goPath := os.Getenv("GOPATH")
-	buildPath := path.Join(goPath, "src", "github.com", "intelsdi-x", "swan", "build")
-
 	Convey("While having Snapd running", t, func() {
 		snapd = testhelpers.NewSnapdOnPort(snapSessionTestAPIPort)
 		err := snapd.Start()
@@ -81,7 +79,9 @@ func TestSnap(t *testing.T) {
 				plugins := snap.NewPlugins(c)
 				So(plugins, ShouldNotBeNil)
 
-				pluginPath := []string{path.Join(buildPath, "snap-plugin-collector-session-test")}
+				pluginPath := []string{
+					path.Join(swan.GetSwanBuildPath(), "snap-plugin-collector-session-test"),
+				}
 				err := plugins.Load(pluginPath)
 				So(err, ShouldBeNil)
 
@@ -106,7 +106,7 @@ func TestSnap(t *testing.T) {
 					So(plugins, ShouldNotBeNil)
 
 					pluginPath := []string{path.Join(
-						buildPath, "snap-plugin-publisher-session-test")}
+						swan.GetSwanBuildPath(), "snap-plugin-publisher-session-test")}
 					err := plugins.Load(pluginPath)
 					So(err, ShouldBeNil)
 
@@ -123,7 +123,12 @@ func TestSnap(t *testing.T) {
 					publisher.AddConfigItem("file", metricsFile)
 
 					Convey("While starting a Snap experiment session", func() {
-						s = snap.NewSession([]string{"/intel/swan/session/metric1"}, 1*time.Second, c, publisher)
+						s = snap.NewSession(
+							[]string{"/intel/swan/session/metric1"},
+							1*time.Second,
+							c,
+							publisher,
+						)
 						So(s, ShouldNotBeNil)
 
 						err := s.Start(phase.Session{

--- a/integration_tests/pkg/snap/sessions/mutilate_test.go
+++ b/integration_tests/pkg/snap/sessions/mutilate_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 	"github.com/intelsdi-x/swan/pkg/executor/mocks"
 	"github.com/intelsdi-x/swan/pkg/experiment/phase"
 	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions"
+	"github.com/intelsdi-x/swan/pkg/swan"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 )
 
 func soMetricRowIsValid(expectedMetrics map[string]string, namespace string,
@@ -45,9 +46,6 @@ func TestSnapMutilateSession(t *testing.T) {
 	var publisher *wmap.PublishWorkflowMapNode
 	var metricsFile string
 
-	goPath := os.Getenv("GOPATH")
-	buildPath := path.Join(goPath, "src", "github.com", "intelsdi-x", "swan", "build")
-
 	Convey("While having Snapd running", t, func() {
 		snapd = testhelpers.NewSnapdOnPort(snapMutilateSessionTestAPIPort)
 		err := snapd.Start()
@@ -75,7 +73,9 @@ func TestSnapMutilateSession(t *testing.T) {
 				plugins := snap.NewPlugins(c)
 				So(plugins, ShouldNotBeNil)
 
-				pluginPath := []string{path.Join(buildPath, "snap-plugin-publisher-session-test")}
+				pluginPath := []string{
+					path.Join(swan.GetSwanBuildPath(), "snap-plugin-publisher-session-test"),
+				}
 				plugins.Load(pluginPath)
 
 				publisher = wmap.NewPublishNode("session-test", 1)
@@ -92,11 +92,12 @@ func TestSnapMutilateSession(t *testing.T) {
 
 				Convey("While launching MutilateSnapSession", func() {
 					mutilateSnapSession := sessions.NewMutilateSnapSessionLauncher(
-						buildPath, 1*time.Second, c, publisher,
+						swan.GetSwanBuildPath(), 1*time.Second, c, publisher,
 					)
 
 					mockedTaskInfo := new(mocks.TaskInfo)
-					mutilateStdoutPath := path.Join(goPath, "src/github.com/intelsdi-x/swan/misc/snap-plugin-collector-mutilate/mutilate/mutilate.stdout")
+					mutilateStdoutPath := path.Join(
+						os.Getenv("GOPATH"), "src/github.com/intelsdi-x/swan/misc/snap-plugin-collector-mutilate/mutilate/mutilate.stdout")
 
 					file, err := os.Open(mutilateStdoutPath)
 

--- a/integration_tests/pkg/workloads/l1data/l1data_test.go
+++ b/integration_tests/pkg/workloads/l1data/l1data_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,21 +9,14 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	swanPkg           = "github.com/intelsdi-x/swan"
-	defaultL1DataPath = "workloads/low-level-aggressors/l1d"
-)
-
 // TestL1DataWithExecutor is an integration test with local executor
 // You should build low-level binaries from `github.com/intelsdi-x/swan/workloads/low-level-aggressors/` first
 func TestL1DataWithExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
-	l1DataPath := path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultL1DataPath)
-
 	Convey("While using Local Shell in L1Data launcher", t, func() {
 		l := executor.NewLocal()
-		l1DataLauncher := l1data.New(l, l1data.DefaultL1dConfig(l1DataPath))
+		l1DataLauncher := l1data.New(l, l1data.DefaultL1dConfig())
 
 		Convey("When l1d binary is launched", func() {
 			taskHandle, err := l1DataLauncher.Launch()

--- a/integration_tests/pkg/workloads/l1intensity/l1intensity_test.go
+++ b/integration_tests/pkg/workloads/l1intensity/l1intensity_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,21 +9,15 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	swanPkg                = "github.com/intelsdi-x/swan"
-	defaultL1IntensityPath = "workloads/low-level-aggressors/l1i"
-)
-
 // TestL1IntensityWithExecutor is an integration test with local executor
 // You should build low-level binaries from `github.com/intelsdi-x/swan/workloads/low-level-aggressors/` first
 func TestL1IntensityWithExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
-	l1IntensityPath := path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultL1IntensityPath)
-
 	Convey("While using Local Shell in L1Intesity launcher", t, func() {
 		l := executor.NewLocal()
-		l1IntensityLauncher := l1intesity.New(l, l1intesity.DefaultL1iConfig(l1IntensityPath))
+		l1IntensityLauncher := l1intesity.New(
+			l, l1intesity.DefaultL1iConfig())
 
 		Convey("When l1i binary is launched", func() {
 			taskHandle, err := l1IntensityLauncher.Launch()

--- a/integration_tests/pkg/workloads/l3data/l3data_test.go
+++ b/integration_tests/pkg/workloads/l3data/l3data_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,21 +9,15 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	swanPkg           = "github.com/intelsdi-x/swan"
-	defaultL3dataPath = "workloads/low-level-aggressors/l3"
-)
-
 // TestL3dataWithExecutor is an integration test with local executor
 // You should build low-level binaries from `github.com/intelsdi-x/swan/workloads/low-level-aggressors/` first
 func TestL3dataWithExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
-	l3dataPath := path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultL3dataPath)
-
 	Convey("While using Local Shell in L3Data launcher", t, func() {
 		l := executor.NewLocal()
-		l3dataLauncher := l3data.New(l, l3data.DefaultL3Config(l3dataPath))
+		l3dataLauncher := l3data.New(
+			l, l3data.DefaultL3Config())
 
 		Convey("When l3d binary is launched", func() {
 			taskHandle, err := l3dataLauncher.Launch()

--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -2,10 +2,7 @@ package workloads
 
 import (
 	"io/ioutil"
-	"os"
-	"path"
 	"testing"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor"
@@ -14,9 +11,7 @@ import (
 )
 
 const (
-	netstatCommand       = "echo stats | nc -w 1 127.0.0.1 11211"
-	defaultMemcachedPath = "workloads/data_caching/memcached/memcached-1.4.25/build/memcached"
-	swanPkg              = "github.com/intelsdi-x/swan"
+	netstatCommand = "echo stats | nc -w 1 127.0.0.1 11211"
 )
 
 // TestMemcachedWithExecutor is an integration test with local executor.
@@ -24,18 +19,10 @@ const (
 func TestMemcachedWithExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
-	// Get optional custom Memcached path from MEMCACHED_PATH.
-	memcachedPath := os.Getenv("MEMCACHED_BIN")
-
-	if memcachedPath == "" {
-		// If custom path does not exists use default path for built memcached.
-		memcachedPath = path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultMemcachedPath)
-	}
-
 	Convey("While using Local Shell in Memcached launcher", t, func() {
 		l := executor.NewLocal()
 		memcachedLauncher := memcached.New(
-			l, memcached.DefaultMemcachedConfig(memcachedPath))
+			l, memcached.DefaultMemcachedConfig())
 
 		Convey("When memcached is launched", func() {
 			// NOTE: It is needed for memcached to have default port available.
@@ -53,78 +40,64 @@ func TestMemcachedWithExecutor(t *testing.T) {
 				So(stopErr, ShouldBeNil)
 			})
 
-			Convey("Wait 1 second for memcached to init", func() {
-				isTerminated := taskHandle.Wait(1 * time.Second)
+			Convey("When we check the memcached endpoint for stats after 1 second", func() {
+				netstatTaskHandle, netstatErr := l.Execute(netstatCommand)
+				if netstatTaskHandle != nil {
+					defer netstatTaskHandle.Stop()
+					defer netstatTaskHandle.Clean()
+					defer netstatTaskHandle.EraseOutput()
+				}
+				Convey("There should be no error", func() {
+					taskHandle.Stop()
+					netstatTaskHandle.Stop()
 
-				Convey("Memcached should be still running", func() {
-					stopErr := taskHandle.Stop()
+					So(netstatErr, ShouldBeNil)
 
-					// NOTE: Here you will be failing if the memcached
-					// can't start because it needs to have default port available.
-					So(isTerminated, ShouldBeFalse)
-
-					So(stopErr, ShouldBeNil)
 				})
 
-				Convey("When we check the memcached endpoint for stats after 1 second", func() {
-					netstatTaskHandle, netstatErr := l.Execute(netstatCommand)
-					if netstatTaskHandle != nil {
-						defer netstatTaskHandle.Stop()
-						defer netstatTaskHandle.Clean()
-						defer netstatTaskHandle.EraseOutput()
-					}
-					Convey("There should be no error", func() {
-						taskHandle.Stop()
-						netstatTaskHandle.Stop()
+				Convey("When we wait for netstat ", func() {
+					netstatTaskHandle.Wait(0)
 
-						So(netstatErr, ShouldBeNil)
+					Convey("The netstat task should be terminated, the task status should be 0"+
+						" and output resultes with a STAT information", func() {
 
-					})
+						netstatTaskState := netstatTaskHandle.Status()
+						So(netstatTaskState, ShouldEqual, executor.TERMINATED)
 
-					Convey("When we wait for netstat ", func() {
-						netstatTaskHandle.Wait(0)
+						exitCode, err := netstatTaskHandle.ExitCode()
+						So(err, ShouldBeNil)
+						So(exitCode, ShouldEqual, 0)
 
-						Convey("The netstat task should be terminated, the task status should be 0"+
-							" and output resultes with a STAT information", func() {
+						stdoutFile, stdoutErr := netstatTaskHandle.StdoutFile()
 
-							netstatTaskState := netstatTaskHandle.Status()
-							So(netstatTaskState, ShouldEqual, executor.TERMINATED)
+						So(stdoutErr, ShouldBeNil)
+						So(stdoutFile, ShouldNotBeNil)
 
-							exitCode, err := netstatTaskHandle.ExitCode()
-							So(err, ShouldBeNil)
-							So(exitCode, ShouldEqual, 0)
-
-							stdoutFile, stdoutErr := netstatTaskHandle.StdoutFile()
-
-							So(stdoutErr, ShouldBeNil)
-							So(stdoutFile, ShouldNotBeNil)
-
-							data, readErr := ioutil.ReadAll(stdoutFile)
-							So(readErr, ShouldBeNil)
-							So(string(data[:]), ShouldStartWith, "STAT")
-						})
+						data, readErr := ioutil.ReadAll(stdoutFile)
+						So(readErr, ShouldBeNil)
+						So(string(data[:]), ShouldStartWith, "STAT")
 					})
 				})
+			})
 
-				Convey("When we stop the memcached task", func() {
-					err := taskHandle.Stop()
+			Convey("When we stop the memcached task", func() {
+				err := taskHandle.Stop()
 
-					Convey("There should be no error", func() {
-						So(err, ShouldBeNil)
-					})
+				Convey("There should be no error", func() {
+					So(err, ShouldBeNil)
+				})
 
-					Convey("The task should be terminated and the task status "+
-						"should be -1 or 0", func() {
+				Convey("The task should be terminated and the task status "+
+					"should be -1 or 0", func() {
 
-						taskState := taskHandle.Status()
-						So(taskState, ShouldEqual, executor.TERMINATED)
+					taskState := taskHandle.Status()
+					So(taskState, ShouldEqual, executor.TERMINATED)
 
-						exitCode, err := taskHandle.ExitCode()
+					exitCode, err := taskHandle.ExitCode()
 
-						So(err, ShouldBeNil)
-						// Memcached on CentOS returns 0 (successful code) after SIGTERM.
-						So(exitCode, ShouldBeIn, -1, 0)
-					})
+					So(err, ShouldBeNil)
+					// Memcached on CentOS returns 0 (successful code) after SIGTERM.
+					So(exitCode, ShouldBeIn, -1, 0)
 				})
 			})
 		})

--- a/integration_tests/pkg/workloads/memoryBandwidth/memoryBandwidth_test.go
+++ b/integration_tests/pkg/workloads/memoryBandwidth/memoryBandwidth_test.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"os"
-	"path"
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,21 +9,15 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	swanPkg              = "github.com/intelsdi-x/swan"
-	defaultMemBwDataPath = "workloads/low-level-aggressors/memBw"
-)
-
 // TestMemBwDataWithExecutor is an integration test with local executor
 // You should build low-level binaries from `github.com/intelsdi-x/swan/workloads/low-level-aggressors/` first
 func TestMemBwDataWithExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
-	memBwDataPath := path.Join(os.Getenv("GOPATH"), "src", swanPkg, defaultMemBwDataPath)
-
 	Convey("While using Local Shell in Memory Bandwidth launcher", t, func() {
 		l := executor.NewLocal()
-		memBwDataLauncher := memoryBandwidth.New(l, memoryBandwidth.DefaultMemBwConfig(memBwDataPath))
+		memBwDataLauncher := memoryBandwidth.New(
+			l, memoryBandwidth.DefaultMemBwConfig())
 
 		Convey("When memBwd binary is launched", func() {
 			taskHandle, err := memBwDataLauncher.Launch()

--- a/integration_tests/snap-plugins/cassandra-publisher/cassandra_publisher_test.go
+++ b/integration_tests/snap-plugins/cassandra-publisher/cassandra_publisher_test.go
@@ -1,21 +1,20 @@
 package cassandra
 
 import (
-	"testing"
-	"time"
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
 	log "github.com/Sirupsen/logrus"
 	"github.com/gocql/gocql"
-	"os"
-	"path"
-	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
-	"github.com/intelsdi-x/swan/pkg/experiment/phase"
 	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
+	"github.com/intelsdi-x/swan/pkg/experiment/phase"
+	"github.com/intelsdi-x/swan/pkg/snap"
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"path"
+	"testing"
+	"time"
 )
-
 
 func TestCassandraPublisher(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
@@ -82,7 +81,7 @@ func loadSnapPlugins(snapClient *client.Client) (err error) {
 	return err
 }
 
-func isNotPluginLoaded(pluginClient *snap.Plugins, pi snapPluginInfo) (isLoaded bool){
+func isNotPluginLoaded(pluginClient *snap.Plugins, pi snapPluginInfo) (isLoaded bool) {
 	isLoaded, err := pluginClient.IsLoaded(pi.pluginType, pi.pluginName)
 	if err != nil {
 		panic(fmt.Errorf("Error while checking if plugin %s:%s is loaded: %s\n",
@@ -115,7 +114,7 @@ func getRequiredPlugins() (plugins []snapPluginInfo) {
 		pluginPath: path.Join(
 			goPath, "src", "github.com", "intelsdi-x", "swan",
 			"build", "snap-plugin-collector-session-test"),
-		})
+	})
 	plugins = append(plugins, snapPluginInfo{
 		pluginName: "cassandra",
 		pluginType: "publisher",
@@ -125,7 +124,7 @@ func getRequiredPlugins() (plugins []snapPluginInfo) {
 	return plugins
 }
 
-func getValueAndTagsFromCassandra() (value float64, tags map[string]string, err error){
+func getValueAndTagsFromCassandra() (value float64, tags map[string]string, err error) {
 	cluster := gocql.NewCluster("127.0.0.1")
 	cluster.ProtoVersion = 4
 	cluster.Keyspace = "snap"
@@ -140,8 +139,8 @@ func getValueAndTagsFromCassandra() (value float64, tags map[string]string, err 
 
 	session.Query(`SELECT doubleval, tags FROM snap.metrics
 			WHERE ns = ? AND ver = ? AND host = ? LIMIT 1`,
-				"/intel/swan/session/metric1", -1, "fedorowicz").
-			Consistency(gocql.One).Scan(&value, &tags)
+		"/intel/swan/session/metric1", -1, "fedorowicz").
+		Consistency(gocql.One).Scan(&value, &tags)
 	return value, tags, err
 }
 
@@ -157,7 +156,7 @@ func runCassandraPublisherWorkflow(snapClient *client.Client) (err error) {
 
 	examplePhase := phase.Session{
 		ExperimentID: "example-experiment",
-		PhaseID     : "example-phase",
+		PhaseID:      "example-phase",
 		RepetitionID: 42,
 	}
 	err = snapSession.Start(examplePhase)

--- a/integration_tests/test_helpers/snapd.go
+++ b/integration_tests/test_helpers/snapd.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"math/rand"
 	"net"
 	"os"
 	"path"
 	"time"
-	"math/rand"
 )
 
 // Snapd represents Snap daemon used in tests.
@@ -19,7 +19,7 @@ type Snapd struct {
 
 // NewSnapd constructs Snapd.
 func NewSnapd() *Snapd {
-	randomHighPort := rand.Intn(32768 - 10000) + 10000
+	randomHighPort := rand.Intn(32768-10000) + 10000
 	return NewSnapdOnPort(randomHighPort)
 }
 
@@ -36,7 +36,8 @@ func (s *Snapd) Start() error {
 		return errors.New("Cannot find GOPATH")
 	}
 
-	snapRoot := path.Join(gopath, "src", "github.com", "intelsdi-x", "snap", "build", "bin", "snapd")
+	snapRoot := path.Join(
+		gopath, "src", "github.com", "intelsdi-x", "snap", "build", "bin", "snapd")
 	snapCommand := fmt.Sprintf("%s -t 0 -p %d", snapRoot, s.apiPort)
 
 	taskHandle, err := l.Execute(snapCommand)
@@ -85,6 +86,6 @@ func (s *Snapd) Connected() bool {
 }
 
 // Port returns port Snapd is listening.
-func (s *Snapd) Port() int{
+func (s *Snapd) Port() int {
 	return s.apiPort
 }

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -1,0 +1,18 @@
+package osutil
+
+import "os"
+
+// GetEnvOrDefault returns the environment variable or default string.
+func GetEnvOrDefault(env string, defaultStr string) string {
+	if env == "" {
+		return defaultStr
+	}
+
+	fetchedEnv := os.Getenv(env)
+
+	if fetchedEnv == "" {
+		return defaultStr
+	}
+
+	return fetchedEnv
+}

--- a/pkg/swan/paths.go
+++ b/pkg/swan/paths.go
@@ -1,0 +1,25 @@
+package swan
+
+import (
+	"os"
+	"path"
+)
+
+const (
+	swanPkg = "github.com/intelsdi-x/swan"
+)
+
+// GetSwanPath returns absolute path to Swan root directory.
+func GetSwanPath() string {
+	return path.Join(os.Getenv("GOPATH"), "src", swanPkg)
+}
+
+// GetSwanBuildPath returns absolute path to Swan build directory.
+func GetSwanBuildPath() string {
+	return path.Join(os.Getenv("GOPATH"), "src", swanPkg, "build")
+}
+
+// GetSwanWorkloadsPath returns absolute path to Swan workloads directory.
+func GetSwanWorkloadsPath() string {
+	return path.Join(os.Getenv("GOPATH"), "src", swanPkg, "workloads")
+}

--- a/pkg/workloads/launcher.go
+++ b/pkg/workloads/launcher.go
@@ -1,6 +1,8 @@
 package workloads
 
-import "github.com/intelsdi-x/swan/pkg/executor"
+import (
+	"github.com/intelsdi-x/swan/pkg/executor"
+)
 
 // Launcher responsibility is to launch previously configured job.
 type Launcher interface {

--- a/pkg/workloads/low_level/l1data/l1data.go
+++ b/pkg/workloads/low_level/l1data/l1data.go
@@ -5,12 +5,24 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
+	"github.com/intelsdi-x/swan/pkg/swan"
 	"github.com/intelsdi-x/swan/pkg/workloads"
+	"path"
 )
 
 const (
 	defaultDuration = 86400 * time.Second
+	defaultL1DPath  = "low-level-aggressors/l1d"
+	l1DPathEnv      = "SWAN_L1D_PATH"
 )
+
+// GetPathFromEnvOrDefault returns the l1d binary path from environment variable
+// SWAN_L1D_PATH or default path in swan directory.
+func GetPathFromEnvOrDefault() string {
+	return osutil.GetEnvOrDefault(
+		l1DPathEnv, path.Join(swan.GetSwanWorkloadsPath(), defaultL1DPath))
+}
 
 // Config is a struct for l1d aggressor configuration.
 type Config struct {
@@ -19,9 +31,9 @@ type Config struct {
 }
 
 // DefaultL1dConfig is a constructor for l1d aggressor Config with default parameters.
-func DefaultL1dConfig(pathToBinary string) Config {
+func DefaultL1dConfig() Config {
 	return Config{
-		Path:     pathToBinary,
+		Path:     GetPathFromEnvOrDefault(),
 		Duration: defaultDuration,
 	}
 }

--- a/pkg/workloads/low_level/l1data/l1data_test.go
+++ b/pkg/workloads/low_level/l1data/l1data_test.go
@@ -23,9 +23,12 @@ func TestL1dAggressor(t *testing.T) {
 		)
 
 		Convey("Default configuration should be valid", func() {
+			config := DefaultL1dConfig()
+			config.Path = pathToBinary
 			launcher := New(
 				mockedExecutor,
-				DefaultL1dConfig(pathToBinary))
+				config,
+			)
 
 			Convey("When executor is able to run this command then it should return mocked taskHandle "+
 				"without error", func() {

--- a/pkg/workloads/low_level/l1intesity/l1intesity.go
+++ b/pkg/workloads/low_level/l1intesity/l1intesity.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
+	"github.com/intelsdi-x/swan/pkg/swan"
 	"github.com/intelsdi-x/swan/pkg/workloads"
+	"path"
 )
 
 const (
@@ -12,9 +15,18 @@ const (
 	defaultIntensity  = 20
 	// {min,max}Intensity are hardcoded values in l1i binary
 	// For further information look inside l1i.c which can be found in github.com/intelsdi-x/swan repository
-	minIntensity = 1
-	maxIntensity = 20
+	minIntensity   = 1
+	maxIntensity   = 20
+	defaultL1IPath = "low-level-aggressors/l1i"
+	l1IPathEnv     = "SWAN_L1I_PATH"
 )
+
+// GetPathFromEnvOrDefault fetches the l1 instructions binary path from environment variable
+// SWAN_L1I_PATH or default path in swan directory.
+func GetPathFromEnvOrDefault() string {
+	return osutil.GetEnvOrDefault(
+		l1IPathEnv, path.Join(swan.GetSwanWorkloadsPath(), defaultL1IPath))
+}
 
 // Config is a struct for l1i aggressor configuration.
 type Config struct {
@@ -26,9 +38,9 @@ type Config struct {
 }
 
 // DefaultL1iConfig is a constructor for l1i aggressor Config with default parameters.
-func DefaultL1iConfig(pathToBinary string) Config {
+func DefaultL1iConfig() Config {
 	return Config{
-		Path:       pathToBinary,
+		Path:       GetPathFromEnvOrDefault(),
 		Intensity:  defaultIntensity,
 		Iterations: defaultIterations,
 	}

--- a/pkg/workloads/low_level/l1intesity/l1intesity_test.go
+++ b/pkg/workloads/low_level/l1intesity/l1intesity_test.go
@@ -22,9 +22,12 @@ func TestL1dAggressor(t *testing.T) {
 		)
 
 		Convey("Default configuration should be valid", func() {
+			config := DefaultL1iConfig()
+			config.Path = pathToBinary
 			launcher := New(
 				mockedExecutor,
-				DefaultL1iConfig(pathToBinary))
+				config,
+			)
 
 			Convey("When executor is able to run this command then it should return mocked taskHandle "+
 				"without error", func() {

--- a/pkg/workloads/low_level/l3data/l3data.go
+++ b/pkg/workloads/low_level/l3data/l3data.go
@@ -5,12 +5,24 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
+	"github.com/intelsdi-x/swan/pkg/swan"
 	"github.com/intelsdi-x/swan/pkg/workloads"
+	"path"
 )
 
 const (
 	defaultDuration = 86400 * time.Second
+	defaultL3Path   = "low-level-aggressors/l3"
+	l3PathEnv       = "SWAN_L3_PATH"
 )
+
+// GetPathFromEnvOrDefault returns the l3 binary path from environment variable
+// SWAN_L3_PATH or default path in swan directory.
+func GetPathFromEnvOrDefault() string {
+	return osutil.GetEnvOrDefault(
+		l3PathEnv, path.Join(swan.GetSwanWorkloadsPath(), defaultL3Path))
+}
 
 // Config is a struct for l3 aggressor configuration.
 type Config struct {
@@ -19,9 +31,9 @@ type Config struct {
 }
 
 // DefaultL3Config is a constructor for l3 aggressor Config with default parameters.
-func DefaultL3Config(pathToBinary string) Config {
+func DefaultL3Config() Config {
 	return Config{
-		Path:     pathToBinary,
+		Path:     GetPathFromEnvOrDefault(),
 		Duration: defaultDuration,
 	}
 }

--- a/pkg/workloads/low_level/l3data/l3data_test.go
+++ b/pkg/workloads/low_level/l3data/l3data_test.go
@@ -23,9 +23,12 @@ func TestL3Aggressor(t *testing.T) {
 		)
 
 		Convey("Default configuration should be valid", func() {
+			config := DefaultL3Config()
+			config.Path = pathToBinary
 			launcher := New(
 				mockedExecutor,
-				DefaultL3Config(pathToBinary))
+				config,
+			)
 
 			Convey("When executor is able to run this command then it should return mocked taskHandle "+
 				"without error", func() {

--- a/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
+++ b/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
@@ -5,12 +5,24 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
+	"github.com/intelsdi-x/swan/pkg/swan"
 	"github.com/intelsdi-x/swan/pkg/workloads"
+	"path"
 )
 
 const (
-	defaultDuration = 86400 * time.Second
+	defaultDuration  = 86400 * time.Second
+	defaultMemBwPath = "low-level-aggressors/memBw"
+	memBwPathEnv     = "SWAN_MEMBW_PATH"
 )
+
+// GetPathFromEnvOrDefault fetches the memoryBandwidth binary path from environment variable
+// SWAN_MEMBW_PATH or default path in swan directory.
+func GetPathFromEnvOrDefault() string {
+	return osutil.GetEnvOrDefault(
+		memBwPathEnv, path.Join(swan.GetSwanWorkloadsPath(), defaultMemBwPath))
+}
 
 // Config is a struct for MemBw aggressor configuration.
 type Config struct {
@@ -19,9 +31,9 @@ type Config struct {
 }
 
 // DefaultMemBwConfig is a constructor for memBw aggressor Config with default parameters.
-func DefaultMemBwConfig(pathToBinary string) Config {
+func DefaultMemBwConfig() Config {
 	return Config{
-		Path:     pathToBinary,
+		Path:     GetPathFromEnvOrDefault(),
 		Duration: defaultDuration,
 	}
 }

--- a/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth_test.go
+++ b/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth_test.go
@@ -23,9 +23,12 @@ func TestL3Aggressor(t *testing.T) {
 		)
 
 		Convey("Default configuration should be valid", func() {
+			config := DefaultMemBwConfig()
+			config.Path = pathToBinary
 			launcher := New(
 				mockedExecutor,
-				DefaultMemBwConfig(pathToBinary))
+				config,
+			)
 
 			Convey("When executor is able to run this command then it should return mocked taskHandle "+
 				"without error", func() {

--- a/pkg/workloads/memcached/memcached_test.go
+++ b/pkg/workloads/memcached/memcached_test.go
@@ -38,9 +38,11 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 		decorators = append(decorators, unshare)
 
 		Convey("While using Memcached launcher", func() {
+			config := DefaultMemcachedConfig()
+			config.PathToBinary = "test"
 			memcachedLauncher := New(
 				mockedExecutor,
-				DefaultMemcachedConfig("test"))
+				config)
 			memcachedLauncher.tryConnect = connectTimeoutSuccess
 			Convey("While simulating proper execution", func() {
 				mockedExecutor.On("Execute", expectedCommand).Return(mockedTaskHandle, nil).Once()

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -11,9 +11,27 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
+	"github.com/intelsdi-x/swan/pkg/swan"
 	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/shopspring/decimal"
+	"path"
 )
+
+const (
+	defaultMemcachedHost          = "127.0.0.1"
+	defaultMemcachedPercentile    = "99.9"
+	defaultMemcachedTuningTimeSec = 10
+	defaultMutilatePath           = "data_caching/memcached/mutilate/mutilate"
+	mutilatePathEnv               = "SWAN_MUTILATE_PATH"
+)
+
+// GetPathFromEnvOrDefault returns the mutilate binary path from environment variable
+// SWAN_MUTILATE_PATH or default path in swan directory.
+func GetPathFromEnvOrDefault() string {
+	return osutil.GetEnvOrDefault(
+		mutilatePathEnv, path.Join(swan.GetSwanWorkloadsPath(), defaultMutilatePath))
+}
 
 // Config contains all data for running mutilate.
 type Config struct {
@@ -21,6 +39,17 @@ type Config struct {
 	MemcachedHost     string
 	TuningTime        time.Duration
 	LatencyPercentile decimal.Decimal
+}
+
+// DefaultMutilateConfig is a constructor for MutilateConfig with default parameters.
+func DefaultMutilateConfig() Config {
+	percentile, _ := decimal.NewFromString(defaultMemcachedPercentile)
+	return Config{
+		MutilatePath:      GetPathFromEnvOrDefault(),
+		MemcachedHost:     defaultMemcachedHost,
+		LatencyPercentile: percentile,
+		TuningTime:        defaultMemcachedTuningTimeSec * time.Second,
+	}
 }
 
 type mutilate struct {


### PR DESCRIPTION
Fixes issue with huge code duplication for fetching paths for different binaries and directories.

Summary of changes:
- Unified way to fetch default paths of binaries
- Added Swan pkg with path Getters
- all Default Config include the default paths

Testing done:
- make all

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
