### PR TITLE
SCE-528: close SSH connection after finishing remote commands

### DIFF
--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/isolation"
 	"golang.org/x/crypto/ssh"
-	"strings"
 )
 
 // Remote provisioning is responsible for providing the execution environment
@@ -106,7 +106,8 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 	// Wait for local task in go routine.
 	go func() {
 		defer close(waitEndChannel)
-		defer session.Close()
+		defer session.Close() // Closing a session is not enough to close connection.
+		defer connection.Close()
 
 		*exitCode = successExitCode
 		// Wait for task completion.


### PR DESCRIPTION
Fixes issue SCE-528

Summary of changes:
- close ssh connection (too many open files bug, connection is open after remote executor finishes)

Testing done:
- manual (checked stable number of file descriptors for ssh connection during experiment run) 

Issue SCE-528 (too many open files)

Co-Authored-By: Maciej Iwanowski maciej.iwanowski@intel.com
