### PR TITLE
SCE-403: Multinode mutilate integrated with experiment.

### DIFF
--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -16,7 +16,7 @@ import (
 // testExecutor tests the execution of process for given executor.
 // This test can be used inside any Executor implementation test.
 func testExecutor(t *testing.T, executor Executor) {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.ErrorLevel)
 
 	Convey("When blocking infinitively sleep command is executed", func() {
 		taskHandle, err := executor.Execute("sleep inf")

--- a/pkg/workloads/load_generator.go
+++ b/pkg/workloads/load_generator.go
@@ -1,14 +1,9 @@
 package workloads
 
 import (
-	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"time"
 )
-
-// LoadGeneratorAddrFlag represents load generator address flag.
-var LoadGeneratorAddrFlag = conf.NewStringFlag(
-	"load_generator_addr", "IP of the target machine for the load generator", "127.0.0.1")
 
 // LoadGenerator launches stresser which generates load on specified workload.
 type LoadGenerator interface {


### PR DESCRIPTION
Fixes issue SCE-403

This was done initially by @ppalucki with proper mutilate parameters. To close SCE-403 I took experiment only and made that `PR ready`.

Summary of changes:
- Added `lg_master` and `lg_agent` flags
- Added creating cluster mutilate

Testing done:
- experiment done locally so far.

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
