### PR TITLE
SCE-429: Initial values of cpuset.cpus are unknown.

### DIFF
--- a/integration_tests/pkg/isolation/cgroup/cgroup_test.go
+++ b/integration_tests/pkg/isolation/cgroup/cgroup_test.go
@@ -191,7 +191,8 @@ func TestCgroupSet(t *testing.T) {
 		So(ok, ShouldBeTrue)
 
 		Convey("The cgroup's attributes should be settable", func() {
-			// Check readability cpuset mems setting
+			// There is no default value in it after cgroup's
+			// creation. Check only if can be read.
 			_, err := cg.Get("cpuset.mems")
 			So(err, ShouldBeNil)
 
@@ -201,7 +202,9 @@ func TestCgroupSet(t *testing.T) {
 			value, _ := cg.Get("cpuset.mems")
 			So(value, ShouldEqual, "0")
 
-			// Check initial cpuset exclusivity setting
+			// Cpu_exclusive is not always settable because
+			// it depends on parent's settings and sibling
+			// cpusets. Therefore check only if it's readable.
 			_, err = cg.Get("cpuset.cpu_exclusive")
 			So(err, ShouldBeNil)
 		})


### PR DESCRIPTION
Fixes issue SCE-429

Summary of changes:
According to cgroup documentation  we cannot assume there is any 'default'
value in cpuset.cpus cpuset.mems.
If clone_children flag in parent group is set then values of the parent
group are inherited and if the flag is not set then some properties are
empty. Therefore relying on "" or 0 as default values is not right.

Additionally cpuset.cpu_exclusive is not always settable. It can be set
only if parent group has this property set and none of the sibling group
have overlapping cpuset. Do not try to set unless you know you can.

Testing done: integration tests

Signed-off-by: Maciej Patelczyk maciej.patelczyk@intel.com
