### PR TITLE
SCE-35, SC#-362 - missing packages added

### DIFF
--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -92,7 +92,9 @@ EOF
       scons \
       tree \
       vim \
-      wget 
+      wget \
+      psmisc \
+      pssh
     . $HOME_DIR/go/src/github.com/intelsdi-x/swan/workloads/deep_learning/caffe/caffe_deps_centos.sh
     if [ ! -f /tmp/go1.6.linux-amd64.tar.gz ]; then
       wget -P /tmp https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz


### PR DESCRIPTION
Fixes issue SCE-35 and SCE-362

Summary of changes:
- adding missing packages to Vagrantfile

Testing done:
- `vagrant provision` was run succesfully
