### PR TITLE
DESIGN PROPOSAL: CLI

### DIFF
--- a/pkg/cli/DESIGN.md
+++ b/pkg/cli/DESIGN.md
@@ -1,0 +1,45 @@
+I see value in separation of ENVIRONMENT and PARAMETERS.
+When I create an Experiment I want to determine that my Memcached runs on 4 threads.
+That's my experiment property.
+
+But there are some variables that are above those properties.
+Values like Cassandra location depends on Enviroment. I cannot foresee their location
+ while writing experiment. But I want my experiment binary to obtain those values
+ from respective ENVIROMENT.
+
+I want my exp binary to work both on my DEVELOPER, STAGING and PROD enviroments.
+I can have my environments prepared by Ansible scripts,
+that can be checked-in to our sno-ops repository. This way our ENVIROMENTS are the same.
+
+For me, there are some crucial aspects of software development:
+
+- Keep code entanglement as low as possible
+- Have one single way of defining something
+- Keep responsibilities encapsulated in their respectable domains
+
+
+In my code example we have following properties:
+- CLI does not know anything about Experiment and Launcher
+- Launcher dos not know anything about CLI
+- Every Launcher can tell what he requires from environment (responsibility encapsulation)
+- Experiment is a proxy that passes Launchers env reqs to CLI (law of demeter)
+- Only Launcher can configure it's own environment configuration - Experiment should not do that, because it's responsibilites (experiment cannot know where Cassandra will be Launched in env) (responsibility segregation)
+- There is only one single way to set environment configuration in launchers (simple code, less bugs)
+
+IMO opinion, an approach where Experiment defines what Launcher needs is wrong. It look fragile because it's easy to overlook some variables. It can also cause regression problems when Launcher would define NEW env requirements (we would have to change all the experiments to accommodate this).
+
+Also, I see problem when Experiment even touches Launchers env configuration. It cannot know it beforehand, so why he should do it? During our discussions, Bartek proposed similar thing which is IMO very good idea.
+
+
+FAQ:
+-
+
+1. Why we are even discussing such small thing?
+
+I don't consider it small. Entangling CLI with Experiment and Launcher brings much overhead to whole code. I consider this a core problem.
+
+2. How is this different from other propositions?
+
+In this PR I have created a CLI that is powerful and simple.
+With IOC by EnvVariables and simple os.setenv() in CLI we can do anything.
+Helper method gives great readme for experiment user and it is very close to entity that utilizes variables (Launchers defines env reqs AND helper).

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/codegangsta/cli"
+	"github.com/intelsdi-x/snap/plugin/helper"
+	"k8s.io/kubernetes/third_party/golang/go/doc/testdata"
+	"os"
+)
+
+type Helper struct {
+	key          string
+	defaultValue string
+	helperString string
+	isRequired   Key // I'm not sure about this swich.
+	// We have defaults in most places now,
+	// but we can be open for changes.
+}
+
+type Key int
+
+const (
+	OPTIONAL Key = iota
+	REQUIRED Key = iota
+)
+
+type Cli struct {
+	helpers []Helper
+	readme  string
+
+	canRun bool
+}
+
+func (c Cli) AddReadme(readme string) {
+	c.readme = readme
+}
+
+func (c Cli) AddHelper(helper Helper) {
+	c.helpers = append(c.helpers, helper)
+}
+
+func (c Cli) CanRunExperiment() {
+	return c.canRun
+}
+
+func (c Cli) ParseArgs(argv []string) {
+	if argumentIsShowHelp(argv) {
+		c.showHelp()
+		c.canRun = false
+	}
+
+	parameters := parseParams(argv)
+
+	for key, value := range parameters {
+		// This way we can pass arguments from CLI to our deepest Launchers.
+		// We can let them configure themselves.
+		os.Setenv(key, value)
+	}
+
+	c.checkIfRequiredParamsAreSet() // throw panic if not
+}
+
+func argumentIsShowHelp(argv []string) {
+	return len(argv) > 1 && (argv[1] == "--help" || argv[1] == "-h")
+}
+
+// Print all nested helpers
+func (c Cli) showHelp() {
+	fmt.Printf("%s\n", c.readme)
+	for _, helper := range c.helpers {
+		fmt.Printf("%s %s %s required: %v",
+			helper.key,
+			helper.helperString,
+			helper.defaultValue,
+			helper.isRequired)
+	}
+}
+
+func parseParams(argv []string) map[string]string {
+	var params map[string]string
+	// Map CLI arguments like SWAN_CASSANDRA_ADDRESS=10.4.1.1 into key-value pairs
+	return params
+}
+
+func (c Cli) checkIfRequiredParamsAreSet() {
+	for _, param := range c.helpers {
+		if param.isRequired {
+			if os.Getenv(param.key) == "" {
+				panic("Key " + param.key + " is not set!")
+			}
+		}
+	}
+}

