### PR TITLE
Moved to huponexit instead of not working `unshare` on remote.

### DIFF
--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -11,7 +11,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/isolation"
 	"golang.org/x/crypto/ssh"
 	"strings"
-	"syscall"
 )
 
 // Remote provisioning is responsible for providing the execution environment
@@ -21,13 +20,11 @@ type Remote struct {
 	commandDecorators isolation.Decorators
 }
 
-// NewRemote returns a Remote instance with default PID namespace isolation.
+// NewRemote returns a Remote instance.
 func NewRemote(sshConfig *SSHConfig) Remote {
-	isolationPid, _ := isolation.NewNamespace(syscall.CLONE_NEWPID)
-
 	return Remote{
 		sshConfig:         sshConfig,
-		commandDecorators: []isolation.Decorator{isolationPid},
+		commandDecorators: []isolation.Decorator{},
 	}
 }
 


### PR DESCRIPTION
Fixes issue of process escaping the unshare.

Summary of changes:
- Dropped unshare
- Added sh -O huponexit -c
- Escaped the quotes chars

Testing done:
- make all

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
