### PR TITLE
SCE-432 - docs update: how to run cassandra inside a docker

### DIFF
--- a/experiments/memcached/llc_aggr_local_cassandra/README.md
+++ b/experiments/memcached/llc_aggr_local_cassandra/README.md
@@ -18,7 +18,7 @@ Every experiment includes:
 
 ## Prerequisites
 - Running `snapd`
-- Running Cassandra (NOTE: Cassandra publisher is required but it's private currently)
+- Running Cassandra. If you want to run it inside a docker: `docker run -d -p :9042:9042 -p :9160:9160 cassandra` (NOTE: Cassandra publisher is required but it's private currently)
 - `make build_workloads`
 - `make build`
 
@@ -32,4 +32,4 @@ Every experiment includes:
 
 After test execution, you can see the results using following script:
 
-`go run ./script/sensitivity_viewer/main.go `
+`go run ./scripts/sensitivity_viewer/main.go `


### PR DESCRIPTION
Fixes issue : SCE-432 there is no specification how to run cassandra in a docs

Summary of changes:
- add example how to run cassandra in a docker
- typo fix

Testing done:
- not needed

Added example because trying to run cassandra with default
configuration there is not enough ports open from docker.
