### PR TITLE
SCE-400 Added checking if err is not nil during creating Cassandra session.

### DIFF
--- a/integration_tests/pkg/cassandra/experiment_result_gatherer_test.go
+++ b/integration_tests/pkg/cassandra/experiment_result_gatherer_test.go
@@ -54,6 +54,7 @@ func TestValuesGatherer(t *testing.T) {
 	logrus.SetLevel(logrus.ErrorLevel)
 	Convey("While connecting to Cassandra with proper parameters", t, func() {
 		cassandraConfig, err := cassandra.CreateConfigWithSession("127.0.0.1", "snap")
+		So(err, ShouldBeNil)
 		session := cassandraConfig.CassandraSession()
 		Convey("I should receive not empty session", func() {
 			So(session, ShouldNotBeNil)


### PR DESCRIPTION
Fixes issue SCE-400 (TestValuesGatherer integration test does not work when there is no `snap` keyspace inside Cassandra.)

Summary of changes:
- Added checking if error for creating cassandraConfig is not nil. For 'snap' keyspace it should be nil.  

Testing done:
- make
