### PR TITLE
SCE-450: Add more flexible CPU topology.

### DIFF
--- a/integration_tests/pkg/isolation/cgroup/cpu_set_test.go
+++ b/integration_tests/pkg/isolation/cgroup/cpu_set_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	iso "github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/isolation"
 	"os/exec"
 	pth "path"
 	"testing"
@@ -18,8 +18,8 @@ func TestCPUSet(t *testing.T) {
 		uuid3 := uuidgen(t)
 
 		path := pth.Join("/", uuid1, uuid2, uuid3)
-		cpus := iso.NewIntSet(1)
-		mems := iso.NewIntSet(0)
+		cpus := isolation.NewIntSet(1)
+		mems := isolation.NewIntSet(0)
 
 		// Setting these to true assumes too much about the environment...
 		// For example the docker cpuset cgroup assigns all cpus by default,
@@ -46,13 +46,13 @@ func TestCPUSet(t *testing.T) {
 
 			actual, err := cpuSet.Cgroup().Get(cgroup.CPUSetCpus)
 			So(err, ShouldBeNil)
-			set, err := iso.NewIntSetFromRange(actual)
+			set, err := isolation.NewIntSetFromRange(actual)
 			So(err, ShouldBeNil)
 			So(set.Equals(cpus), ShouldBeTrue)
 
 			actual, err = cpuSet.Cgroup().Get(cgroup.CPUSetMems)
 			So(err, ShouldBeNil)
-			set, err = iso.NewIntSetFromRange(actual)
+			set, err = isolation.NewIntSetFromRange(actual)
 			So(err, ShouldBeNil)
 			So(set.Equals(mems), ShouldBeTrue)
 

--- a/integration_tests/pkg/isolation/topo/disco_test.go
+++ b/integration_tests/pkg/isolation/topo/disco_test.go
@@ -1,0 +1,69 @@
+package topo
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/isolation/topo"
+)
+
+const lscpu1 = `# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# CPU,Core,Socket,Node,,L1d,L1i,L2,L3
+0,0,0,0,,0,0,0,0
+1,1,0,0,,1,1,1,1
+`
+
+const lscpu2 = `# The following is the parsable format, which can be fed to other
+# programs. Each different item in every column has an unique ID
+# starting from zero.
+# CPU,Core,Socket,Node,,L1d,L1i,L2,L3
+0,0,0,0,,0,0,0,0
+1,1,0,0,,1,1,1,0
+2,2,0,0,,2,2,2,0
+3,3,0,0,,3,3,3,0
+4,0,0,0,,0,0,0,0
+5,1,0,0,,1,1,1,0
+6,2,0,0,,2,2,2,0
+7,3,0,0,,3,3,3,0
+`
+
+func TestDiscover(t *testing.T) {
+	Convey("When discovering the CPU topology", t, func() {
+		threadSet, err := topo.Discover()
+		So(err, ShouldBeNil)
+
+		Convey("It should discover a nonzero number of threads", func() {
+			So(len(threadSet), ShouldBeGreaterThan, 0)
+		})
+	})
+}
+
+func TestReadTopology(t *testing.T) {
+	Convey("When reading a canned topology with 2 CPUs", t, func() {
+		threadSet, err := topo.ReadTopology([]byte(lscpu1))
+		So(err, ShouldBeNil)
+
+		Convey("It should return a thread set with 2 threads from 2 cores on the same socket", func() {
+			So(len(threadSet), ShouldEqual, 2)
+			So(threadSet.AvailableThreads().Equals(isolation.NewIntSet(0, 1)), ShouldBeTrue)
+			So(threadSet.AvailableCores().Equals(isolation.NewIntSet(0, 1)), ShouldBeTrue)
+			So(threadSet.AvailableSockets().Equals(isolation.NewIntSet(0)), ShouldBeTrue)
+		})
+	})
+
+	Convey("When reading a canned topology with 8 CPUs", t, func() {
+		threadSet, err := topo.ReadTopology([]byte(lscpu2))
+		So(err, ShouldBeNil)
+
+		Convey("It should return a thread set with 8 threads from 4 cores on 1 socket", func() {
+			So(len(threadSet), ShouldEqual, 8)
+			So(threadSet.AvailableThreads().Equals(isolation.NewIntSet(0, 1, 2, 3, 4, 5, 6, 7)), ShouldBeTrue)
+			So(threadSet.AvailableCores().Equals(isolation.NewIntSet(0, 1, 2, 3)), ShouldBeTrue)
+			So(threadSet.AvailableSockets().Equals(isolation.NewIntSet(0)), ShouldBeTrue)
+		})
+	})
+}

--- a/pkg/isolation/cgroup/cpu_set.go
+++ b/pkg/isolation/cgroup/cpu_set.go
@@ -5,21 +5,21 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
-	iso "github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/isolation"
 )
 
 // CPUSet represents a cgroup in the cpuset hierarchy.
 type CPUSet interface {
-	iso.Isolation
+	isolation.Isolation
 
 	// Cgroup returns the underlying cgroup for this CPUSet.
 	Cgroup() Cgroup
 
 	// Cpus returns the set of cpus allocated to this CPUSet.
-	Cpus() iso.IntSet
+	Cpus() isolation.IntSet
 
 	// Cpus returns the set of memory nodes allocated to this CPUSet.
-	Mems() iso.IntSet
+	Mems() isolation.IntSet
 
 	// CPUExclusive returns true if this CPUSet's cpus are allocated
 	// exclusively..
@@ -49,23 +49,23 @@ const (
 // CPUSet describes a cgroup cpuset with core ids and numa (memory) nodes.
 type cpuset struct {
 	cgroup       Cgroup
-	cpus         iso.IntSet
-	mems         iso.IntSet
+	cpus         isolation.IntSet
+	mems         isolation.IntSet
 	cpuExclusive bool
 	memExclusive bool
 }
 
 // NewCPUSet creates a new CPUSet with the default (local) executor
 // and default timeout.
-func NewCPUSet(path string, cpus, mems iso.IntSet, cpuExclusive, memExclusive bool) (CPUSet, error) {
+func NewCPUSet(path string, cpus, mems isolation.IntSet, cpuExclusive, memExclusive bool) (CPUSet, error) {
 	return NewCPUSetWithExecutor(path, cpus, mems, cpuExclusive, memExclusive, executor.NewLocal(), DefaultCommandTimeout)
 }
 
 // NewCPUSetWithExecutor creates a new CPUSet with the supplied executor
 // and timeout.
 func NewCPUSetWithExecutor(path string,
-	cpus iso.IntSet,
-	mems iso.IntSet,
+	cpus isolation.IntSet,
+	mems isolation.IntSet,
 	cpuExclusive bool,
 	memExclusive bool,
 	executor executor.Executor,
@@ -96,11 +96,11 @@ func (cs *cpuset) Cgroup() Cgroup {
 	return cs.cgroup
 }
 
-func (cs *cpuset) Cpus() iso.IntSet {
+func (cs *cpuset) Cpus() isolation.IntSet {
 	return cs.cpus
 }
 
-func (cs *cpuset) Mems() iso.IntSet {
+func (cs *cpuset) Mems() isolation.IntSet {
 	return cs.mems
 }
 

--- a/pkg/isolation/set.go
+++ b/pkg/isolation/set.go
@@ -1,6 +1,7 @@
 package isolation
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -34,6 +35,19 @@ func (s IntSet) Remove(elem int) {
 // Equals returns true iff the supplied set is equal to this set.
 func (s IntSet) Equals(t IntSet) bool {
 	return reflect.DeepEqual(s, t)
+}
+
+// Subset returns true iff the supplied set contains all the elements in
+// this set (e.g. s is a subset of t).
+func (s IntSet) Subset(t IntSet) bool {
+	result := true
+	for elem := range s {
+		if !t.Contains(elem) {
+			result = false
+			break
+		}
+	}
+	return result
 }
 
 // Union returns a new set that contains all of the elements from this set
@@ -75,6 +89,19 @@ func (s IntSet) Difference(t IntSet) IntSet {
 		result.Remove(elem)
 	}
 	return result
+}
+
+// Take returns a new set containing n items from this set. If n is greater
+// than the number of elements in the set, returns an error.
+func (s IntSet) Take(n int) (IntSet, error) {
+	if n > len(s) {
+		return nil, fmt.Errorf("cannot take %d elements from a set of size %d", n, len(s))
+	}
+	result := NewIntSet()
+	for _, elem := range s.AsSlice()[0:n] {
+		result.Add(elem)
+	}
+	return result, nil
 }
 
 // AsSlice returns a slice of integers that contains all elements from

--- a/pkg/isolation/set_test.go
+++ b/pkg/isolation/set_test.go
@@ -119,6 +119,16 @@ func TestIntSet(t *testing.T) {
 					So(s1.Equals(s2), ShouldBeFalse)
 					So(s2.Equals(s1), ShouldBeFalse)
 				})
+
+				Convey("And they should not be subsets of each other", func() {
+					So(s1.Subset(s2), ShouldBeFalse)
+					So(s2.Subset(s1), ShouldBeFalse)
+				})
+
+				Convey("But they should be subsets of themselves", func() {
+					So(s1.Subset(s1), ShouldBeTrue)
+					So(s2.Subset(s2), ShouldBeTrue)
+				})
 			})
 
 			Convey("The difference should not include the shared element", func() {
@@ -170,6 +180,24 @@ func TestIntSet(t *testing.T) {
 				So(s1.Difference(s2).Union(s1.Intersection(s2)).Equals(s1), ShouldBeTrue)
 				So(s2.Difference(s1).Union(s2.Intersection(s1)).Equals(s2), ShouldBeTrue)
 			})
+
+			Convey("The intersection should be a subset of both", func() {
+				So(s1.Intersection(s2).Subset(s1), ShouldBeTrue)
+				So(s2.Intersection(s1).Subset(s2), ShouldBeTrue)
+			})
+		})
+
+		Convey("IntSet correctly yields a subset of a given size with take", func() {
+			s := NewIntSet(1, 2, 3, 4, 5, 6, 7, 8)
+
+			r, err := s.Take(0)
+			So(err, ShouldBeNil)
+			So(r.Empty(), ShouldBeTrue)
+
+			r, err = s.Take(4)
+			So(err, ShouldBeNil)
+			So(len(r), ShouldEqual, 4)
+			So(r.Subset(s), ShouldBeTrue)
 		})
 
 		Convey("IntSet correctly converts to a slice of integers", func() {

--- a/pkg/isolation/topo/disco.go
+++ b/pkg/isolation/topo/disco.go
@@ -1,0 +1,53 @@
+package topo
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Discover CPU and basic NUMA topology.
+func Discover() (ThreadSet, error) {
+	out, err := exec.Command("lscpu", "-p").Output()
+	if err != nil {
+		return nil, err
+	}
+	return ReadTopology(out)
+}
+
+// ReadTopology attempts to create a ThreadSet that corresponds to the
+// supplied output from `lscpu -p`.
+func ReadTopology(lscpuOutput []byte) (ThreadSet, error) {
+	threadSet := NewThreadSet()
+
+	out := strings.TrimSpace(string(lscpuOutput))
+	lines := strings.Split(out, "\n")
+
+	// lscpu -p output looks like:
+	//
+	// # comments
+	// # comments
+	// cpu,core,socket,node,,l1d,l1i,l2,l3
+	// cpu,core,socket,node,,l1d,l1i,l2,l3
+	// ...
+	for _, line := range lines {
+		// Skip informational header lines.
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		var cpu, core, socket int
+		n, err := fmt.Sscanf(line, "%d,%d,%d", &cpu, &core, &socket)
+		if n != 3 {
+			return nil, fmt.Errorf("Expected to read 3 values but got %d", n)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Construct a new thread and append it to the "set".
+		threadSet = append(threadSet, NewThread(cpu, core, socket))
+	}
+
+	return threadSet, nil
+}

--- a/pkg/isolation/topo/thread.go
+++ b/pkg/isolation/topo/thread.go
@@ -1,0 +1,33 @@
+package topo
+
+// Thread represents a hyperthread, typically presented by the operating
+// system as a logical CPU.
+type Thread interface {
+	ID() int
+	Core() int
+	Socket() int
+}
+
+// NewThread returns a new thread with the supplied thread, core, and
+// socket IDs.
+func NewThread(id int, core int, socket int) Thread {
+	return thread{id, core, socket}
+}
+
+type thread struct {
+	id     int
+	core   int
+	socket int
+}
+
+func (t thread) ID() int {
+	return t.id
+}
+
+func (t thread) Core() int {
+	return t.core
+}
+
+func (t thread) Socket() int {
+	return t.socket
+}

--- a/pkg/isolation/topo/thread_test.go
+++ b/pkg/isolation/topo/thread_test.go
@@ -1,0 +1,25 @@
+package topo
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewThread(t *testing.T) {
+	Convey("When creating a new thread", t, func() {
+		t := NewThread(1, 2, 3)
+
+		Convey("It should have the right thread ID", func() {
+			So(t.ID(), ShouldEqual, 1)
+		})
+
+		Convey("It should have the right core ID", func() {
+			So(t.Core(), ShouldEqual, 2)
+		})
+
+		Convey("It should have the right socket ID", func() {
+			So(t.Socket(), ShouldEqual, 3)
+		})
+	})
+}

--- a/pkg/isolation/topo/threadset.go
+++ b/pkg/isolation/topo/threadset.go
@@ -1,0 +1,127 @@
+package topo
+
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/swan/pkg/isolation"
+)
+
+// ThreadSet represents a subset of the available hyperthreads on a system.
+type ThreadSet []Thread
+
+// NewThreadSet returns a newly allocated thread set.
+func NewThreadSet() ThreadSet {
+	return []Thread{}
+}
+
+// Partition returns two newly allocated thread sets: the first contains
+// threads from this set that match the supplied predicate and the second
+// contains threads that do not.
+func (s ThreadSet) Partition(by func(Thread) bool) (ThreadSet, ThreadSet) {
+	left := ThreadSet{}
+	right := ThreadSet{}
+	for _, t := range s {
+		if by(t) {
+			left = append(left, t)
+		} else {
+			right = append(right, t)
+		}
+	}
+	return left, right
+}
+
+// Filter returns a newly allocated thread set containing all elements
+// from this set that match the supplied predicate.
+func (s ThreadSet) Filter(by func(Thread) bool) ThreadSet {
+	res := ThreadSet{}
+	for _, t := range s {
+		if by(t) {
+			res = append(res, t)
+		}
+	}
+	return res
+}
+
+// AvailableThreads returns the set of thread ids for threads in this
+// thread set.
+func (s ThreadSet) AvailableThreads() isolation.IntSet {
+	threads := isolation.NewIntSet()
+	for _, t := range s {
+		threads.Add(t.ID())
+	}
+	return threads
+}
+
+// AvailableCores returns the set of core ids for threads in this
+// thread set.
+func (s ThreadSet) AvailableCores() isolation.IntSet {
+	cores := isolation.NewIntSet()
+	for _, t := range s {
+		cores.Add(t.Core())
+	}
+	return cores
+}
+
+// AvailableSockets returns the set of socket ids for threads in this
+// thread set.
+func (s ThreadSet) AvailableSockets() isolation.IntSet {
+	sockets := isolation.NewIntSet()
+	for _, t := range s {
+		sockets.Add(t.Socket())
+	}
+	return sockets
+}
+
+// Threads returns a newly allocated thread set containing `n` distinct
+// threads from this thread set. If there are fewer than `n` available,
+// returns an error.
+func (s ThreadSet) Threads(n int) (ThreadSet, error) {
+	threads, err := s.AvailableThreads().Take(n)
+	if err != nil {
+		return nil, err
+	}
+	return s.Filter(func(t Thread) bool { return threads.Contains(t.ID()) }), nil
+}
+
+// Cores returns a newly allocated thread set containing all threads from
+// `n` distinct cores. If there are fewer than `n` available, returns an error.
+func (s ThreadSet) Cores(n int) (ThreadSet, error) {
+	cores, err := s.AvailableCores().Take(n)
+	if err != nil {
+		return nil, err
+	}
+	return s.Filter(func(t Thread) bool { return cores.Contains(t.Core()) }), nil
+}
+
+// Sockets returns a newly allocated thread set containing all threads from
+// `n` distinct sockets. If there are fewer than `n` available, returns
+// an error.
+func (s ThreadSet) Sockets(n int) (ThreadSet, error) {
+	sockets, err := s.AvailableSockets().Take(n)
+	if err != nil {
+		return nil, err
+	}
+	return s.Filter(func(t Thread) bool { return sockets.Contains(t.Socket()) }), nil
+}
+
+// FromCores returns a newly allocated thread set containing all threads from
+// the supplied cores. If any of the supplied cores are invalid, returns
+// an error.
+func (s ThreadSet) FromCores(coreIDs ...int) (ThreadSet, error) {
+	cores := isolation.NewIntSet(coreIDs...)
+	if !cores.Subset(s.AvailableCores()) {
+		return nil, fmt.Errorf("invalid core id(s): available cores are %s", s.AvailableCores().AsRangeString())
+	}
+	return s.Filter(func(t Thread) bool { return cores.Contains(t.Core()) }), nil
+}
+
+// FromSockets returns a newly allocated thread set containing all threads from
+// the supplied sockets. If any of the supplied sockets are invalid, returns
+// an error.
+func (s ThreadSet) FromSockets(socketIDs ...int) (ThreadSet, error) {
+	sockets := isolation.NewIntSet(socketIDs...)
+	if !sockets.Subset(s.AvailableSockets()) {
+		return nil, fmt.Errorf("invalid socket id(s): available sockets are %s", s.AvailableSockets().AsRangeString())
+	}
+	return s.Filter(func(t Thread) bool { return sockets.Contains(t.Socket()) }), nil
+}

--- a/pkg/isolation/topo/threadset_test.go
+++ b/pkg/isolation/topo/threadset_test.go
@@ -1,0 +1,205 @@
+package topo
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/intelsdi-x/swan/pkg/isolation"
+)
+
+func syntheticThreadSet() ThreadSet {
+	return ThreadSet{
+		// id, core, socket
+		NewThread(1, 1, 1),
+		NewThread(2, 1, 1),
+		NewThread(3, 2, 1),
+		NewThread(4, 2, 1),
+		NewThread(5, 3, 2),
+		NewThread(6, 3, 2),
+		NewThread(7, 4, 2),
+		NewThread(8, 4, 2),
+	}
+}
+
+func TestNewThreadSet(t *testing.T) {
+	Convey("When creating a new thread set", t, func() {
+		ts := NewThreadSet()
+		Convey("It should be empty", func() {
+			So(len(ts), ShouldEqual, 0)
+		})
+	})
+}
+
+func TestThreadSetAvailableThreads(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Listing the available threads should yield a set of size 8", func() {
+			So(ts.AvailableThreads().Equals(isolation.NewIntSet(1, 2, 3, 4, 5, 6, 7, 8)), ShouldBeTrue)
+		})
+	})
+}
+
+func TestThreadSetAvailableCores(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Listing the available cores should yield a set of size 4", func() {
+			So(ts.AvailableCores().Equals(isolation.NewIntSet(1, 2, 3, 4)), ShouldBeTrue)
+		})
+	})
+}
+
+func TestThreadSetAvailableSockets(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Listing the available sockets should yield a set of size 2", func() {
+			So(ts.AvailableSockets().Equals(isolation.NewIntSet(1, 2)), ShouldBeTrue)
+		})
+	})
+}
+
+func TestThreadSetPartition(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Partitioning thread ids into evens and odds should equal thread sets of equal length", func() {
+			evens, odds := ts.Partition(func(t Thread) bool { return t.ID()%2 == 0 })
+			So(len(evens), ShouldEqual, len(odds))
+			So(evens.AvailableThreads().Equals(isolation.NewIntSet(2, 4, 6, 8)), ShouldBeTrue)
+			So(odds.AvailableThreads().Equals(isolation.NewIntSet(1, 3, 5, 7)), ShouldBeTrue)
+		})
+	})
+}
+
+func TestThreadSetFilter(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Filtering out the odd thread ids should yield only the evens", func() {
+			evens := ts.Filter(func(t Thread) bool { return t.ID()%2 == 0 })
+			So(len(evens), ShouldEqual, 4)
+			So(evens.AvailableThreads().Equals(isolation.NewIntSet(2, 4, 6, 8)), ShouldBeTrue)
+		})
+	})
+}
+
+func TestThreadSetThreads(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Requesting 3 threads should yield 3 disjoint threads", func() {
+			threads, err := ts.Threads(3)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 3)
+			So(len(threads.AvailableThreads()), ShouldEqual, 3)
+		})
+
+		Convey("Requesting 10 threads should yield an error", func() {
+			threads, err := ts.Threads(10)
+			So(err, ShouldNotBeNil)
+			So(threads, ShouldBeNil)
+		})
+	})
+}
+
+func TestThreadSetCores(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Requesting 2 cores should yield 4 threads from 2 cores", func() {
+			threads, err := ts.Cores(2)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 4)
+			So(len(threads.AvailableThreads()), ShouldEqual, 4)
+			So(len(threads.AvailableCores()), ShouldEqual, 2)
+		})
+
+		Convey("Requesting 4 cores should yield 8 threads from 4 cores", func() {
+			threads, err := ts.Cores(4)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 8)
+			So(len(threads.AvailableThreads()), ShouldEqual, 8)
+			So(len(threads.AvailableCores()), ShouldEqual, 4)
+		})
+
+		Convey("Requesting 5 cores should yield an error", func() {
+			threads, err := ts.Cores(5)
+			So(err, ShouldNotBeNil)
+			So(threads, ShouldBeNil)
+		})
+	})
+}
+
+func TestThreadSetSockets(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Requesting 1 socket should yield 4 threads from 2 cores and 1 socket", func() {
+			threads, err := ts.Sockets(1)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 4)
+			So(len(threads.AvailableThreads()), ShouldEqual, 4)
+			So(len(threads.AvailableCores()), ShouldEqual, 2)
+			So(len(threads.AvailableSockets()), ShouldEqual, 1)
+		})
+
+		Convey("Requesting 2 sockets should yield 8 threads from 4 cores and 2 sockets", func() {
+			threads, err := ts.Sockets(2)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 8)
+			So(len(threads.AvailableThreads()), ShouldEqual, 8)
+			So(len(threads.AvailableCores()), ShouldEqual, 4)
+			So(len(threads.AvailableSockets()), ShouldEqual, 2)
+		})
+
+		Convey("Requesting 3 sockets should yield an error", func() {
+			threads, err := ts.Sockets(3)
+			So(err, ShouldNotBeNil)
+			So(threads, ShouldBeNil)
+		})
+	})
+}
+
+func TestThreadSetFromCores(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Requesting threads from cores 1 and 3 should yield 4 threads from 2 cores and 2 sockets", func() {
+			threads, err := ts.FromCores(1, 3)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 4)
+			So(threads.AvailableThreads().Equals(isolation.NewIntSet(1, 2, 5, 6)), ShouldBeTrue)
+			So(threads.AvailableCores().Equals(isolation.NewIntSet(1, 3)), ShouldBeTrue)
+			So(threads.AvailableSockets().Equals(isolation.NewIntSet(1, 2)), ShouldBeTrue)
+		})
+
+		Convey("Requesting threads from cores 1, 3, and 5 should yield an error", func() {
+			threads, err := ts.FromCores(1, 3, 5)
+			So(err, ShouldNotBeNil)
+			So(threads, ShouldBeNil)
+		})
+	})
+}
+
+func TestThreadSetFromSockets(t *testing.T) {
+	Convey("Given a synthetic thread set", t, func() {
+		ts := syntheticThreadSet()
+		Convey("Requesting threads from socket 2 should yield 4 threads from 2 cores and 1 sockets", func() {
+			threads, err := ts.FromSockets(2)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 4)
+			So(threads.AvailableThreads().Equals(isolation.NewIntSet(5, 6, 7, 8)), ShouldBeTrue)
+			So(threads.AvailableCores().Equals(isolation.NewIntSet(3, 4)), ShouldBeTrue)
+			So(threads.AvailableSockets().Equals(isolation.NewIntSet(2)), ShouldBeTrue)
+		})
+
+		Convey("Requesting threads from both sockets should yield 8 threads from 4 cores and 2 sockets", func() {
+			threads, err := ts.FromSockets(2, 1)
+			So(err, ShouldBeNil)
+			So(len(threads), ShouldEqual, 8)
+			So(threads.AvailableThreads().Equals(isolation.NewIntSet(1, 2, 3, 4, 5, 6, 7, 8)), ShouldBeTrue)
+			So(threads.AvailableCores().Equals(isolation.NewIntSet(1, 2, 3, 4)), ShouldBeTrue)
+			So(threads.AvailableSockets().Equals(isolation.NewIntSet(1, 2)), ShouldBeTrue)
+		})
+
+		Convey("Requesting threads from sockets 1 and 3 should yield an error", func() {
+			threads, err := ts.FromSockets(1, 3)
+			So(err, ShouldNotBeNil)
+			So(threads, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
Fixes issue SCE-450

Summary of changes:
- Adds pkg/isolation/topo with types Thread and ThreadSet.
- Use sites of the existing CPUSelect can be updated in subsequent
  patches.
- Augments IntSet interface with Subset and Take functions.

Testing done:
- Added tests for newly added functions.
- `go test -v ./integration_tests/pkg/isolation/topo/...`
- `go test -v ./pkg/isolation/topo/...`
- `make`
- `make integration_test`
