### PR TITLE
SCE-418: Handle missing subsys mount points.

### DIFF
--- a/integration_tests/pkg/isolation/cgroup/subsys_test.go
+++ b/integration_tests/pkg/isolation/cgroup/subsys_test.go
@@ -53,5 +53,10 @@ func TestCgroupSubsysPath(t *testing.T) {
 			So(info, ShouldNotBeNil)
 			So(info.IsDir(), ShouldBeTrue)
 		})
+		Convey("And the foobar subsystem mount should not exist", func() {
+			mount, err := SubsysPath("foobar", executor.NewLocal(), DefaultCommandTimeout)
+			So(err, ShouldNotBeNil)
+			So(mount, ShouldEqual, "")
+		})
 	})
 }

--- a/pkg/isolation/cgroup/subsys.go
+++ b/pkg/isolation/cgroup/subsys.go
@@ -26,7 +26,11 @@ func SubsysPath(name string, executor executor.Executor, timeout time.Duration) 
 	if err != nil {
 		return "", err
 	}
-	return mounts[name], nil
+	mount, mounted := mounts[name]
+	if !mounted {
+		return "", fmt.Errorf("Subsystem '%s' is not mounted", name)
+	}
+	return mount, nil
 }
 
 // SubsysMounts returns a map of cgroup subsystem controller names to


### PR DESCRIPTION
Fixes issue SCE-418

Summary of changes:
- Previously in the Cgroup abstraction, if a controller was not mounted
  then AbsPath would return a non-existent path. With this change it
  returns a non-nil error instead.

Testing done:
- `make integration_test`
