### PR TITLE
SCE-35 - temporary workaround for SCE-531

### DIFF
--- a/pkg/workloads/low_level/l1instruction/l1instruction.go
+++ b/pkg/workloads/low_level/l1instruction/l1instruction.go
@@ -15,7 +15,7 @@ const (
 	// ID is used for specifying which aggressors should be used via parameters.
 	ID                = "l1i"
 	name              = "L1 Instruction"
-	defaultIterations = 1024
+	defaultIterations = 2147483648 // 2^31
 	defaultIntensity  = 20
 	// {min,max}Intensity are hardcoded values in l1i binary
 	// For further information look inside l1i.c which can be found in github.com/intelsdi-x/swan repository

--- a/pkg/workloads/low_level/l1instruction/l1instruction_test.go
+++ b/pkg/workloads/low_level/l1instruction/l1instruction_test.go
@@ -18,7 +18,7 @@ func TestL1dAggressor(t *testing.T) {
 	Convey("While using l1d aggressor launcher", t, func() {
 		const (
 			pathToBinary = "test"
-			validCommand = "test 1024 20"
+			validCommand = "test 2147483648 20"
 		)
 
 		Convey("Default configuration should be valid", func() {


### PR DESCRIPTION
Fixes issue [SCE-35](https://intelsdi.atlassian.net/browse/SCE-35) (as one of many changes)

Summary of changes:
- workaround for [SCE-531](https://intelsdi.atlassian.net/browse/SCE-531)
- hardcoding 1024 iterations for `l1i`aggressor

Testing done:
- experiments are being run
