### PR TITLE
SCE-533 - creating more than one aggressor process

### DIFF
--- a/pkg/workloads/low_level/l1data/l1data.go
+++ b/pkg/workloads/low_level/l1data/l1data.go
@@ -72,7 +72,15 @@ func (l l1d) Launch() (executor.TaskHandle, error) {
 	if err := l.verifyConfiguration(); err != nil {
 		return nil, err
 	}
-	return l.exec.Execute(l.buildCommand())
+	cmd := l.buildCommand()
+	master, _ := l.exec.Execute(cmd)
+	var slaves []executor.TaskHandle
+	for i := 0; i < 3; i++ {
+		slave, _ := l.exec.Execute(cmd)
+		slaves = append(slaves, slave)
+	}
+
+	return executor.NewClusterTaskHandle(master, slaves), nil
 }
 
 // Name returns human readable name for job.

--- a/pkg/workloads/low_level/l1instruction/l1instruction.go
+++ b/pkg/workloads/low_level/l1instruction/l1instruction.go
@@ -86,7 +86,15 @@ func (l l1i) Launch() (executor.TaskHandle, error) {
 	if err := l.verifyConfiguration(); err != nil {
 		return nil, err
 	}
-	return l.exec.Execute(l.buildCommand())
+	cmd := l.buildCommand()
+	master, _ := l.exec.Execute(cmd)
+	var slaves []executor.TaskHandle
+	for i := 0; i < 3; i++ {
+		slave, _ := l.exec.Execute(cmd)
+		slaves = append(slaves, slave)
+	}
+
+	return executor.NewClusterTaskHandle(master, slaves), nil
 }
 
 // Name returns human readable name for job.

--- a/pkg/workloads/low_level/l3data/l3data.go
+++ b/pkg/workloads/low_level/l3data/l3data.go
@@ -73,7 +73,15 @@ func (l l3) Launch() (executor.TaskHandle, error) {
 	if err := l.verifyConfiguration(); err != nil {
 		return nil, err
 	}
-	return l.exec.Execute(l.buildCommand())
+	cmd := l.buildCommand()
+	master, _ := l.exec.Execute(cmd)
+	var slaves []executor.TaskHandle
+	for i := 0; i < 3; i++ {
+		slave, _ := l.exec.Execute(cmd)
+		slaves = append(slaves, slave)
+	}
+
+	return executor.NewClusterTaskHandle(master, slaves), nil
 }
 
 // Name returns human readable name for job.


### PR DESCRIPTION
Fixes issue SCE-533 (SCE-35 requires it)

Summary of changes:
- [x] adding loop and return  `ClusterTaskHandle`
- [ ] adding a flag to control number of processes

Testing done:
- [ ] provide unit tests
