### PR TITLE
SCE-375: Selection of cores based on filters for LLC sharing

### DIFF
--- a/integration_tests/pkg/isolation/cpu_select_test.go
+++ b/integration_tests/pkg/isolation/cpu_select_test.go
@@ -13,6 +13,17 @@ func TestCPUSelect(t *testing.T) {
 
 	cpus.Discover()
 
+	Convey("Should build reasonable topology mappings", t, func() {
+		So(len(cpus.SocketCores), ShouldEqual, cpus.Sockets)
+		So(len(cpus.CoreCpus), ShouldEqual, cpus.PhysicalCores)
+
+		numCpus := 0
+		for _, cpus := range cpus.CoreCpus {
+			numCpus += len(cpus)
+		}
+		So(numCpus, ShouldEqual, cpus.PhysicalCores*cpus.ThreadsPerCore)
+	})
+
 	Convey("Should provide CPUSelect() to return an error when requesting zero cpus", t, func() {
 
 		threadset, err := isolation.CPUSelect(0, isolation.ShareLLCButNotL1L2)

--- a/pkg/isolation/discover.go
+++ b/pkg/isolation/discover.go
@@ -1,6 +1,7 @@
 package isolation
 
 import (
+	"fmt"
 	"github.com/pivotal-golang/bytefmt"
 	"os/exec"
 	"strconv"
@@ -16,6 +17,12 @@ type CPUInfo struct {
 	CacheL1d       int
 	CacheL2        int
 	CacheL3        int
+
+	// Maps physical sockets to physical cores
+	SocketCores map[int]IntSet
+
+	// Maps physical cores to logical CPU ids
+	CoreCpus map[int]IntSet
 }
 
 // NewCPUInfo instance creation.
@@ -69,5 +76,49 @@ func (cputopo *CPUInfo) Discover() error {
 			*ptr = t
 		}
 	}
+
+	// Build core topology mappings
+	out, err = exec.Command("lscpu", "-p").Output()
+	if err != nil {
+		return err
+	}
+
+	outstring = strings.TrimSpace(string(out))
+	lines = strings.Split(outstring, "\n")
+
+	socketCores := make(map[int]IntSet)
+	coreCpus := make(map[int]IntSet)
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		// cpu,core,socket,node,,l1d,l1i,l2,l3
+		var cpu, core, socket int
+		n, err := fmt.Sscanf(line, "%d,%d,%d", &cpu, &core, &socket)
+		if n != 3 {
+			return fmt.Errorf("Expected to read 3 values but got %d", n)
+		}
+		if err != nil {
+			return err
+		}
+		// Check whether we know about this socket yet
+		if _, found := socketCores[socket]; !found {
+			socketCores[socket] = NewIntSet()
+		}
+		// Save the socket -> core mapping
+		socketCores[socket].Add(core)
+
+		// Check whether we know about this core yet
+		if _, found := coreCpus[core]; !found {
+			coreCpus[core] = NewIntSet()
+		}
+		// Save the core -> cpu mapping
+		coreCpus[core].Add(cpu)
+	}
+
+	cputopo.SocketCores = socketCores
+	cputopo.CoreCpus = coreCpus
+
 	return nil
 }


### PR DESCRIPTION
SCE-375 - Provides support for obtaining cores based on filter selection

Summary of changes:
- Query supported currently is core selection based two criterion. 1. Must share LLC 2, must not share L1 & L2 cache
- Cored meeting the selection criterion is obtained based on the CPU topology of the target m/c

Testing done:
- Tested for 10 core m/c requesting 0 to 10 cores and matching results.
