### PR TITLE
[SCE-296] New cgroups abstraction.

### DIFF
--- a/integration_tests/pkg/isolation/cgroup/cgroup_test.go
+++ b/integration_tests/pkg/isolation/cgroup/cgroup_test.go
@@ -1,0 +1,291 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	pth "path"
+	"strings"
+	"testing"
+
+	. "github.com/intelsdi-x/swan/pkg/isolation/cgroup"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func uuidgen(t *testing.T) string {
+	cmd := exec.Command("/usr/bin/uuidgen")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Error(err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// AbsPath(controller string) (string, error)
+func TestCgroupAbsPath(t *testing.T) {
+	Convey("After constructing a cgroup", t, func() {
+		cg, _ := NewCgroup([]string{"cpuset"}, "foo")
+		Convey("It should have a reasonable absolute path", func() {
+			So(cg.AbsPath("cpuset"), ShouldNotBeNil)
+		})
+	})
+}
+
+// Create() error
+func TestCgroupCreate(t *testing.T) {
+	Convey("After creating a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpu"
+		cg, _ := NewCgroup([]string{controller}, path)
+		err := cg.Create()
+		defer cg.Destroy(true)
+
+		Convey("The returned error should be nil", func() {
+			So(err, ShouldBeNil)
+		})
+		Convey("And the absolute path should exist", func() {
+			abs := cg.AbsPath(controller)
+			info, err := os.Stat(abs)
+			So(err, ShouldBeNil)
+			So(info, ShouldNotBeNil)
+			So(info.IsDir(), ShouldBeTrue)
+		})
+	})
+}
+
+// Exists() (bool, error)
+func TestCgroupExists(t *testing.T) {
+	Convey("After constructing a new cgroup", t, func() {
+		path := uuidgen(t)
+		cg, _ := NewCgroup([]string{"cpu", "cpuset"}, path)
+
+		Convey("It should not exist before being created", func() {
+			ok, err := cg.Exists()
+			So(err, ShouldBeNil)
+			So(ok, ShouldBeFalse)
+		})
+
+		cg.Create()
+		defer cg.Destroy(true)
+
+		Convey("It should exist after being created", func() {
+			ok, err := cg.Exists()
+			So(err, ShouldBeNil)
+			So(ok, ShouldBeTrue)
+		})
+		Convey("And the directories should exist for each controller", func() {
+			for _, ctrl := range cg.Controllers() {
+				abs := cg.AbsPath(ctrl)
+				info, err := os.Stat(abs)
+				So(err, ShouldBeNil)
+				So(info, ShouldNotBeNil)
+				So(info.IsDir(), ShouldBeTrue)
+			}
+		})
+	})
+}
+
+// Parent() Cgroup
+func TestCgroupParent(t *testing.T) {
+	Convey("After creating a new nested cgroup", t, func() {
+		uuid1 := uuidgen(t)
+		uuid2 := uuidgen(t)
+		path := pth.Join(uuid1, uuid2)
+		controller := "cpu"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Parent().Destroy(true)
+
+		Convey("The nested cgroup should exist", func() {
+			ok, _ := cg.Exists()
+			So(ok, ShouldBeTrue)
+		})
+		Convey("The path should be nested correctly", func() {
+			So(cg.Path(), ShouldEqual, "/"+uuid1+"/"+uuid2)
+		})
+		Convey("The parent should also exist", func() {
+			So(cg.Parent().Path(), ShouldEqual, "/"+uuid1)
+			ok, _ := cg.Parent().Exists()
+			So(ok, ShouldBeTrue)
+		})
+		Convey("And the grand-parent should be the root (and exist)", func() {
+			So(cg.Parent().Parent().Path(), ShouldEqual, "/")
+			ok, _ := cg.Parent().Parent().Exists()
+			So(ok, ShouldBeTrue)
+		})
+	})
+}
+
+// Destroy(recursive bool) error
+func TestCgroupDestroy(t *testing.T) {
+	Convey("After creating a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpu,cpuset"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Destroy(true)
+
+		Convey("The cgroup should exist until it is destroyed", func() {
+			ok, _ := cg.Exists()
+			So(ok, ShouldBeTrue)
+
+			cg.Destroy(true)
+			ok, _ = cg.Exists()
+			So(ok, ShouldBeFalse)
+			for _, ctrl := range cg.Controllers() {
+				abs := cg.AbsPath(ctrl)
+				_, err := os.Stat(abs)
+				So(err, ShouldNotBeNil)
+			}
+		})
+	})
+
+	Convey("After creating a new nested cgroup", t, func() {
+		uuid1 := uuidgen(t)
+		uuid2 := uuidgen(t)
+		path := pth.Join(uuid1, uuid2)
+		controller := "cpu"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Parent().Destroy(true)
+
+		Convey("The nested cgroup should exist", func() {
+			ok, _ := cg.Exists()
+			So(ok, ShouldBeTrue)
+
+			Convey("And destroying the parent non-recursively should fail", func() {
+				err := cg.Parent().Destroy(false)
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+// Get(name string) (string, error)
+func TestCgroupGet(t *testing.T) {
+	Convey("After creating a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpuset"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Destroy(true)
+		ok, _ := cg.Exists()
+		So(ok, ShouldBeTrue)
+
+		Convey("The cgroup's attributes should be gettable", func() {
+			value, err := cg.Get("cpuset.cpu_exclusive")
+			So(err, ShouldBeNil)
+			So(value, ShouldEqual, "0")
+		})
+	})
+}
+
+// Set(name string, value string) error
+func TestCgroupSet(t *testing.T) {
+	Convey("After creating a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpuset"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Destroy(true)
+		ok, _ := cg.Exists()
+		So(ok, ShouldBeTrue)
+
+		Convey("The cgroup's attributes should be settable", func() {
+			// Check initial cpuset mems setting
+			value, _ := cg.Get("cpuset.mems")
+			So(value, ShouldEqual, "")
+
+			// Set cpuset mems
+			err := cg.Set("cpuset.mems", "0")
+			So(err, ShouldBeNil)
+			value, _ = cg.Get("cpuset.mems")
+			So(value, ShouldEqual, "0")
+
+			// Check initial cpuset exclusivity setting
+			value, _ = cg.Get("cpuset.cpu_exclusive")
+			So(value, ShouldEqual, "0")
+
+			// Set cpuset exclusivity
+			err = cg.Set("cpuset.cpu_exclusive", "1")
+			So(err, ShouldBeNil)
+			value, _ = cg.Get("cpuset.cpu_exclusive")
+			So(value, ShouldEqual, "1")
+
+			// Unset cpuset exclusivity
+			err = cg.Set("cpuset.cpu_exclusive", "0")
+			So(err, ShouldBeNil)
+			value, _ = cg.Get("cpuset.cpu_exclusive")
+			So(value, ShouldEqual, "0")
+		})
+	})
+}
+
+// Tasks(controller string) ([]uint32, error)
+func TestCgroupTasks(t *testing.T) {
+	Convey("After creating a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpu"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Destroy(true)
+		ok, _ := cg.Exists()
+		So(ok, ShouldBeTrue)
+
+		Convey("When sleeping in the cgroup", func() {
+			cmd := exec.Command("cgexec", "-g", "cpu:"+cg.Path(), "/usr/bin/sleep", "10")
+			cmd.Start()
+			defer cmd.Process.Kill()
+			Convey("The tasks set should contain the sleeping process id", func() {
+				tasks, err := cg.Tasks(controller)
+				So(err, ShouldBeNil)
+				So(len(tasks), ShouldEqual, 1)
+				So(tasks.Contains(cmd.Process.Pid), ShouldBeTrue)
+			})
+		})
+	})
+}
+
+// Decorate(command string) string
+func TestCgroupDecorate(t *testing.T) {
+	Convey("After constructing a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpu"
+		cg, _ := NewCgroup([]string{controller}, path)
+
+		Convey("It should decorate commands", func() {
+			result := cg.Decorate("sleep 10")
+			So(result, ShouldEqual, "cgexec -g cpu:"+cg.Path()+" sleep 10")
+		})
+	})
+}
+
+// Isolate(PID int) error
+func TestCgroupIsolate(t *testing.T) {
+	Convey("After creating a new cgroup", t, func() {
+		path := uuidgen(t)
+		controller := "cpu"
+		cg, _ := NewCgroup([]string{controller}, path)
+		cg.Create()
+		defer cg.Destroy(true)
+		ok, _ := cg.Exists()
+		So(ok, ShouldBeTrue)
+
+		Convey("When sleeping outside of the cgroup", func() {
+			cmd := exec.Command("/usr/bin/sleep", "10")
+			cmd.Start()
+			defer cmd.Process.Kill()
+			tasks, _ := cg.Tasks(controller)
+			So(tasks.Contains(cmd.Process.Pid), ShouldBeFalse)
+
+			Convey("After isolating the sleeping process", func() {
+				err := cg.Isolate(cmd.Process.Pid)
+				So(err, ShouldBeNil)
+
+				Convey("The tasks set should contain the sleeping process id", func() {
+					tasks, _ := cg.Tasks(controller)
+					So(tasks.Contains(cmd.Process.Pid), ShouldBeTrue)
+				})
+			})
+		})
+	})
+}

--- a/integration_tests/pkg/isolation/cgroup/subsys_test.go
+++ b/integration_tests/pkg/isolation/cgroup/subsys_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/intelsdi-x/swan/pkg/executor"
+	. "github.com/intelsdi-x/swan/pkg/isolation/cgroup"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCgroupSubsysMounts(t *testing.T) {
+
+	// SubsysMounts()
+	Convey("When reporting cgroup subsystem mounts", t, func() {
+		mounts, err := SubsysMounts(executor.NewLocal(), DefaultCommandTimeout)
+		Convey("The returned mounts should not be nil", func() {
+			So(mounts, ShouldNotBeNil)
+		})
+		Convey("The returned mounts should not be empty", func() {
+			So(mounts, ShouldNotBeEmpty)
+		})
+		Convey("The returned error should be nil", func() {
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+// Subsys()
+func TestCgroupSubsys(t *testing.T) {
+	Convey("When reporting whether certain subsystems are mounted", t, func() {
+		Convey("The cpu subsystem should be mounted", func() {
+			mounted, err := Subsys("cpu", executor.NewLocal(), DefaultCommandTimeout)
+			So(err, ShouldBeNil)
+			So(mounted, ShouldBeTrue)
+		})
+		Convey("And the foobar subsystem should not be mounted", func() {
+			mounted, err := Subsys("foobar", executor.NewLocal(), DefaultCommandTimeout)
+			So(err, ShouldBeNil)
+			So(mounted, ShouldBeFalse)
+		})
+	})
+}
+
+// SubsysPath()
+func TestCgroupSubsysPath(t *testing.T) {
+	Convey("When reporting the mount for a given subsys", t, func() {
+		Convey("The cpu subsystem mount should exist", func() {
+			mount, err := SubsysPath("cpu", executor.NewLocal(), DefaultCommandTimeout)
+			So(err, ShouldBeNil)
+			info, err := os.Stat(mount)
+			So(err, ShouldBeNil)
+			So(info, ShouldNotBeNil)
+			So(info.IsDir(), ShouldBeTrue)
+		})
+	})
+}

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -81,6 +81,10 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 			}
 		}
 
+		// Flush write buffers to disk to prevent a race with the caller.
+		stdoutFile.Sync()
+		stderrFile.Sync()
+
 		log.Debug(
 			"Ended ", strings.Join(cmd.Args, " "),
 			" with output in file: ", stdoutFile.Name(),

--- a/pkg/isolation/cgroup/cgroup.go
+++ b/pkg/isolation/cgroup/cgroup.go
@@ -1,0 +1,262 @@
+package cgroup
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	pth "path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/isolation"
+)
+
+const (
+	// DefaultCommandTimeout is the default amount of time to wait for
+	// dispatched commands to finish executing.
+	DefaultCommandTimeout = 1 * time.Second
+)
+
+// Cgroup represents a Linux control group.
+// See https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
+//
+// Usage of this interface requires the libcgroup tools to be installed
+// on the system. This library interacts with cgroups by shelling out to
+// utility programs like `cgcreate`, `cgexec`, `cgget` and friends.
+type Cgroup interface {
+	isolation.Isolation
+
+	// Path returns this cgroup's controllers.
+	Controllers() []string
+
+	// Path returns this cgroup's path in the hierarchy.
+	Path() string
+
+	// AbsPath returns the absolute path to this cgroup within the
+	// VFS mount for the specified controller.
+	// Returns the empty string if the controller is not a member of
+	// this cgroup's controllers.
+	// e.g. `d, err := cgroup.AbsPath("cpuset")`
+	AbsPath(controller string) string
+
+	// Exists returns `true` iff this cgroup is present in all of its
+	// controller hierarchies.
+	Exists() (bool, error)
+
+	// Destroy removes this cgroup.
+	// If recursive is specified, also destroy this cgroup's children.
+	// Returns an error if this cgroup has children but recurvisve was not
+	// specified.
+	// Returns an error if this cgroup cannot be destroyed.
+	Destroy(recursive bool) error
+
+	// Parent returns the direct ancestor of this cgroup, or nil if this
+	// is the root.
+	Parent() Cgroup
+
+	// Tasks returns the pids for this cgroup and the supplied controller.
+	// Returns an error if the controller is not a member of
+	// this cgroup's controllers.
+	//
+	// NB: Linux pid range is [0,  2^22]; see /proc/sys/kernel/pid_max.
+	Tasks(controller string) (isolation.IntSet, error)
+
+	// Get returns the value of an attribute for this Cgroup.
+	Get(name string) (string, error)
+
+	// Set overwrites the value of an attribute for this Cgroup.
+	Set(name string, value string) error
+}
+
+// NewCgroup returns a new Cgroup with the supplied controllers and path.
+// Returns an error if no controllers are specified or the path is empty.
+func NewCgroup(controllers []string, path string) (Cgroup, error) {
+	return NewCgroupWithExecutor(controllers,
+		path,
+		executor.NewLocal(),
+		DefaultCommandTimeout)
+}
+
+// NewCgroupWithExecutor returns a new Cgroup with the supplied controllers,
+// path and executor. Returns an error if no controllers are specified or
+// the path is empty.
+func NewCgroupWithExecutor(controllers []string,
+	path string,
+	executor executor.Executor,
+	cmdTimeout time.Duration) (Cgroup, error) {
+	if len(controllers) == 0 {
+		return nil, fmt.Errorf("No controllers specified for cgroup")
+	}
+	if path == "" {
+		return nil, fmt.Errorf("Empty path specified for cgroup")
+	}
+	if executor == nil {
+		return nil, fmt.Errorf("Nil executor supplied for cgroup")
+	}
+	canonicalPath := pth.Join("/", path)
+	return &cgroup{controllers, canonicalPath, executor, cmdTimeout}, nil
+}
+
+// The cgroup struct implements the Cgroup interface.
+type cgroup struct {
+	controllers []string
+	path        string
+	executor    executor.Executor
+	cmdTimeout  time.Duration
+}
+
+func (cg *cgroup) Controllers() []string {
+	return cg.controllers
+}
+
+func (cg *cgroup) Path() string {
+	return cg.path
+}
+
+func (cg *cgroup) AbsPath(controller string) string {
+	p, err := SubsysPath(controller, cg.executor, cg.cmdTimeout)
+	if err != nil {
+		return ""
+	}
+	return pth.Join(p, cg.path)
+}
+
+func (cg *cgroup) Exists() (bool, error) {
+	for _, ctrl := range cg.controllers {
+		out, err := cg.cmdOutput("lscgroup", "-g", fmt.Sprintf("%s:%s", ctrl, cg.path))
+		if err != nil {
+			return false, err
+		}
+		if strings.Count(string(out), "\n") < 1 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (cg *cgroup) Create() error {
+	_, err := cg.cmdOutput("cgcreate", "-g", cg.spec())
+	return err
+}
+
+func (cg *cgroup) Destroy(recursive bool) error {
+	if recursive {
+		_, err := cg.cmdOutput("cgdelete", "--recursive", "-g", cg.spec())
+		return err
+	}
+	_, err := cg.cmdOutput("cgdelete", "-g", cg.spec())
+	return err
+}
+
+func (cg *cgroup) Parent() Cgroup {
+	if cg.path == "/" {
+		return nil
+	}
+	parentPath, _ := pth.Split(cg.path)
+	// Discarding errors here because controllers and path are both
+	// guaranteed to be non-empty.
+	p, _ := NewCgroup(cg.controllers, parentPath)
+	return p
+}
+
+func (cg *cgroup) Tasks(controller string) (isolation.IntSet, error) {
+	d := cg.AbsPath(controller)
+	if d == "" {
+		return nil, fmt.Errorf("Failed to read absolute path for controller %s", controller)
+	}
+
+	tf, err := os.Open(pth.Join(d, "tasks"))
+	defer tf.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	pids := isolation.NewIntSet()
+	s := bufio.NewScanner(tf)
+	for s.Scan() {
+		t, err := strconv.Atoi(s.Text())
+		if err != nil {
+			return nil, err
+		}
+		pids.Add(t)
+	}
+
+	// After Scan returns false, the Err method returns any scanning
+	// operations, except in case of EOF.
+	if s.Err() != nil {
+		return nil, s.Err()
+	}
+
+	return pids, err
+}
+
+func (cg *cgroup) Get(name string) (string, error) {
+	out, err := cg.cmdOutput("cgget", "-nv", "--variable", name, cg.path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (cg *cgroup) Set(name string, value string) error {
+	_, err := cg.cmdOutput("cgset", "-r", fmt.Sprintf("%s=%s", name, value), cg.path)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cg *cgroup) Clean() error {
+	return cg.Destroy(true)
+}
+
+func (cg *cgroup) Decorate(command string) string {
+	return fmt.Sprintf("cgexec -g %s %s", cg.spec(), command)
+}
+
+func (cg *cgroup) Isolate(PID int) error {
+	_, err := cg.cmdOutput("cgclassify", "-g", cg.spec(), strconv.Itoa(PID))
+	return err
+}
+
+// Internal helpers for getting command output.
+func cmdOutput(executor executor.Executor, cmdTimeout time.Duration, argv ...string) (string, error) {
+	cmd := strings.Join(argv, " ")
+	task, err := executor.Execute(cmd)
+	defer task.EraseOutput()
+	if err != nil {
+		return "", err
+	}
+	if ok := task.Wait(cmdTimeout); !ok {
+		return "", fmt.Errorf("Timed out waiting for command: %s", cmd)
+	}
+	code, err := task.ExitCode()
+	if err != nil {
+		return "", err
+	}
+	if code != 0 {
+		return "", fmt.Errorf("Command exited with code %d: %s", code, cmd)
+	}
+	oFile, err := task.StdoutFile()
+	if err != nil {
+		return "", err
+	}
+	bytes, err := ioutil.ReadFile(oFile.Name()) // assume small output
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func (cg *cgroup) cmdOutput(argv ...string) (string, error) {
+	return cmdOutput(cg.executor, cg.cmdTimeout, argv...)
+}
+
+// Internal helper for creating libcgroup-tools compatible args.
+// Returns a string like 'cpu,cpuset:/my/cool/group'.
+func (cg *cgroup) spec() string {
+	return fmt.Sprintf("%s:%s", strings.Join(cg.controllers, ","), cg.path)
+}

--- a/pkg/isolation/cgroup/cgroup_test.go
+++ b/pkg/isolation/cgroup/cgroup_test.go
@@ -1,0 +1,66 @@
+package cgroup
+
+import (
+	"testing"
+
+	"github.com/intelsdi-x/swan/pkg/isolation"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// NewCgroup(controllers []string, path string)
+func TestNewCgroup(t *testing.T) {
+	Convey("When properly constructing a cgroup", t, func() {
+		controllers := []string{"cpu", "cpuset"}
+		path := "foo"
+		cg, err := NewCgroup(controllers, path)
+		Convey("The returned cgroup should not be nil", func() {
+			So(cg, ShouldNotBeNil)
+		})
+		Convey("It should implement isolation.Isolation", func() {
+			So(cg, ShouldImplement, (*isolation.Isolation)(nil))
+		})
+		Convey("The returned error should be nil", func() {
+			So(err, ShouldBeNil)
+		})
+	})
+	Convey("When improperly constructing a cgroup with empty controllers", t, func() {
+		cg, err := NewCgroup([]string{}, "foo")
+		Convey("The returned cgroup should be nil", func() {
+			So(cg, ShouldBeNil)
+		})
+		Convey("And the returned error should not be nil", func() {
+			So(err, ShouldNotBeNil)
+		})
+	})
+	Convey("When improperly constructing a cgroup with an empty path", t, func() {
+		cg, err := NewCgroup([]string{"foo", "bar"}, "")
+		Convey("The returned cgroup should be nil", func() {
+			So(cg, ShouldBeNil)
+		})
+		Convey("And the returned error should not be nil", func() {
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
+// Controllers() []string
+func TestCgroupControllers(t *testing.T) {
+	Convey("After constructing a cgroup", t, func() {
+		controllers := []string{"cpuset"}
+		cg, _ := NewCgroup(controllers, "foo")
+		Convey("It should have the right controllers", func() {
+			So(cg.Controllers(), ShouldResemble, controllers)
+		})
+	})
+}
+
+// Path() string
+func TestCgroupPath(t *testing.T) {
+	Convey("After constructing a cgroup", t, func() {
+		path := "foo"
+		cg, _ := NewCgroup([]string{"cpuset"}, path)
+		Convey("It should have the right path", func() {
+			So(cg.Path(), ShouldEqual, "/foo")
+		})
+	})
+}

--- a/pkg/isolation/cgroup/subsys.go
+++ b/pkg/isolation/cgroup/subsys.go
@@ -1,0 +1,60 @@
+package cgroup
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/swan/pkg/executor"
+)
+
+// Subsys returns true if the named subsystem is mounted.
+func Subsys(name string, executor executor.Executor, timeout time.Duration) (bool, error) {
+	mounts, err := SubsysMounts(executor, timeout)
+	if err != nil {
+		return false, err
+	}
+	_, found := mounts[name]
+	return found, nil
+}
+
+// SubsysPath returns the absolute path where the supplied subsystem is
+// mounted. Returns the empty string if the subsystem is not mounted.
+func SubsysPath(name string, executor executor.Executor, timeout time.Duration) (string, error) {
+	mounts, err := SubsysMounts(executor, timeout)
+	if err != nil {
+		return "", err
+	}
+	return mounts[name], nil
+}
+
+// SubsysMounts returns a map of cgroup subsystem controller names to
+// mount points in the file system.
+func SubsysMounts(executor executor.Executor, timeout time.Duration) (map[string]string, error) {
+	out, err := cmdOutput(executor, timeout, "lssubsys", "--all-mount-points")
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	lines := strings.Split(string(out), "\n")
+
+	for _, line := range lines {
+		var name, mount string
+		_, err := fmt.Sscanf(line, "%s %s", &name, &mount)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		// The name part may indicate co-mounted subsystems (e.g. "cpu,cpuacct").
+		// Let's save them separately to make them easier to find.
+		names := strings.Split(name, ",")
+		for _, n := range names {
+			result[n] = mount
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
Related to issue SCE-296.

_Rationale:_

Since there is already duplicate code for direct usage of `cgcreate` in the various isolators, it makes sense to introduce an abstraction for creating, inspecting and manipulating cgroups and also exposing the nested cgroups that `cgcreate` is capable of setting up. In particular, this was motivated by more complex rules for settings across multiple cgroups to correctly implement SCE-296 (exclusive cpu sets). We can lean on standard tooling from the same `libcgroup-tools` package like `lscgroup`, `cgget`, `cgset` and `cgclassify`. Handling this in our own internal library helps avoid bad assumptions like the cgroup root is `/sys/fs/cgroup`, for example.  The `CPUSet`, `CPUShares` and `MemorySize` isolators will be updated to use the new `Cgroup` abstraction in upcoming patches.

Summary of changes:
- Added a new cgroups abstraction  
- Added tests for the above.

Testing done:
- `go test ./pkg/cgroup/...` (as root and non-root)
- `make integration_test` (as root and non-root)
