### PR TITLE
Added http helper for checking if service is listening. It is required for further changes in k8s launcher.

### DIFF
--- a/integration_tests/pkg/workloads/memcached_test.go
+++ b/integration_tests/pkg/workloads/memcached_test.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/utils/os"
+	"github.com/intelsdi-x/swan/pkg/utils/env"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -25,7 +25,7 @@ func TestMemcachedWithExecutor(t *testing.T) {
 		config := memcached.DefaultMemcachedConfig()
 		// Prefer to run memcached locally using the current user,
 		// if it can be determined from the environment.
-		config.User = os.GetEnvOrDefault("USER", config.User)
+		config.User = env.GetOrDefault("USER", config.User)
 		memcachedLauncher := memcached.New(l, config)
 
 		Convey("When memcached is launched", func() {

--- a/integration_tests/pkg/workloads/mutilate/mutilate_test.go
+++ b/integration_tests/pkg/workloads/mutilate/mutilate_test.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/misc/snap-plugin-collector-mutilate/mutilate/parse"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	fs "github.com/intelsdi-x/swan/pkg/utils/os"
+	"github.com/intelsdi-x/swan/pkg/utils/env"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	"github.com/intelsdi-x/swan/pkg/workloads/mutilate"
 	. "github.com/smartystreets/goconvey/convey"
@@ -34,7 +34,7 @@ func TestMutilateWithExecutor(t *testing.T) {
 
 	// Memcached setup.
 	memcachedConfig := memcached.DefaultMemcachedConfig()
-	memcachedConfig.User = fs.GetEnvOrDefault("USER", memcachedConfig.User)
+	memcachedConfig.User = env.GetOrDefault("USER", memcachedConfig.User)
 	memcachedConfig.Port = memachedPort
 	mcAddress := fmt.Sprintf("127.0.0.1:%d", memcachedConfig.Port)
 

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -1,9 +1,9 @@
-package os
+package env
 
 import "os"
 
-// GetEnvOrDefault returns the environment variable or default string.
-func GetEnvOrDefault(env string, defaultStr string) string {
+// GetOrDefault returns the environment variable or default string.
+func GetOrDefault(env string, defaultStr string) string {
 	if env == "" {
 		return defaultStr
 	}

--- a/pkg/utils/netutil/netutil.go
+++ b/pkg/utils/netutil/netutil.go
@@ -1,4 +1,4 @@
-package http
+package netutil
 
 import (
 	"net"
@@ -10,17 +10,7 @@ const retries = 5
 // IsListeningFunction is a function type for checking if http endpoint is responding.
 type IsListeningFunction func(address string, timeout time.Duration) bool
 
-// IsListeningMockedSuccess is a mocked IsListeningFunction returning always true.
-func IsListeningMockedSuccess(address string, timeout time.Duration) bool {
-	return true
-}
-
-// IsListeningMockedFailure is a mocked IsListeningFunction returning always false.
-func IsListeningMockedFailure(address string, timeout time.Duration) bool {
-	return false
-}
-
-// IsListening tries to connect to given address http address in a form of `http://ip:port`.
+// IsListening tries to establish TCP connection to given address in a form of `ip:port`.
 // It returns true when it was able to connect to given endpoint within timeout time.
 func IsListening(address string, timeout time.Duration) bool {
 	sleepTime := time.Duration(

--- a/pkg/workloads/caffe/caffe.go
+++ b/pkg/workloads/caffe/caffe.go
@@ -6,8 +6,8 @@ import (
 	"path"
 
 	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/utils/env"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	swanOs "github.com/intelsdi-x/swan/pkg/utils/os"
 	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/pkg/errors"
 )
@@ -25,7 +25,7 @@ const (
 )
 
 func getPathFromEnvOrDefault(envkey string, relativePath string) string {
-	return swanOs.GetEnvOrDefault(
+	return env.GetOrDefault(
 		envkey, path.Join(fs.GetSwanWorkloadsPath(), relativePath))
 }
 

--- a/pkg/workloads/memcached/memcached.go
+++ b/pkg/workloads/memcached/memcached.go
@@ -11,7 +11,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/utils/http"
+	"github.com/intelsdi-x/swan/pkg/utils/netutil"
 )
 
 const (
@@ -75,7 +75,7 @@ func DefaultMemcachedConfig() Config {
 type Memcached struct {
 	exec          executor.Executor
 	conf          Config
-	isMemcachedUp http.IsListeningFunction // For mocking purposes.
+	isMemcachedUp netutil.IsListeningFunction // For mocking purposes.
 }
 
 // New is a constructor for Memcached.
@@ -83,7 +83,7 @@ func New(exec executor.Executor, config Config) Memcached {
 	return Memcached{
 		exec:          exec,
 		conf:          config,
-		isMemcachedUp: http.IsListening,
+		isMemcachedUp: netutil.IsListening,
 	}
 
 }

--- a/pkg/workloads/memcached/memcached_test.go
+++ b/pkg/workloads/memcached/memcached_test.go
@@ -5,11 +5,22 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor/mocks"
 	"github.com/intelsdi-x/swan/pkg/isolation"
-	"github.com/intelsdi-x/swan/pkg/utils/http"
 	. "github.com/smartystreets/goconvey/convey"
 	"syscall"
 	"testing"
+	"time"
 )
+
+// IsEndpointListeningMockedSuccess is a mocked IsListeningFunction returning always true.
+func IsEndpointListeningMockedSuccess(address string, timeout time.Duration) bool {
+	return true
+}
+
+// IsEndpointListeningMockedFailure is a mocked IsListeningFunction returning always false.
+func IsEndpointListeningMockedFailure(address string, timeout time.Duration) bool {
+
+	return false
+}
 
 // TestMemcachedWithMockedExecutor runs a Memcached launcher with the mocked executor to simulate
 // different cases like proper process execution and error case.
@@ -35,7 +46,7 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 			memcachedLauncher := New(
 				mockedExecutor,
 				config)
-			memcachedLauncher.isMemcachedUp = http.IsListeningMockedSuccess
+			memcachedLauncher.isMemcachedUp = IsEndpointListeningMockedSuccess
 			Convey("While simulating proper execution", func() {
 				mockedExecutor.On("Execute", expectedCommand).Return(mockedTaskHandle, nil).Once()
 				mockedTaskHandle.On("Address").Return(expectedHost)
@@ -61,7 +72,7 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 					Convey("When test connection to memcached fails task handle shall be nil and error shall be return", func() {
 						mockedTaskHandle.On("Stop").Return(nil)
 						mockedTaskHandle.On("Clean").Return(nil)
-						memcachedLauncher.isMemcachedUp = http.IsListeningMockedFailure
+						memcachedLauncher.isMemcachedUp = IsEndpointListeningMockedFailure
 						task, err := memcachedLauncher.Launch()
 						So(err, ShouldNotBeNil)
 						So(task, ShouldBeNil)
@@ -71,7 +82,7 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 					Convey("When test connection to memcached fails and task.Stop fails task handle shall be nil and error shall be return", func() {
 						mockedTaskHandle.On("Stop").Return(errors.New("Test error code for stop"))
 						mockedTaskHandle.On("Clean").Return(nil)
-						memcachedLauncher.isMemcachedUp = http.IsListeningMockedFailure
+						memcachedLauncher.isMemcachedUp = IsEndpointListeningMockedFailure
 						task, err := memcachedLauncher.Launch()
 						So(err, ShouldNotBeNil)
 						So(task, ShouldBeNil)
@@ -81,7 +92,7 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 					Convey("When test connection to memcached fails, task.Stop succeeds and task.Clean fails task handle shall be nil and error shall be return", func() {
 						mockedTaskHandle.On("Stop").Return(nil)
 						mockedTaskHandle.On("Clean").Return(errors.New("Test error code for clean"))
-						memcachedLauncher.isMemcachedUp = http.IsListeningMockedFailure
+						memcachedLauncher.isMemcachedUp = IsEndpointListeningMockedFailure
 						task, err := memcachedLauncher.Launch()
 						So(err, ShouldNotBeNil)
 						So(task, ShouldBeNil)


### PR DESCRIPTION
It is required for further changes in k8s launcher.

Summary of changes:
- Moved tryConnect function to http helper,

Testing done:
- make all

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
