### PR TITLE
Only add user if he/she doesn't exist

### DIFF
--- a/workloads/data_caching/memcached/build.sh
+++ b/workloads/data_caching/memcached/build.sh
@@ -3,7 +3,7 @@ set -e
 mkdir -p memcached-1.4.25/build
 pushd memcached-1.4.25/build
 ../configure && make
-sudo adduser memcached
+id -u memcached &>/dev/null || sudo adduser memcached
 popd
 
 pushd mutilate


### PR DESCRIPTION
Skip trying to create the memcached user if he/she already exists. It creates noise in the test output otherwise.
