### PR TITLE
SCE 513: add additional flag for stop experiment on failure

### DIFF
--- a/pkg/experiment/experiment.go
+++ b/pkg/experiment/experiment.go
@@ -15,11 +15,21 @@ import (
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
+// Configuration - set of parameters to control the experiment.
+type Configuration struct {
+	LogLevel    log.Level
+	// Stop experiment in a case if any error happen
+	StopOnError bool
+	TextUI bool
+}
+
+
 // Experiment captures the internal data for the Experiment Driver.
 type Experiment struct {
 	// Human-readable name.
 	// TODO(bp): Push that to DB via Snap in tag or using SwanCollector.
 	name string
+	configuration Configuration
 	// Unique ID for Experiment.
 	// Pushed to DB via Snap in tag.
 	uuid                string
@@ -27,18 +37,16 @@ type Experiment struct {
 	phases              []experimentPhase.Phase
 	startingDirectory   string
 	experimentDirectory string
-
 	logFile  *os.File
-	logLevel log.Level
-
-	textUI bool
 }
+
+
 
 // NewExperiment creates a new Experiment instance,
 // initialize experiment working directory and initialize logs.
 // Caller have to provide slice of Phase interfaces which are going to be executed.
 func NewExperiment(name string, phases []experimentPhase.Phase,
-	directory string, logLevel log.Level) (*Experiment, error) {
+	directory string, config Configuration) (*Experiment, error) {
 	if len(phases) == 0 {
 		return nil, errors.New("invalid argument: no phases provided")
 	}
@@ -53,8 +61,7 @@ func NewExperiment(name string, phases []experimentPhase.Phase,
 		uuid:             uuid.String(),
 		workingDirectory: directory,
 		phases:           phases,
-		logLevel:         logLevel,
-		textUI:           logLevel == log.ErrorLevel,
+		configuration:    config,
 	}
 
 	err = e.createExperimentDir()
@@ -73,7 +80,7 @@ func NewExperiment(name string, phases []experimentPhase.Phase,
 
 // Run runs experiment.
 // It runs in a sequence defined phases with given repetition count.
-func (e *Experiment) Run() (err error) {
+func (e *Experiment) Run() error {
 	experimentStartingTime := time.Now()
 
 	log.Info("Starting Experiment ", e.name, " with uuid ", e.uuid)
@@ -84,7 +91,7 @@ func (e *Experiment) Run() (err error) {
 	// mode.
 	var bar *pb.ProgressBar
 	var increment int
-	if e.textUI {
+	if e.configuration.TextUI {
 		fmt.Printf("Experiment %q with uuid %q\n", e.name, e.uuid)
 		bar = pb.StartNew(100)
 		bar.ShowCounters = false
@@ -97,17 +104,18 @@ func (e *Experiment) Run() (err error) {
 	}
 
 	for id, phase := range e.phases {
-		if e.textUI {
+		if e.configuration.TextUI {
 			prefix := fmt.Sprintf("[%02d / %02d] %s ", id, len(e.phases), phase.Name())
 			bar.Prefix(prefix)
 		}
 
-		for i := 0; i < phase.Repetitions(); i++ {
+		repetition := 0
+		for ; repetition < phase.Repetitions(); repetition++ {
 			// Create phase session.
 			session := experimentPhase.Session{
 				PhaseID:      phase.Name(),
 				ExperimentID: e.uuid,
-				RepetitionID: i,
+				RepetitionID: repetition,
 			}
 
 			// Start timer.
@@ -115,48 +123,47 @@ func (e *Experiment) Run() (err error) {
 			log.Info("Starting ", session.PhaseID, " repetition ", session.RepetitionID)
 
 			// Create and step into unique phase dir.
-			err = e.createPhaseDir(session)
+			err := e.createPhaseDir(session)
 			if err != nil {
 				return err
 			}
 
 			// Start phase.
-			err := phase.Run(session)
-			if err != nil {
-				// When phase return error we stop the whole experiment.
-				log.Error(phase.Name(), " returned error ", err)
-				return err
+			if err = phase.Run(session); err != nil {
+				log.Error(phase.Name(), " repetition ", repetition,", returned error ", err)
+				if e.configuration.StopOnError {
+					// When phase return error we want to stop the whole experiment.
+					return err
+				}
+			} else {
+				log.Info("Ended ", phase.Name(), " repetition ", repetition,
+					" in ", time.Since(phaseStartingTime))
 			}
 
-			if e.textUI {
+			if e.configuration.TextUI {
 				bar.Add(increment)
 			}
-
-			log.Info("Ended ", phase.Name(), " repetition ", i,
-				" in ", time.Since(phaseStartingTime))
 		}
 
 		// Give a chance for phase to finalize.
 		// E.g to check statistical confidence of a result based on repetitions results.
-		log.Info("Finalizing ", phase.Name(),
-			" after ", phase.Repetitions(), " repetitions")
-		err := phase.Finalize()
-		if err != nil {
+		if err := phase.Finalize(); err != nil {
 			// When phase return error we stop the whole experiment.
-			log.Error(phase.Name(), " returned error ", err,
-				" while finalizing.")
+			log.Errorf("%s returned error %q while finalizing.", phase.Name(), err.Error())
 			return err
 		}
+
+		log.Info("Finalizing ", phase.Name(), " after ", repetition, " repetitions")
 	}
 
-	if e.textUI {
+	if e.configuration.TextUI {
 		bar.Finish()
 	}
 
 	log.Info("Ended experiment ", e.name, " with uuid ", e.uuid,
 		" in ", time.Since(experimentStartingTime))
 
-	return err
+	return nil
 }
 
 // createExperimentDir creates unique directory for experiment logs and results.
@@ -213,7 +220,7 @@ func (e *Experiment) logInitialize() (err error) {
 	}
 
 	// Setup logging set to both output and logFile.
-	log.SetLevel(e.logLevel)
+	log.SetLevel(e.configuration.LogLevel)
 	log.SetFormatter(new(log.TextFormatter))
 	log.SetOutput(io.MultiWriter(e.logFile, os.Stderr))
 

--- a/pkg/experiment/experiment_test.go
+++ b/pkg/experiment/experiment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"os"
 	"testing"
+	"errors"
 )
 
 func TestExperiment(t *testing.T) {
@@ -15,7 +16,7 @@ func TestExperiment(t *testing.T) {
 		Convey("With proper configuration and empty phases", func() {
 			var phases []phase.Phase
 			exp, err := NewExperiment("example-experiment1", phases,
-				os.TempDir(), logrus.ErrorLevel)
+				os.TempDir(), Configuration{logrus.ErrorLevel, false, true})
 
 			Convey("Experiment should return with error", func() {
 				So(exp, ShouldBeNil)
@@ -31,15 +32,67 @@ func TestExperiment(t *testing.T) {
 
 			phases = append(phases, mockedPhase)
 
-			exp, err := NewExperiment("example-experiment", phases, os.TempDir(), logrus.ErrorLevel)
+			exp, err := NewExperiment("example-experiment", phases,
+				os.TempDir(), Configuration{logrus.ErrorLevel, false, true})
 			So(exp, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 
-			Convey("While setting one repetition to phase", func() {
+			Convey("While setting ten repetition to phase", func() {
 				mockedPhase.On("Run", mock.AnythingOfType("phase.Session")).Return(nil).Times(10)
 				mockedPhase.On("Repetitions").Return(int(10))
 				mockedPhase.On("Finalize").Return(nil).Once()
 				Convey("Experiment should succeed with 10 phase repetitions", func() {
+					err := exp.Run()
+					So(err, ShouldBeNil)
+
+					mockedPhase.AssertExpectations(t)
+				})
+			})
+		})
+
+		Convey("With invalid configuration stop experiment if error", func() {
+			var phases []phase.Phase
+
+			mockedPhase := new(mocks.Phase)
+			mockedPhase.On("Name").Return("mock-phase01")
+
+			phases = append(phases, mockedPhase)
+
+			exp, err := NewExperiment("example-experiment", phases,
+				os.TempDir(), Configuration{logrus.ErrorLevel, true, true})
+			So(exp, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+
+			Convey("While setting one repetition to phase", func() {
+				mockedPhase.On("Run", mock.AnythingOfType("phase.Session")).Return(errors.New("Production task can't be launched")).Once()
+				mockedPhase.On("Repetitions").Return(int(10))
+				Convey("Experiment should fail with error phase", func() {
+					err := exp.Run()
+					So(err, ShouldNotBeNil)
+
+					mockedPhase.AssertExpectations(t)
+				})
+			})
+		})
+
+		Convey("With invalid configuration and not empty phases", func() {
+			var phases []phase.Phase
+
+			mockedPhase := new(mocks.Phase)
+			mockedPhase.On("Name").Return("mock-phase01")
+
+			phases = append(phases, mockedPhase)
+
+			exp, err := NewExperiment("example-experiment", phases,
+				os.TempDir(), Configuration{logrus.ErrorLevel, false, true})
+			So(exp, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+
+			Convey("While setting one repetition to phase", func() {
+				mockedPhase.On("Run", mock.AnythingOfType("phase.Session")).Return(errors.New("Production task can't be launched"))
+				mockedPhase.On("Repetitions").Return(int(10))
+				mockedPhase.On("Finalize").Return(nil)
+				Convey("Experiment should fail with error phase", func() {
 					err := exp.Run()
 					So(err, ShouldBeNil)
 

--- a/pkg/experiment/sensitivity/sensitivity.go
+++ b/pkg/experiment/sensitivity/sensitivity.go
@@ -16,6 +16,7 @@ var (
 	loadPointsCountFlag = conf.NewIntFlag("load_points", "Number of load points to test", 10)
 	loadDurationFlag    = conf.NewDurationFlag("load_duration", "Load duration [s].", 10*time.Second)
 	repetitionsFlag     = conf.NewIntFlag("reps", "Number of repetitions for each measurement", 3)
+	stopOnErrorFlag     = conf.NewBoolFlag("stop", "Stop experiment in a case of error", false)
 	// peakLoadFlag represents special case when peak load is provided instead of calculated from Tuning phase.
 	// It omits tuning phase.
 	peakLoadFlag   = conf.NewIntFlag("peak_load", "Peakload max number of QPS without violating SLO (by default inducted from tunning phase).", 0) // "0" means include tunning phase.
@@ -38,6 +39,8 @@ type Configuration struct {
 	Repetitions int
 	// PeakLoad. If set >0 skip tuning phase.
 	PeakLoad int
+	// Stop experiment in a case if any error happen
+	StopOnError bool
 }
 
 // DefaultConfiguration returns default configuration for experiment from Conf flags.
@@ -48,6 +51,7 @@ func DefaultConfiguration() Configuration {
 		LoadPointsCount: loadPointsCountFlag.Value(),
 		Repetitions:     repetitionsFlag.Value(),
 		PeakLoad:        peakLoadFlag.Value(),
+		StopOnError:     stopOnErrorFlag.Value(),
 	}
 }
 
@@ -149,7 +153,7 @@ func (e *Experiment) prepareAggressorsPhases() [][]phase.Phase {
 	return aggressorPhases
 }
 
-func (e *Experiment) configureGenericExperiment() (err error) {
+func (e *Experiment) configureGenericExperiment() error {
 	// Configure phases & measurements.
 	// Each sensitivity phase (part of experiment) can include couple of measurements.
 	var allMeasurements []phase.Phase
@@ -172,7 +176,9 @@ func (e *Experiment) configureGenericExperiment() (err error) {
 		allMeasurements = append(allMeasurements, aggressorPhase...)
 	}
 
-	e.exp, err = experiment.NewExperiment(e.name, allMeasurements, os.TempDir(), e.logLevel)
+	var err error
+	config :=  experiment.Configuration{e.logLevel, e.configuration.StopOnError, e.logLevel == log.ErrorLevel}
+	e.exp, err = experiment.NewExperiment(e.name, allMeasurements, os.TempDir(), config)
 	if err != nil {
 		return err
 	}
@@ -190,7 +196,7 @@ func (e *Experiment) Run() error {
 
 	err = e.exp.Run()
 	defer e.exp.Finalize()
-	if err != nil {
+	if err != nil && e.configuration.StopOnError {
 		return err
 	}
 

--- a/pkg/experiment/sensitivity/sensitivity_test.go
+++ b/pkg/experiment/sensitivity/sensitivity_test.go
@@ -70,6 +70,7 @@ func (s *SensitivityTestSuite) SetupTest() {
 		LoadDuration:    1 * time.Second,
 		LoadPointsCount: 2,
 		Repetitions:     1,
+		StopOnError:     true,
 	}
 
 	s.mockedPeakLoad = 2


### PR DESCRIPTION
Fixes issue: SCE 513

Summary of changes:
- additional flag for stop repetition in case of any failure
- additional field in a `Experiment` constructor - passing from `Configuration`
- update some tests

Testing done:
-  done -> functional test with `CTRL+C`  on mutilate during experiment (with or without `stop` flag)
