### PR TITLE
SCE-415: Missing custom percentile (Cassandra)

### DIFF
--- a/integration_tests/pkg/snap/sessions/mutilate_test.go
+++ b/integration_tests/pkg/snap/sessions/mutilate_test.go
@@ -126,15 +126,16 @@ func TestSnapMutilateSession(t *testing.T) {
 						// in "src/github.com/intelsdi-x/swan/misc/
 						// snap-plugin-collector-mutilate/mutilate/mutilate.stdout"
 						expectedMetrics := map[string]string{
-							"avg":  "20.80000",
-							"std":  "23.10000",
-							"min":  "11.90000",
-							"5th":  "13.30000",
-							"10th": "13.40000",
-							"90th": "33.40000",
-							"95th": "43.10000",
-							"99th": "59.50000",
-							"qps":  "4993.10000",
+							"avg":    "20.80000",
+							"std":    "23.10000",
+							"min":    "11.90000",
+							"5th":    "13.30000",
+							"10th":   "13.40000",
+							"90th":   "33.40000",
+							"95th":   "43.10000",
+							"99th":   "59.50000",
+							"qps":    "4993.10000",
+							"custom": "1777.88781",
 						}
 
 						Convey("Reading samples from file", func() {

--- a/pkg/snap/sessions/mutilate.go
+++ b/pkg/snap/sessions/mutilate.go
@@ -38,8 +38,8 @@ func NewMutilateSnapSessionLauncher(
 				"/intel/swan/mutilate/*/percentile/99th",
 				"/intel/swan/mutilate/*/qps",
 				//TODO: Fetch the 99_999th value from MUTILATE task itself!
-				//Does not work for now:
-				// "/intel/swan/mutilate/*/percentile/99_999th",
+				//It shall be redesigned ASAP
+				"/intel/swan/mutilate/*/percentile/*/custom",
 			},
 			interval,
 			snapClient,


### PR DESCRIPTION
Issue:
There are no data for custom percentile (eg. 99.9) in Cassandra while
running llc_aggr_local_cassandra.

FIX:
Metric
/intel/swan/mutilate/*/percentile/99_999th/custom
can be reached at
/intel/swan/mutilate/*/percentile/*/custom

However we need to redesign it asap. We can just keep .../percentile/custom and attach tag to it telling which percentile is in 'custom'.

Signed-off-by: Maciej Patelczyk maciej.patelczyk@intel.com
