### PR TITLE
SCE-362, SCE-35: remove hardcoded values from experiment and base on sane defaults

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -166,12 +166,6 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	mutilateConfig.LatencyPercentile = percentileFlag.Value()
 	mutilateConfig.TuningTime = 1 * time.Second
 
-	// Master options.
-	mutilateConfig.MasterQPS = 1000
-	mutilateConfig.MasterConnections = 4
-	mutilateConfig.MasterConnectionsDepth = 4
-	mutilateConfig.MasterThreads = 4
-
 	// Special case to have ability to use local executor for mutilate master load generator.
 	// This is needed for docker testing.
 	var masterLoadGeneratorExecutor executor.Executor

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -29,13 +29,13 @@ const (
 	defaultAgentAffinity          = false
 	defaultAgentBlocking          = true
 	defaultMasterThreads          = 8
-	defaultMasterConnections      = 1
-	defaultMasterConnectionsDepth = 1
+	defaultMasterConnections      = 4
+	defaultMasterConnectionsDepth = 4
 	defaultMasterAffinity         = false
 	defaultMasterBlocking         = true
 	defaultKeySize                = 30  // [bytes]
 	defaultValueSize              = 200 // [bytes]
-	defaultMasterQPS              = 0
+	defaultMasterQPS              = 1000
 )
 
 var (


### PR DESCRIPTION
Fixes issue SCE-362, SCE-35

Changes:
- remove hardcoded values from experiment and base on sane defaults
