### PR TITLE
SCE-553: l1d,l3 aggressors: disable sleeping during while (disable throttling)

### DIFF
--- a/workloads/low-level-aggressors/l1d.c
+++ b/workloads/low-level-aggressors/l1d.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
+#include <sched.h>
 
 // #define CACHE_SIZE 32*1024
 #define NS_PER_S (1000000000L)
@@ -69,7 +70,8 @@ int main(int argc, char **argv) {
 
 	while (getNs() < usr_timer) {
 		memcpy(block, block+CACHE_SIZE/2, CACHE_SIZE/2);
-		sleep((float)(usr_timer-getNs())/usr_timer);
+		// note: replaced original throttling sleep with yielding that gives chance ther workloads to run
+		sched_yield(); // sleep((float)(usr_timer-time_spent)/usr_timer);
 	}
 	return 0;
 }

--- a/workloads/low-level-aggressors/l3.c
+++ b/workloads/low-level-aggressors/l3.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <time.h>
+#include <sched.h>
 
 #define CACHE_SIZE 20*1024*1024
 
@@ -66,7 +67,8 @@ int main(int argc, char **argv) {
 	while (time_spent < usr_timer) {
   		begin = clock();
 		memcpy(block, block+CACHE_SIZE/2, CACHE_SIZE/2);
-		sleep((float)(usr_timer-time_spent)/usr_timer);
+		// note: replaced original throttling sleep with yielding that gives chance ther workloads to run
+		sched_yield(); // sleep((float)(usr_timer-time_spent)/usr_timer);
 		end = clock();
   		time_spent += (double)(end - begin) / CLOCKS_PER_SEC;
 	}


### PR DESCRIPTION
Fixes issue SCE-553

Summary of changes:
- remove sleep during while loops
- throttling/acceleration limts interference we expect to have

Testing done:
- run manually

rationale:
- we treat aggressors like long running services and want have control
  when then stops, so for that we running them for very long
- warm up algorithm (duration-spent/duration), make them sleep for 1s
  every loop during whole measurement time
