### PR TITLE
SCE-365: Fix integration tests in development VM.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -147,112 +147,112 @@
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/client",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/strategy",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/control_event",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/rest/client",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/rest/rbody",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/rest/request",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/mgmt/tribe/agreement",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/aci",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/chrono",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/psigning",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
 			"Comment": "v0.13.0-beta-69-g0a2acb7",
-			"Rev": "0a2acb7bd09234e363c8fd8ce0d824e43cec145a"
+			"Rev": "7e41c44c284bc5ee411ac01510733016d0d8b148"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",

--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/osutil"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -21,8 +22,11 @@ func TestMemcachedWithExecutor(t *testing.T) {
 
 	Convey("While using Local Shell in Memcached launcher", t, func() {
 		l := executor.NewLocal()
-		memcachedLauncher := memcached.New(
-			l, memcached.DefaultMemcachedConfig())
+		config := memcached.DefaultMemcachedConfig()
+		// Prefer to run memcached locally using the current user,
+		// if it can be determined from the environment.
+		config.User = osutil.GetEnvOrDefault("USER", config.User)
+		memcachedLauncher := memcached.New(l, config)
 
 		Convey("When memcached is launched", func() {
 			// NOTE: It is needed for memcached to have default port available.

--- a/misc/dev/vagrant/singlenode/README.md
+++ b/misc/dev/vagrant/singlenode/README.md
@@ -5,6 +5,7 @@
 ```sh
 $ git clone git@github.com:intelsdi-x/swan.git
 $ cd swan/misc/dev/vagrant/singlenode
+$ ssh-add ~/.ssh/id_rsa  # if not already added to host ssh agent
 $ vagrant plugin install vagrant-vbguest  # automatic guest additions
 $ vagrant box update
 $ vagrant up  # takes a few minutes
@@ -18,6 +19,9 @@ $ vagrant ssh
 
 - [Vagrant](https://vagrantup.com)
 - [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
+- Read access to the
+  [snap-plugin-publisher-cassandra](https://github.com/intelsdi-x/snap-plugin-publisher-cassandra)
+  repository.
 
 ## What's provided "out of the box"
 
@@ -28,6 +32,7 @@ $ vagrant ssh
   - golang 1.6
   - libcgroup-tools
   - libevent-devel
+  - nmap-ncat
   - perf
   - scons
   - tree
@@ -39,8 +44,25 @@ $ vagrant ssh
 - The project directory is mounted in the guest file system: edit with your
   preferred tools in the host OS!
 
+## Running the integration tests
+
+1. SSH into the VM: `vagrant ssh`
+1. Change to the swan directory: `cd ~/swan`
+1. Fetch swan dependencies: `make deps`
+1. Change to the snap directory:
+   `cd $GOPATH/src/github.com/intelsdi-x/snap`
+1. Build snap: `make deps && make`
+1. Change to the swan directory: `cd ~/swan`
+1. Run the integration tests: `make integration_test`
+
 ## Troubleshooting
 
+- The integration tests require cassandra to be running. In this
+  environment, systemd is responsible for keeping it alive. You can see
+  how it's doing by running `systemctl status cassandra` and
+  `journalctl -fu cassandra`
+- If you get permission errors when trying to run the integration tests,
+  you may need to remove build artifacts first by running `make clean`.
 - If you get a connection error when attempting to SSH into the guest
   VM and you're behind a proxy you may need to add an override rule to ignore
   SSH traffic to localhost.

--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -1,4 +1,4 @@
-# -*- mode: ruby -*-
+# q -*- mode: ruby -*-
 # vi: set ft=ruby :
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
@@ -6,6 +6,9 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure(2) do |config|
+
+  # SSH agent forwarding (for host private keys)
+  config.ssh.forward_agent = true
 
   config.vm.box = "centos/7"
   config.vm.box_check_update = false
@@ -39,6 +42,8 @@ gpgkey=https://yum.dockerproject.org/gpg
 EOF
     echo Updating package lists
     yum update -y
+    yum install -y epel-release  # Enables EPEL repo
+    yum clean all
     echo Installing packages
     yum install -y \
       docker-engine \
@@ -46,6 +51,7 @@ EOF
       git \
       libcgroup-tools \
       libevent-devel \
+      nmap-ncat \
       perf \
       scons \
       tree \
@@ -58,19 +64,40 @@ SCRIPT
   $configure_docker = <<SCRIPT
     echo Configuring Docker
     systemctl enable docker
+    # Add the vagrant user to the docker group
     gpasswd -a vagrant docker
     systemctl restart docker
 SCRIPT
 
   $setup_user_env = <<SCRIPT
     echo Setting up user environment
+    # Vagrant user owns $GOPATH
     chown -R vagrant:vagrant /home/vagrant/go
+    # Create convenient symlinks in the home directory
     ln -s /home/vagrant/go/src/github.com/intelsdi-x/swan /home/vagrant/
+    # Add GOPATH and Go binaries to PATH in profile
     echo 'export GOPATH="/home/vagrant/go"' >> /home/vagrant/.bash_profile
     echo 'export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"' >> /home/vagrant/.bash_profile
+    # Add key to SSH agent
+    ssh-add -l
+    # Rewrite github URLs for fetching private repos
+    sudo -u vagrant git config --global url."git@github.com:".insteadOf "https://github.com/"
 SCRIPT
+
+  $configure_cassandra = <<SCRIPT
+    # Set up data directory
+    mkdir -p /var/data/cassandra
+    chcon -Rt svirt_sandbox_file_t /var/data/cassandra # SELinux policy
+    # Create and enable systemd unit
+    cp /home/vagrant/swan/misc/dev/vagrant/singlenode/resources/cassandra.service /usr/lib/systemd/system/
+    systemctl daemon-reload
+    systemctl enable cassandra.service
+    systemctl restart cassandra.service
+SCRIPT
+
 
   config.vm.provision "shell", inline: $install_packages
   config.vm.provision "shell", inline: $configure_docker
   config.vm.provision "shell", inline: $setup_user_env
+  config.vm.provision "shell", inline: $configure_cassandra
 end

--- a/misc/dev/vagrant/singlenode/resources/cassandra.service
+++ b/misc/dev/vagrant/singlenode/resources/cassandra.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Apache Cassandra
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker rm -f cassandra-swan
+ExecStartPre=/usr/bin/docker pull cassandra:3.5
+ExecStart=/usr/bin/docker run \
+  --name cassandra-swan \
+  --net host \
+  -e CASSANDRA_LISTEN_ADDRESS=127.0.0.1 \
+  -e CASSANDRA_CLUSTER_NAME=cassandra-swan \
+  -v /var/data/cassandra:/var/lib/cassandra \
+  cassandra:3.5
+ExecStartPost=/usr/bin/sleep 10
+ExecStartPost=/usr/bin/docker run \
+  --rm \
+  --net host \
+  -v /home/vagrant/swan/misc/dev/vagrant/singlenode/resources:/resources \
+  cassandra:3.5 \
+  cqlsh localhost --file /resources/keyspace.cql
+
+[Install]
+WantedBy=multi-user.target

--- a/misc/dev/vagrant/singlenode/resources/keyspace.cql
+++ b/misc/dev/vagrant/singlenode/resources/keyspace.cql
@@ -1,0 +1,2 @@
+CREATE KEYSPACE IF NOT EXISTS snap WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+DESCRIBE KEYSPACES;


### PR DESCRIPTION
Fixes issue SCE-365.

**Summary of changes**
- Added a helper script to run the integration tests within the
  development VM.
- Added a helper script to launch a local dockerized Cassandra instance
  and create the necessary keyspace.
- Modified cassandra integration tests to create the snap.metrics table
  in case it doesn't already exist (there's no reason it would exist in
  a fresh Cassandra ring).
- Updated local executor to prefer running memcached as the current
  user, if it can be determined by the environment.
- Updated snap dependency hash in Godeps because the current version
  does not build due to errors in fetching a broken dependency.
- Converted both expected and actual time values to UTC in the Cassandra
  result gatherer integration test to avoid flaky failures when the
  tests are run during a date boundary between the test machine and the
  Cassandra instance.
- Added netcat to the additional VM packages (integration test dep)

**Testing done**
- `vagrant destroy && vagrant up`
- Ran integration tests by following the new instructions for the local dev VM.

_NOTE: the remote executor tests do not currently run in the development
VM (requires additional configuration). Tracked as SCE-389._
