### PR TITLE
SCE-568: Speed-up workloads execution

### DIFF
--- a/misc/dev/docker/Dockerfile_centos
+++ b/misc/dev/docker/Dockerfile_centos
@@ -6,8 +6,8 @@ ENV GOPATH=/opt/gopath \
     PATH=/usr/local/go/bin:/opt/gopath/bin:$PATH \
     GIT_TERMINAL_PROMPT=1
 
-ADD workload_deps_centos/ /workload_deps_centos/
-ADD install_deps.sh /workload_deps_centos/
+ADD misc/dev/docker/workload_deps_centos/ /workload_deps_centos/
+ADD misc/dev/docker/install_deps.sh /workload_deps_centos/
 
 RUN yum install -y epel-release && \
     yum groupinstall -y 'Development Tools' && \
@@ -27,11 +27,15 @@ RUN yum install -y epel-release && \
     yum clean all && \
     wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz -O /usr/local/go.tar.gz && \
     cd /usr/local/ && \
-    tar xfvv go.tar.gz && \
-    mkdir /opt/gopath
+    tar xfvv go.tar.gz
+
+ADD . /opt/gopath/src/github.com/intelsdi-x/swan
+RUN cd /opt/gopath/src/github.com/intelsdi-x/swan && \
+    adduser memcached && \
+    make build_workloads
 
 WORKDIR /opt/gopath/src/github.com/intelsdi-x
-ADD swan_scripts /
+ADD misc/dev/docker/swan_scripts /
 
 ENTRYPOINT ["/start.sh"]
 CMD ["-t make -s integration_tests"]

--- a/misc/dev/docker/Dockerfile_ubuntu
+++ b/misc/dev/docker/Dockerfile_ubuntu
@@ -6,8 +6,8 @@ ENV GOPATH=/opt/gopath \
     PATH=/usr/local/go/bin:/opt/gopath/bin:$PATH \
     GIT_TERMINAL_PROMPT=1
 
-ADD workload_deps_ubuntu/ /workload_deps_ubuntu/
-ADD install_deps.sh /workload_deps_ubuntu/
+ADD misc/dev/docker/workload_deps_ubuntu/ /workload_deps_ubuntu/
+ADD misc/dev/docker/install_deps.sh /workload_deps_ubuntu/
 
 RUN apt-get update && \
     apt-get install -y build-essential \
@@ -30,11 +30,15 @@ RUN apt-get update && \
     cp /usr/sbin/useradd /usr/sbin/adduser && \
     wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz -O /usr/local/go.tar.gz && \
     cd /usr/local/ && \
-    tar xfvv go.tar.gz && \
-    mkdir /opt/gopath
+    tar xfvv go.tar.gz
+
+ADD . /opt/gopath/src/github.com/intelsdi-x/swan
+RUN cd /opt/gopath/src/github.com/intelsdi-x/swan && \
+    adduser memcached && \
+    make build_workloads
 
 WORKDIR /opt/gopath/src/github.com/intelsdi-x
-ADD swan_scripts /
+ADD misc/dev/docker/swan_scripts /
 
 ENTRYPOINT ["/start.sh"]
 CMD ["-t make -s integration_tests"]

--- a/misc/dev/docker/README.md
+++ b/misc/dev/docker/README.md
@@ -20,15 +20,15 @@ With `-l` parameter container stays running after command execution.
 
 ## Building
 
-To build Docker images just run:
+To build Docker images just run following commands from swan root:
 
 - based on Ubuntu image:
 
-`docker build -t <image_tag> ./integration_tests/docker/ubuntu/`
+`docker build -t <image_tag> -f ./misc/dev/docker/Dockerfile_ubuntu` .
 
 - based on Centos image:
 
-`docker build -t <image_tag> ./integration_tests/docker/centos/`
+`docker build -t <image_tag> -f ./misc/dev/docker/Dockerfile_centos` .
 
 where:
 - `image_tag` means friendly name for docker image
@@ -37,10 +37,11 @@ where:
 
 To build, test or run swan workload inside Docker container run:
 
-`docker run --privileged -i -t -e GIT_TOKEN=<*your_git_token*> -e GIT_BRANCH=<*target_branch*> -v <*path_to_repo*>:/swan -v /sys/fs/cgroup:/sys/fs/cgroup/:rw --net=host <*image_name*> -t <*target*> -s <*scenario*> -l -p <*params*>`
+`docker run --privileged -i -t -e GIT_LOGIN=<*your_github_id*> -e GIT_TOKEN=<*your_git_token*> -e GIT_BRANCH=<*target_branch*> -v <*path_to_repo*>:/swan -v /sys/fs/cgroup:/sys/fs/cgroup/:rw --net=host <*image_name*> -t <*target*> -s <*scenario*> -l -p <*params*>`
 
 where:
 
