### PR TITLE
SCE-399: Fixes integration test bug introduced in #151.

### DIFF
--- a/integration_tests/pkg/isolation/cpu_select_test.go
+++ b/integration_tests/pkg/isolation/cpu_select_test.go
@@ -43,9 +43,9 @@ func TestCPUSelect(t *testing.T) {
 			So(threadset, ShouldHaveLength, cpus.PhysicalCores)
 		})
 
-		Convey("It should contain all core ids", func() {
-			for i := 0; i < cpus.PhysicalCores; i++ {
-				So(threadset.Contains(i), ShouldBeTrue)
+		Convey("It should contain exactly one CPU from each physical core", func() {
+			for core := range cpus.CoreCpus {
+				So(len(threadset.Intersection(cpus.CoreCpus[core])), ShouldEqual, 1)
 			}
 		})
 	})


### PR DESCRIPTION
Fixes issue SCE-375 (regression in integration tests introduced in #151 )

Summary of changes:
- Updates a faulty assumption in TestCPUSelect about how logical CPUs
  are numbered with respect to physical cores.

Testing done:
- `make integration_test`

Attn @MrigankAtGitHub @mstachowski @ppalucki @skonefal 