--- a/pkg/cli/some_experiment.go
+++ b/pkg/cli/some_experiment.go
@@ -1,0 +1,44 @@
+package main
+
+import "github.com/codegangsta/cli"
+
+const (
+	// Experiment sets the Local/Remote executors, so he need to gather their addresses from environment
+	loadGeneratorLocationKey = "SWAN_LOAD_GENERATOR_LOCATION"
+	loadGeneratorLocationDefault = "127.0.0.1"
+)
+
+// Example usage of experiment:
+// ./experiment --help
+// ./experiment SWAN_CASSANDRA_ADDRESS=10.4.1.1
+// We can also implement ./experiment cassandra_address=10.4.1.1
+// or https://github.com/kelseyhightower/envconfig to reduce prefixes
+func main() {
+	cli.AddReadme("Some link to readme")
+	cli.AddHelper(thisExperiment.Helper()) // Most imporant part
+	dontRun := cli.ParseArgs(argv) // If our enviroment lack required variable, we throw error
+	if (dontRun) { // don't run when user just wanted to see help
+		return 0
+	}
+
+	// rest of experiment goes here
+
+	// At this moment all Launchers are configured by themselves.
+	// Experiment nor CLI does not directly changes any enviroment configuration in them.
+	// Here, Environment Variables are my IOC Container that injects configs where it has to be injected.
+	// Simple, and with no entangling
+}
+
+// Helper function informs user of enviroment variables that are used by this Experiment and underlying launchers
+// It should be part of Experiment Interface
+func (e Experiment) Helper() []cli.Helper {
+	return {
+		cli.Helper{loadGeneratorLocationKey, loadGeneratorLocationDefault, "Mutilate host", cli.OPTIONAL},
+		e.load_generator.Helper(), // We can extract helpers from Experiment's launcher
+		e.lc_workload.Helper(),
+		e.be_workload.Helper(),
+	}
+}
+// Helper returs list of used enviroment variables in format
+// <KEY, DEFAULT_VALUE, Description for experiment user, Optional/required>
+// Optional/required - if required key is non-existent, CLI will throw error

--- a/pkg/cli/some_launcher.go
+++ b/pkg/cli/some_launcher.go
@@ -1,0 +1,57 @@
+package cli
+
+import "github.com/codegangsta/cli"
+
+const (
+	cassandraAddressKey = "SWAN_CASSANDRA_ADDRESS"
+	snapDAddress = "SWAN_SNAPD_ADDRESS"
+
+	cassandraAddressDefault = "127.0.0.1"
+	snapDAddressDefault = "10.4.1.1"
+)
+
+type SomeLauncher struct {
+	c Config
+	e executor.Executor
+}
+
+type Config struct {
+	CassandraAddress string
+	SnapDAddress 	 string
+	Threads      int
+}
+
+func DefaultConfig() Config {
+	return Config{
+		CassandraAddress: osutil.GetEnvOrDefault(cassandraAddressKey, cassandraAddressDefault),
+		SnapDAddress: osutil.GetEnvOrDefault(snapDAddress, snapDAddressDefault),
+		Threads: 4,
+	}
+}
+
+func (s SomeLauncher) Launch() (executor.TaskHandle, error) {
+	task, err := s.e.Execute("command")
+	if err != nil {
+		return nil, err
+	}
+
+	return task, nil
+}
+
+// Helper function informs user of enviroment variables that are used by this Launcher
+// It should be part of Launcher Interface
+func (s SomeLauncher) Helper() []cli.Helper {
+	// Helper returs list of used enviroment variables in format
+	// <KEY, DEFAULT_VALUE, Description for experiment user, Optional/required>
+	// Optional/required - if required key is non-existent, CLI will throw error
+	return
+	{
+		cli.Helper{cassandraAddressKey, cassandraAddressDefault, "Cassandra hostname", cli.OPTIONAL},
+		cli.Helper{snapDAddress, snapDAddressDefault, "Cassandra hostname", cli.REQUIRED},
+	}
+}
+
+// Name returns human readable name for job.
+func (m SomeLauncher) Name() string {
+	return "SomeLauncher"
+}


