### PR TITLE
misc: vagrant dev environment cassandra plugin snap.metrics table fix

### DIFF
--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -132,6 +132,7 @@ SCRIPT
     cp $HOME_DIR/swan/misc/dev/vagrant/singlenode/resources/cassandra.service /usr/lib/systemd/system/
     mkdir -p /opt/swan/resources
     cp $HOME_DIR/swan/misc/dev/vagrant/singlenode/resources/keyspace.cql /opt/swan/resources
+    cp $HOME_DIR/swan/misc/dev/vagrant/singlenode/resources/table.cql /opt/swan/resources
     systemctl daemon-reload
     systemctl enable cassandra.service
     systemctl restart cassandra.service

--- a/misc/dev/vagrant/singlenode/resources/cassandra.service
+++ b/misc/dev/vagrant/singlenode/resources/cassandra.service
@@ -26,5 +26,11 @@ ExecStartPost=/usr/bin/docker run \
   -v /opt/swan/resources:/resources \
   cassandra:3.5 \
   cqlsh localhost --file /resources/keyspace.cql
+ExecStartPost=/usr/bin/docker run \
+  --rm \
+  --net host \
+  -v /opt/swan/resources:/resources \
+  cassandra:3.5 \
+  cqlsh localhost --file /resources/table.cql
 [Install]
 WantedBy=multi-user.target

--- a/misc/dev/vagrant/singlenode/resources/table.cql
+++ b/misc/dev/vagrant/singlenode/resources/table.cql
@@ -1,0 +1,14 @@
+// https://github.com/intelsdi-x/snap-plugin-publisher-cassandra#plugin-database-schema
+CREATE TABLE IF NOT EXISTS snap.metrics (
+    ns  text, 
+    ver int, 
+    host text, 
+    time timestamp, 
+    valtype text,
+    doubleVal double, 
+    boolVal boolean,
+    strVal text,
+    tags map<text,text>, 
+    PRIMARY KEY ((ns, ver, host), time)
+) WITH CLUSTERING ORDER BY (time DESC);
+DESCRIBE snap.metrics;


### PR DESCRIPTION
Fixes issue snap.metrics no available with manually creating a table.

Summary of changes:
- new `table.cql` to create a table for snap.metrics 

Testing done:
- **_NO_**!
