### PR TITLE
SCE-439: Use round-robin strategy for CPU select.

### DIFF
--- a/integration_tests/pkg/isolation/cpu_select_test.go
+++ b/integration_tests/pkg/isolation/cpu_select_test.go
@@ -25,7 +25,6 @@ func TestCPUSelect(t *testing.T) {
 	})
 
 	Convey("Should provide CPUSelect() to return an error when requesting zero cpus", t, func() {
-
 		threadset, err := isolation.CPUSelect(0, isolation.ShareLLCButNotL1L2)
 		So(err, ShouldNotBeNil)
 
@@ -35,7 +34,6 @@ func TestCPUSelect(t *testing.T) {
 	})
 
 	Convey("Should provide CPUSelect() to return nil and correct cpu ids", t, func() {
-
 		threadset, err := isolation.CPUSelect(cpus.PhysicalCores, isolation.ShareLLCButNotL1L2)
 		So(err, ShouldBeNil)
 
@@ -51,14 +49,12 @@ func TestCPUSelect(t *testing.T) {
 	})
 
 	Convey("Should provide CPUSelect() to not return nil when requesting more cores than a socket has", t, func() {
-
 		threadset, err := isolation.CPUSelect(cpus.PhysicalCores+1, isolation.ShareLLCButNotL1L2)
 		So(err, ShouldNotBeNil)
 
 		Convey("Should have length zero", func() {
 			So(threadset, ShouldHaveLength, 0)
 		})
-
 	})
 
 }

--- a/pkg/isolation/cpu_select.go
+++ b/pkg/isolation/cpu_select.go
@@ -52,11 +52,12 @@ func CPUSelect(countRequested int, filters uint) (IntSet, error) {
 
 	if filters == ShareLLCButNotL1L2 {
 		for i := 0; i < info.Sockets; i++ {
-			result, err := searchSocket(info, countRequested, i)
+			socket := nextSocket()
+			cpus, err := searchSocket(info, countRequested, socket)
 			if err == nil {
-				if len(result) == countRequested {
-					log.Debug("Answering CPUSelect query for %d cpus with %v", countRequested, result)
-					return result, nil
+				if len(cpus) == countRequested {
+					log.Debug("Answering CPUSelect query for %d cpus with %v on socket %d", countRequested, cpus, socket)
+					return cpus, nil
 				}
 			}
 		}


### PR DESCRIPTION
Fixes issue SCE-439

Summary of changes:
- `nextSocket` which implements round-robin over physical sockets was
  previously unreachable.

Testing done:
- `go test -v ./integration_tests/pkg/isolation/... -run TestCPUSelect`