### PR DESCRIPTION
We have argument about CLI design we should accommodate in our code.

As for Connor's email I would like to start a team discussion about possible solutions and pick one that would fit best into Swan.

Other approaches are:
- @Bplotka #161 

**My proposal in TLDR:**
- Launchers and Experiments will use Enviroment Variables to configure themselves
- Every Launcher and Experiment can tell what env variables it requires. This Help will be printed by CLI by passing `./experiment --help`
- CLI will accept parameters int format `./experiment SWAN_CASSANDRA_PATH=10.4.1.1` and expose them as key-value env variables (we can make those params shorter)
- Launcher can tell that some vars are `required` and CLI will check if they are available
- We need to have ansible scripts to prepare env vars in our enviroments. We have SCE-406 for that.

`./experiment --help` example:

```
This experiment runs sensitivity profile of Memcached.
+------------------------+---------------+---------------------+----------+
|          Key           | Default Value |    Desciription     | Required |
+------------------------+---------------+---------------------+----------+
| SWAN_CASSANDRA_ADDRESS | 127.0.0.1     | "Cassandra address" | true     |
| SWAN_SNAPD_ADDRESS     | 127.0.0.1     | "Snapd address"     | false    |
+------------------------+---------------+---------------------+----------+
```

---

I see value in separation of ENVIRONMENT and PARAMETERS.
When I create an Experiment I want to determine that my Memcached runs on 4 threads.
That's my experiment property.

But there are some variables that are above those properties.
Values like Cassandra location depends on Enviroment. I cannot foresee their location
 while writing experiment. But I want my experiment binary to obtain those values
 from respective ENVIROMENT.

I want my exp binary to work both on my DEVELOPER, STAGING and PROD enviroments.
I can have my environments prepared by Ansible scripts,
that can be checked-in to our sno-ops repository. This way our ENVIROMENTS are the same.

For me, there are some crucial aspects of software development:
- Keep code entanglement as low as possible
- Have one single way of defining something
- Keep responsibilities encapsulated in their respectable domains

In my code example we have following properties:
- CLI does not know anything about Experiment and Launcher
- Launcher dos not know anything about CLI
- Every Launcher can tell what he requires from environment (responsibility encapsulation)
- Experiment is a proxy that passes Launchers env reqs to CLI (law of demeter)
- Only Launcher can configure it's own environment configuration - Experiment should not do that, because it's responsibilites (experiment cannot know where Cassandra will be Launched in env) (responsibility segregation)
- There is only one single way to set environment configuration in launchers (simple code, less bugs)

IMO opinion, an approach where Experiment defines what Launcher needs is wrong. It look fragile because it's easy to overlook some variables. It can also cause regression problems when Launcher would define NEW env requirements (we would have to change all the experiments to accommodate this).

Also, I see problem when Experiment even touches Launchers env configuration. It cannot know it beforehand, so why he should do it? During our discussions, Bartek proposed similar thing which is IMO very good idea.
## FAQ:
1. Why we are even discussing such small thing?

I don't consider it small. Entangling CLI with Experiment and Launcher brings much overhead to whole code. I consider this a core problem.
1. How is this different from other propositions?

In this PR I have created a CLI that is powerful and simple.
With IOC by EnvVariables and simple os.setenv() in CLI we can do anything.
Helper method gives great readme for experiment user and it is very close to entity that utilizes variables (Launchers defines env reqs AND helper).
