### PR TITLE
Fixed critical issue in mutilate snap session test

### DIFF
--- a/integration_tests/pkg/snap/sessions/mutilate_test.go
+++ b/integration_tests/pkg/snap/sessions/mutilate_test.go
@@ -111,7 +111,7 @@ func TestSnapMutilateSession(t *testing.T) {
 						RepetitionID: 1,
 					}
 
-					handle, err := mutilateSnapSession.Launch(mockedTaskInfo, session)
+					handle, err := mutilateSnapSession.LaunchSession(mockedTaskInfo, session)
 					So(err, ShouldBeNil)
 
 					defer func() {


### PR DESCRIPTION
Fixes issue in mutilate_test for snap session.

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
