### PR TITLE
SCE-365: Fix integration tests in development VM.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -147,112 +147,112 @@
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/client",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/strategy",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/control_event",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/rest/client",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/rest/rbody",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/rest/request",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/tribe/agreement",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/aci",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/chrono",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/psigning",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",

--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -21,8 +22,11 @@ func TestMemcachedWithExecutor(t *testing.T) {
 
 	Convey("While using Local Shell in Memcached launcher", t, func() {
 		l := executor.NewLocal()
-		memcachedLauncher := memcached.New(
-			l, memcached.DefaultMemcachedConfig())
+		config := memcached.DefaultMemcachedConfig()
+		// Prefer to run memcached locally using the current user,
+		// if it can be determined from the environment.
+		config.User = osutil.GetEnvOrDefault("USER", config.User)
+		memcachedLauncher := memcached.New(l, config)
 
 		Convey("When memcached is launched", func() {
 			// NOTE: It is needed for memcached to have default port available.

--- a/misc/dev/vagrant/singlenode/README.md
+++ b/misc/dev/vagrant/singlenode/README.md
@@ -5,6 +5,7 @@
 ```sh
 $ git clone git@github.com:intelsdi-x/swan.git
 $ cd swan/misc/dev/vagrant/singlenode
+$ ssh-add ~/.ssh/id_rsa  # if not already added to host ssh agent
 $ vagrant plugin install vagrant-vbguest  # automatic guest additions
 $ vagrant box update
 $ vagrant up  # takes a few minutes
@@ -38,6 +39,16 @@ $ vagrant ssh
 
 - The project directory is mounted in the guest file system: edit with your
   preferred tools in the host OS!
+
+## Running the integration tests
+
+1. SSH into the VM: `vagrant ssh`
+1. Change to the swan directory: `cd ~/swan`
+1. Fetch swan dependencies: `make deps`
+1. Build snap:
+  - `cd $GOPATH/src/github.com/intelsdi-x/snap`
+  - `make`
+1. Run the integration tests: `~/scripts/run-integration-tests.sh`
 
 ## Troubleshooting
 

--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -7,6 +7,9 @@
 # you're doing.
 Vagrant.configure(2) do |config|
 
+  # SSH agent forwarding (for host private keys)
+  config.ssh.forward_agent = true
+
   config.vm.box = "centos/7"
   config.vm.box_check_update = false
 
@@ -39,6 +42,8 @@ gpgkey=https://yum.dockerproject.org/gpg
 EOF
     echo Updating package lists
     yum update -y
+    yum install epel-release  # Enables EPEL repo
+    yum clean all
     echo Installing packages
     yum install -y \
       docker-engine \
@@ -46,6 +51,7 @@ EOF
       git \
       libcgroup-tools \
       libevent-devel \
+      nmap-ncat \
       perf \
       scons \
       tree \
@@ -64,8 +70,15 @@ SCRIPT
 
   $setup_user_env = <<SCRIPT
     echo Setting up user environment
+    # Vagrant user owns $GOPATH
     chown -R vagrant:vagrant /home/vagrant/go
+    # Create convenient symlinks in the home directory
     ln -s /home/vagrant/go/src/github.com/intelsdi-x/swan /home/vagrant/
+    ln -s /home/vagrant/go/src/github.com/intelsdi-x/swan/misc/dev/vagrant/singlenode/scripts /home/vagrant/
+    # Set up Cassandra data directory
+    mkdir -p /var/data/cassandra
+    chcon -Rt svirt_sandbox_file_t /var/data/cassandra # SELinux policy
+    # Add GOPATH and Go binaries to PATH in profile
     echo 'export GOPATH="/home/vagrant/go"' >> /home/vagrant/.bash_profile
     echo 'export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"' >> /home/vagrant/.bash_profile
 SCRIPT

--- a/misc/dev/vagrant/singlenode/scripts/run_integration_tests.sh
+++ b/misc/dev/vagrant/singlenode/scripts/run_integration_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o nounset -o pipefail -o errexit
+
+echo "Preparing environment for integration tests"
+/home/vagrant/scripts/start-local-cassandra.sh
+
+# TODO(CD): Export these values to enable remote executor integration tests
+# Tracked: SCE-389.
+# NB: Those tests are skipped if ANY of these are undefined.
+# See integration_tests/pkg/executor/remote_test.go
+
+# export REMOTE_EXECUTOR_TEST_HOST="localhost"
+# export REMOTE_EXECUTOR_USER="vagrant"
+# export REMOTE_EXECUTOR_SSH_KEY=""
+# export REMOTE_EXECUTOR_MEMCACHED_BIN_PATH=""
+# export REMOTE_EXECUTOR_MEMCACHED_USER="vagrant"
+
+echo "Running integration test suite"
+pushd /home/vagrant/swan
+export REMOTE_EXECUTOR_TEST_HOST="localhost"
+export REMOTE_EXECUTOR_USER="vagrant"
+export REMOTE_EXECUTOR_MEMCACHED_USER="vagrant"
+make integration_test

--- a/misc/dev/vagrant/singlenode/scripts/start-local-cassandra.sh
+++ b/misc/dev/vagrant/singlenode/scripts/start-local-cassandra.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -o nounset -o pipefail -o errexit
+
+# Run this script from inside the development virtual machine
+# to provide a local instance of Cassandra for the integration
+# test suite.
+
+CASSANDRA_DOCKER_TAG="3.5"
+CASSANDRA_HOST_DATA_DIR="/var/data/cassandra"
+CASSANDRA_NAME="cassandra-swan"
+
+# Check whether Cassandra is already running
+
+if [[ $(docker ps --no-trunc) == *"$CASSANDRA_NAME"* ]]
+then
+  echo "Cassandra is already running, nothing to do"
+  exit 0
+fi
+
+# Start Cassandra
+
+if [[ $(docker ps -a --no-trunc) == *"$CASSANDRA_NAME"* ]]
+then
+  echo "Removing old container with name $CASSANDRA_NAME"
+  docker rm $CASSANDRA_NAME
+fi
+
+docker run \
+  --name $CASSANDRA_NAME \
+  --net host \
+  -e CASSANDRA_LISTEN_ADDRESS="127.0.0.1" \
+  -e CASSANDRA_CLUSTER_NAME=$CASSANDRA_NAME \
+  -v $CASSANDRA_HOST_DATA_DIR:/var/lib/cassandra \
+  -d cassandra:$CASSANDRA_DOCKER_TAG
+
+if [[ $(docker ps --no-trunc) == *" $CASSANDRA_NAME "* ]]
+then
+  echo "Failed to start Cassandra."
+  echo "Try checking the logs: 'docker logs $CASSANDRA_NAME'"
+  echo "Verify the data directory exists: $CASSANDRA_HOST_DATA_DIR"
+  exit 1
+fi
+
+# Create the 'snap' keyspace, without which the integration tests fail.
+
+KS="snap"
+
+echo "Creating Cassandra keyspace $KS"
+
+CQLFILE=$(mktemp)
+echo "CREATE KEYSPACE IF NOT EXISTS $KS WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };" > $CQLFILE
+echo "DESCRIBE KEYSPACES;" >> $CQLFILE
+
+# NB: xargs to trim leading and trailing whitespace
+KEYSPACES=$(docker run -it \
+  --rm \
+  --net host \
+  -v /tmp:/tmp \
+  cassandra:3.5 \
+  cqlsh \
+  localhost \
+  --file $CQLFILE \
+  | xargs)
+
+echo "Keyspaces are: $KEYSPACES"
+
+if [[ $KEYSPACES != *" $KS "* ]]
+then
+  echo "Creating keyspace '$KS' failed!"
+  exit 1;
+fi


### PR DESCRIPTION
Fixes issue SCE-365.

**Summary of changes**
- Added a helper script to run the integration tests within the
  development VM.
- Added a helper script to launch a local dockerized Cassandra instance
  and create the necessary keyspace.
- Modified cassandra integration tests to create the snap.metrics table
  in case it doesn't already exist (there's no reason it would exist in
  a fresh Cassandra ring).
- Updated local executor to prefer running memcached as the current
  user, if it can be determined by the environment.
- Updated snap dependency hash in Godeps because the current version
  does not build due to errors in fetching a broken dependency.

**Testing done**
- `vagrant destroy && vagrant up`
- Ran integration tests by following the new instructions for the local dev VM.

NOTE: the remote executor tests do not currently run in the development
VM (requires additional configuration). Tracked as SCE-389.
