### PR TITLE
SCE-504: Moved launcher interfaces to executor pkg

### DIFF
--- a/integration_tests/pkg/executor/remote_test.go
+++ b/integration_tests/pkg/executor/remote_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/isolation"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	. "github.com/smartystreets/goconvey/convey"
 	"os/user"
 )
@@ -94,7 +93,7 @@ func testRemoteProcessPidIsolation() {
 
 }
 
-func newMultipleMemcached(sshConfig executor.SSHConfig) workloads.Launcher {
+func newMultipleMemcached(sshConfig executor.SSHConfig) executor.Launcher {
 	decors := isolation.Decorators{}
 	unshare, _ := isolation.NewNamespace(syscall.CLONE_NEWPID)
 	decors = append(decors, unshare)

--- a/pkg/executor/launcher.go
+++ b/pkg/executor/launcher.go
@@ -1,15 +1,11 @@
-package workloads
-
-import (
-	"github.com/intelsdi-x/swan/pkg/executor"
-)
+package executor
 
 // Launcher responsibility is to launch previously configured job.
 type Launcher interface {
 	// Launch starts the workload (process or group of processes). It returns a workload
 	// represented as a Task Handle instance.
 	// Error is returned when Launcher is unable to start a job.
-	Launch() (executor.TaskHandle, error)
+	Launch() (TaskHandle, error)
 
 	// Name returns human readable name for job.
 	// TODO(bp): Do the same for LoadGenerator.

--- a/pkg/executor/load_generator.go
+++ b/pkg/executor/load_generator.go
@@ -1,7 +1,6 @@
-package workloads
+package executor
 
 import (
-	"github.com/intelsdi-x/swan/pkg/executor"
 	"time"
 )
 
@@ -17,5 +16,5 @@ type LoadGenerator interface {
 	// Load starts a load on the specific workload with the defined loadPoint (number of QPS).
 	// The task will do the load for specified amount of time.
 	// Note: Results from Load needs to be fetched out of band e.g using Snap.
-	Load(load int, duration time.Duration) (task executor.TaskHandle, err error)
+	Load(load int, duration time.Duration) (task TaskHandle, err error)
 }

--- a/pkg/experiment/sensitivity/launcher.go
+++ b/pkg/experiment/sensitivity/launcher.go
@@ -1,8 +1,8 @@
 package sensitivity
 
 import (
+	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 )
 
 // LauncherSessionPair is a pair of Launcher and corresponding Session Launcher.
@@ -10,38 +10,38 @@ import (
 // Launcher and SessionLauncher. It is not possible right now since Launcher
 // and LauncherSession have not the same API.
 type LauncherSessionPair struct {
-	Launcher            workloads.Launcher
+	Launcher            executor.Launcher
 	SnapSessionLauncher snap.SessionLauncher
 }
 
 // NewLauncherWithoutSession constructs LauncherSessionPair without any Session.
-func NewLauncherWithoutSession(launcher workloads.Launcher) LauncherSessionPair {
+func NewLauncherWithoutSession(launcher executor.Launcher) LauncherSessionPair {
 	return LauncherSessionPair{launcher, nil}
 }
 
 // NewMonitoredLauncher constructs LauncherSessionPair with specified Session.
 func NewMonitoredLauncher(
-	launcher workloads.Launcher,
+	launcher executor.Launcher,
 	snapSessionLauncher snap.SessionLauncher) LauncherSessionPair {
 	return LauncherSessionPair{launcher, snapSessionLauncher}
 }
 
 // LoadGeneratorSessionPair is a pair of Load Generator and corresponding Session Launcher.
 type LoadGeneratorSessionPair struct {
-	LoadGenerator       workloads.LoadGenerator
+	LoadGenerator       executor.LoadGenerator
 	SnapSessionLauncher snap.SessionLauncher
 }
 
 // NewLoadGeneratorWithoutSession constructs LoadGenerator without any Session.
 func NewLoadGeneratorWithoutSession(
-	loadGenerator workloads.LoadGenerator) LoadGeneratorSessionPair {
+	loadGenerator executor.LoadGenerator) LoadGeneratorSessionPair {
 
 	return LoadGeneratorSessionPair{loadGenerator, nil}
 }
 
 // NewMonitoredLoadGenerator constructs LoadGenerator with specified Session.
 func NewMonitoredLoadGenerator(
-	loadGenerator workloads.LoadGenerator,
+	loadGenerator executor.LoadGenerator,
 	snapSessionLauncher snap.SessionLauncher) LoadGeneratorSessionPair {
 
 	return LoadGeneratorSessionPair{loadGenerator, snapSessionLauncher}

--- a/pkg/experiment/sensitivity/tuning.go
+++ b/pkg/experiment/sensitivity/tuning.go
@@ -2,16 +2,16 @@ package sensitivity
 
 import (
 	"github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/experiment/phase"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/montanaflynn/stats"
 )
 
 type tuningPhase struct {
 	// Latency Sensitivity (Production) workload.
-	pr workloads.Launcher
+	pr executor.Launcher
 	// Workload Generator for Latency Sensitivity task.
-	lgForPr workloads.LoadGenerator
+	lgForPr executor.LoadGenerator
 	// Given Service Level Objective.
 	SLO int
 	// Number of repetitions

--- a/pkg/workloads/caffe/caffe.go
+++ b/pkg/workloads/caffe/caffe.go
@@ -8,7 +8,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/env"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/pkg/errors"
 )
 
@@ -54,7 +53,7 @@ type Caffe struct {
 }
 
 // New is a constructor for Caffe.
-func New(exec executor.Executor, config Config) workloads.Launcher {
+func New(exec executor.Executor, config Config) executor.Launcher {
 	return Caffe{
 		exec: exec,
 		conf: config,

--- a/pkg/workloads/low_level/l1data/l1data.go
+++ b/pkg/workloads/low_level/l1data/l1data.go
@@ -7,7 +7,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"path"
 )
 
@@ -46,7 +45,7 @@ type l1d struct {
 }
 
 // New is a constructor for l1d aggressor.
-func New(exec executor.Executor, config Config) workloads.Launcher {
+func New(exec executor.Executor, config Config) executor.Launcher {
 	return l1d{
 		exec: exec,
 		conf: config,

--- a/pkg/workloads/low_level/l1instruction/l1instruction.go
+++ b/pkg/workloads/low_level/l1instruction/l1instruction.go
@@ -7,7 +7,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/pkg/errors"
 )
 
@@ -55,7 +54,7 @@ type l1i struct {
 }
 
 // New is a constructor for l1i aggressor.
-func New(exec executor.Executor, config Config) workloads.Launcher {
+func New(exec executor.Executor, config Config) executor.Launcher {
 	return l1i{
 		exec: exec,
 		conf: config,

--- a/pkg/workloads/low_level/l3data/l3data.go
+++ b/pkg/workloads/low_level/l3data/l3data.go
@@ -8,7 +8,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +46,7 @@ type l3 struct {
 }
 
 // New is a constructor for l3 aggressor.
-func New(exec executor.Executor, config Config) workloads.Launcher {
+func New(exec executor.Executor, config Config) executor.Launcher {
 	return l3{
 		exec: exec,
 		conf: config,

--- a/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
+++ b/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
@@ -8,7 +8,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/pkg/errors"
 )
 
@@ -47,7 +46,7 @@ type memBw struct {
 }
 
 // New is a constructor for memBw aggressor.
-func New(exec executor.Executor, config Config) workloads.Launcher {
+func New(exec executor.Executor, config Config) executor.Launcher {
 	return memBw{
 		exec: exec,
 		conf: config,

--- a/pkg/workloads/low_level/stream/stream.go
+++ b/pkg/workloads/low_level/stream/stream.go
@@ -7,7 +7,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 )
 
 const (
@@ -53,7 +52,7 @@ type stream struct {
 // Working set size should be more than 4x the size of sum of all last-level cache used in the run
 // If you need more consider rebuilding stream with STREAM_ARRAY_SIZE adjusted accordingly.
 // Check stream.c "Instructions" for more details.
-func New(exec executor.Executor, config Config) workloads.Launcher {
+func New(exec executor.Executor, config Config) executor.Launcher {
 	return stream{
 		exec: exec,
 		conf: config,

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	"github.com/intelsdi-x/swan/pkg/workloads"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	"github.com/pkg/errors"
 )
@@ -137,7 +136,7 @@ type mutilate struct {
 // New returns a new Mutilate Load Generator instance.
 // Mutilate is a load generator for Memcached.
 // https://github.com/leverich/mutilate
-func New(exec executor.Executor, config Config) workloads.LoadGenerator {
+func New(exec executor.Executor, config Config) executor.LoadGenerator {
 	return mutilate{
 		master: exec,
 		agents: []executor.Executor{},
@@ -150,7 +149,7 @@ func New(exec executor.Executor, config Config) workloads.LoadGenerator {
 // Mutilate is a load generator for Memcached.
 // https://github.com/leverich/mutilate
 func NewCluster(
-	master executor.Executor, agents []executor.Executor, config Config) workloads.LoadGenerator {
+	master executor.Executor, agents []executor.Executor, config Config) executor.LoadGenerator {
 	return mutilate{
 		master: master,
 		agents: agents,


### PR DESCRIPTION
Fixes issue SCE-504

It is needed since we will use these interfaces in different packages than workloads.

Summary of changes:
- Moved launcher interfaces to executor package

Testing done:
- make all

Signed-off-by: Bartlomiej Plotka bartlomiej.plotka@intel.com