+- `your_github_id` - github account username
 - `your_git_token` - per git account token for access to private repositories (if you don't provide it, you will be asked for GitHub credentials during tests)
 - `path_to_repo` - absolute path to swan source code (optional)
 - `target_branch` - select swan branch for test(s). (default: master)

--- a/misc/dev/docker/inside-docker-tests.sh
+++ b/misc/dev/docker/inside-docker-tests.sh
@@ -12,16 +12,18 @@ if [[ ${GIT_TOKEN} != "" ]]; then
     GIT_TOKEN_ENV="-e GIT_TOKEN=${GIT_TOKEN}"
 fi
 
+cd ../../../
+
 echo "Building up docker images"
 # Skip showing output for clean output on CI
 echo "* Building up Centos based image"
-docker build -t swan_centos_tests -f Dockerfile_centos . > /dev/null
+docker build -t misc/dev/docker/swan_centos_tests -f Dockerfile_centos . > /dev/null
 echo "* Building up Ubuntu based image"
-docker build -t swan_ubuntu_tests -f Dockerfile_ubuntu . > /dev/null
+docker build -t misc/dev/docker/swan_ubuntu_tests -f Dockerfile_ubuntu . > /dev/null
 
 echo "Running up tests"
 echo "* Running Centos based image"
-docker run --privileged $GIT_TOKEN_ENV -t -v $(pwd)/../../:/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_centos_tests
+docker run --privileged $GIT_TOKEN_ENV -t -v $(pwd):/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_centos_tests
 echo "* Running Ubuntu based image"
-docker run --privileged $GIT_TOKEN_ENV -t -v $(pwd)/../../:/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_ubuntu_tests
+docker run --privileged $GIT_TOKEN_ENV -t -v $(pwd):/swan -v /sys/fs/cgroup:/sys/fs/cgroup:rw --net=host swan_ubuntu_tests
 

--- a/misc/dev/docker/swan_scripts/start.sh
+++ b/misc/dev/docker/swan_scripts/start.sh
@@ -8,6 +8,7 @@ SCENARIO=""
 BINPARAMETERS=""
 LOCKSTATE=false
 COLORTERMINAL=false
+GIT_REPO_LOCATION=""
 
 . /make.sh
 . /workload.sh
@@ -59,24 +60,33 @@ function verifyStatus() {
 
 function setGitHubCredentials() {
     printStep "Set GitHub credentials"
-    if [[ $GIT_TOKEN != "" ]]; then
-        git config --global url."https://$GIT_TOKEN:x-oauth-basic@github.com/".insteadOf "https://github.com/"
-        printInfo "Token for GitHub has been set"
+    if [[ $GIT_TOKEN != "" && $GIT_LOGIN != "" ]]; then
+        echo -e "machine github.com\nlogin $GIT_LOGIN\npassword $GIT_TOKEN" > ~/.netrc
+        printInfo "Token for GitHub has been set for user $GIT_LOGIN"
     fi
 }
 
-function cloneCode() {
-    printStep "Clone source code from github"
-
+function setRemoteRepo() {
+    printStep "Setting up remote repository"
+    
     if [[ $GIT_BRANCH == "" ]]; then
         GIT_BRANCH="master"
     fi
-
-    printInfo "Selected branch: $GIT_BRANCH"
-    git clone -b $GIT_BRANCH  https://$REPOSITORY_URL
-
+       
     verifyStatus
-    printInfo "Clone source code has been completed"
+    printInfo "Remote repository configuration has been set"
+}
+
+function setLocalRepo() {
+    printStep "Setting up local source repository"
+
+    pushd /swan
+    GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    popd
+    git remote remove $GIT_REPO_LOCATION &> /dev/null
+    git remote add $GIT_REPO_LOCATION /swan/.git
+    verifyStatus
+    printInfo "Local repository configuration has been set"
 }
 
 function prepareEnvironment() {
@@ -86,20 +96,18 @@ function prepareEnvironment() {
     printInfo "All dependencies have been downloaded"
 }
 
-function getCodeFromDir() {
-    printStep "Binding source code from /swan to proper directory in \$GOPATH"
-    mkdir swan
-    mount -o bind /swan ./swan
-    verifyStatus
-    printInfo "Binding has been completed"
-}
-
 function getCode() {
+    cd swan
     if [[ -d "/swan" ]]; then
-        getCodeFromDir
+        GIT_REPO_LOCATION="local_repo"
+        setLocalRepo
     else
-        cloneCode
+        GIT_REPO_LOCATION="origin"
+        setRemoteRepo
     fi
+    git pull $GIT_REPO_LOCATION $GIT_BRANCH
+    git checkout -b $GIT_REPO_LOCATION/$GIT_BRANCH
+    cd ..
 }
 
 function usage() {

--- a/misc/dev/docker/swan_scripts/workload.sh
+++ b/misc/dev/docker/swan_scripts/workload.sh
@@ -9,7 +9,6 @@ function buildWorkloads() {
 function workload() {
     printStep "Running workload: $SCENARIO"
     cd swan
-    buildWorkloads
     BIN=""
     WD=""
     case $SCENARIO in


### PR DESCRIPTION
Fixes issue SCE-568

Summary of changes:
- swan repository is now used during image building
  - this operation decreases workloads spinning up time to few seconds
- using .netrc for github login
- updated documentation

Testing done:
- spinning up workloads for ubuntu and centos Docker images
