### PR TITLE
mutilate integration tests: consistent memcached naming and typos

### DIFF
--- a/integration_tests/pkg/workloads/mutilate/mutilate_test.go
+++ b/integration_tests/pkg/workloads/mutilate/mutilate_test.go
@@ -29,42 +29,42 @@ func TestMutilateWithExecutor(t *testing.T) {
 	// log.SetLevel(log.ErrorLevel)
 	// log.SetOutput(os.Stderr)
 
-	// memcached setup
+	// Memcached setup.
 	memcachedConfig := memcached.DefaultMemcachedConfig()
 	memcachedConfig.User = fs.GetEnvOrDefault("USER", memcachedConfig.User)
 	mcAddress := fmt.Sprintf("127.0.0.1:%d", memcachedConfig.Port)
 
-	// start memcached and make sure it is a new one!
+	// Start memcached and make sure it is a new one.
 	memcachedLauncher := memcached.New(executor.NewLocal(), memcachedConfig)
 	mcHandle, err := memcachedLauncher.Launch()
 	if err != nil {
 		t.Fatal("cannot start memcached:" + err.Error())
 	}
 
-	// clean memcached
+	// Clean after memcached ...
 	defer func() {
-		// and our memcached instance was closed properly
+		// and our memcached instance was closed properly.
 		if err := mcHandle.Stop(); err != nil {
 			t.Fatal(err)
 		}
 		mcHandle.Wait(0)
 		if ec, err := mcHandle.ExitCode(); err != nil || ec != -1 {
-			// expected -1 on SIGKILL (TODO: change to zero, after Stop "graceful stop fix"
+			// Expect -1 on SIGKILL (TODO: change to zero, after Stop "graceful stop fix").
 			t.Fatalf("memcached was stopped incorrectly err %s exit-code: %d", err, ec)
 		}
-		// make sure temp files removal was successful
+		// Make sure temp files removal was successful.
 		if err := mcHandle.EraseOutput(); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	// Give memcached chance to start and possibly die
+	// Give memcached chance to start and possibly die.
 	if stopped := mcHandle.Wait(1 * time.Second); stopped {
 		t.Fatal("memcached is not running after the second")
 	}
 
 	currItems, _ := getMemcachedStats(mcAddress, t)
-	if currItems != 0 { // in case of not memcached or someone at the same time is messing with it
+	if currItems != 0 { // In case of not empty or someone at the same time is messing with it.
 		t.Fatal("expecting empty memcached but some items are already there")
 	}
 
@@ -72,8 +72,11 @@ func TestMutilateWithExecutor(t *testing.T) {
 
 		mutilateConfig := mutilate.DefaultMutilateConfig()
 		mutilateConfig.TuningTime = 1 * time.Second
-		mutilateConfig.EraseSearchTuneOutput = true                       // make sure files are removed correctly
-		mutilateConfig.LatencyPercentile, _ = decimal.NewFromString("99") // not sure if custom percentile is working correctly TODO: added a custom percentile integration test
+		// Ensure files are removed afterwards.
+		mutilateConfig.EraseSearchTuneOutput = true
+		// Note: not sure if custom percentile is working correctly.
+		// TODO: added a custom percentile integration test.
+		mutilateConfig.LatencyPercentile, _ = decimal.NewFromString("99")
 
 		Convey("When run mutilate populate", func() {
 			mutilateLauncher := mutilate.New(executor.NewLocal(), mutilateConfig)
@@ -86,7 +89,8 @@ func TestMutilateWithExecutor(t *testing.T) {
 		Convey("When run mutilate tune", func() {
 			_, previousGetCnt := getMemcachedStats(mcAddress, t)
 			mutilateLauncher := mutilate.New(executor.NewLocal(), mutilateConfig)
-			achievedLoad, achievedSLI, err := mutilateLauncher.Tune(5000) // very high to be easily achievable
+			// Tune up to 5000 us to be be easily achievable.
+			achievedLoad, achievedSLI, err := mutilateLauncher.Tune(5000)
 			So(err, ShouldBeNil)
 			So(achievedLoad, ShouldNotEqual, 0)
 			So(achievedSLI, ShouldNotEqual, 0)
@@ -130,13 +134,13 @@ func TestMutilateWithExecutor(t *testing.T) {
 	})
 }
 
-// getMemcachedStats helper read and parse "stats" memcached command and return map key -> value
+// getMemcachedStats helper read and parse "stats" memcached command and return map key -> value.
 // https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L511
 func getMemcachedStats(mcAddress string, t *testing.T) (currItems, getCount int) {
 
 	const (
 		statsCmd         = "stats\n"
-		mcStatsReplySize = 4096 // enough to get whole response from memcache
+		mcStatsReplySize = 4096 // Enough size to get whole response from memcached.
 	)
 
 	conn, err := net.Dial("tcp", mcAddress)


### PR DESCRIPTION
Fixes issue typos/spellings/name consistency

Testing done:
- not required
