### PR TITLE
Some fixes and questions for cassandra integration test

### DIFF
--- a/integration_tests/snap-plugins/cassandra-publisher/cassandra_publisher_test.go
+++ b/integration_tests/snap-plugins/cassandra-publisher/cassandra_publisher_test.go
@@ -48,7 +48,7 @@ func TestCassandraPublisher(t *testing.T) {
 	}
 
 	value, tags, err := getValueAndTagsFromCassandra()
-	Convey("When getting values from Cassadndra", t, func() {
+	Convey("When getting values from Cassandra", t, func() {
 		So(err, ShouldBeNil)
 		Convey("Stored value in Cassandra should equal 1", func() {
 			So(value, ShouldEqual, 1)
@@ -126,7 +126,6 @@ func getRequiredPlugins() (plugins []snapPluginInfo) {
 
 func getValueAndTagsFromCassandra() (value float64, tags map[string]string, err error) {
 	cluster := gocql.NewCluster("127.0.0.1")
-	cluster.ProtoVersion = 4
 	cluster.Keyspace = "snap"
 	cluster.Consistency = gocql.All
 	session, _ := cluster.CreateSession()
@@ -135,12 +134,11 @@ func getValueAndTagsFromCassandra() (value float64, tags map[string]string, err 
 	//cqlsh> select * from snap.metrics where ns='/intel/swan/session/metric1' AND ver=-1 AND host='fedorowicz' ORDER BY time ASC limit 1;
 	//ns                          | ver | host       | time                            | boolval | doubleval | strval | tags                                                                                                                                 | valtype
 	//-----------------------------+-----+------------+---------------------------------+---------+-----------+--------+--------------------------------------------------------------------------------------------------------------------------------------+-----------
-	///intel/swan/session/metric1 |  -1 | fedorowicz | 2016-05-20 11:07:02.890000+0000 |    null |         1 |   null | {'plugin_running_on': 'fedorowicz', 'swan_experiment': 'example-experiment', 'swan_phase': 'example-phase', 'swan_repetition': '42'} | doubleval
+		///intel/swan/session/metric1 |  -1 | fedorowicz | 2016-05-20 11:07:02.890000+0000 |    null |         1 |   null | {'plugin_running_on': 'fedorowicz', 'swan_experiment': 'example-experiment', 'swan_phase': 'example-phase', 'swan_repetition': '42'} | doubleval
 
-	session.Query(`SELECT doubleval, tags FROM snap.metrics
-			WHERE ns = ? AND ver = ? AND host = ? LIMIT 1`,
-		"/intel/swan/session/metric1", -1, "fedorowicz").
-		Consistency(gocql.One).Scan(&value, &tags)
+	// TODO: Reintroduce selector 'WHERE ns=... AND host=... AND ver=...' when we have index which is not based on host.
+	session.Query(`SELECT doubleval, tags FROM snap.metrics LIMIT 1`).Consistency(gocql.One).Scan(&value, &tags)
+
 	return value, tags, err
 }
 


### PR DESCRIPTION
The cassandra integration test looks like it is hardcoded to a certain host. We need to strip that code out.

The cassandra version I had access to use the older binary protocol. The client supports both as long as it is not set explicitly (it was forced to 4 before).
