### PR TITLE
SCE-477: Added path to mutilate binary in experiment.

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -106,7 +106,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 
 	percentile, _ := decimal.NewFromString("99.9")
 	mutilateConfig := mutilate.Config{
-		PathToBinary:			 mutilate.PathFlag.Value(),
+		PathToBinary:      mutilate.PathFlag.Value(),
 		MemcachedHost:     memcachedConfig.IP,
 		MemcachedPort:     memcachedConfig.Port,
 		LatencyPercentile: percentile,


### PR DESCRIPTION
Fixes issue SCE-477

Testing done:
- make
- make integration_test
- Tried to run experiment in Vagrant VM
