### PR TITLE
SCE-530: remote validation of "ulimit -n" (NOFILE) for mutilate cluster

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -181,7 +181,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	}
 	logrus.Debugf("Added %d mutilate agent(s) to mutilate cluster", len(agentsLoadGeneratorExecutors))
 
-	// Validate mutilate cluster executors and theirs limit of
+	// Validate mutilate cluster executors and their limit of
 	// number of open file descriptors. Sane mutilate configuration requires
 	// more than default (1024) for mutilate cluster.
 	validateExecutorsNOFILELimit(

--- a/experiments/memcached-sensitivity-profile/validate.go
+++ b/experiments/memcached-sensitivity-profile/validate.go
@@ -18,7 +18,7 @@ const (
 	// be enough to handle distributed mutilate cluster when generating sensible load
 	// and enough to run production tasks like memcached that handle a lot of
 	// number simultaneous connections.
-	minimalNOFILERequirment = 10 * 1024
+	minimalNOFILERequirement = 10 * 1024
 )
 
 // checkTCPSyncookies warn user about potential issue with SYN flooding of victim machine.
@@ -67,17 +67,17 @@ func validateOS() {
 	checkCPUPowerGovernor()
 	checkNOFILE(
 		getNOFILE(executor.NewLocal()),
-		minimalNOFILERequirment,
+		minimalNOFILERequirement,
 	)
 }
 
-// validateExecutorsNOFILELimit validates is environment provided by executors can run
+// validateExecutorsNOFILELimit validates if environment provided by executors can run
 // distributed application that requires large number of open file descriptors.
 func validateExecutorsNOFILELimit(executors []executor.Executor) {
 	for _, executor := range executors {
 		checkNOFILE(
 			getNOFILE(executor),
-			minimalNOFILERequirment,
+			minimalNOFILERequirement,
 		)
 	}
 }


### PR DESCRIPTION
Fixes issue SCE-503

Summary of changes:
- use provided executors (whether they are local or remote) and "calls ulimit -n" parses and checks is it about default (1024)
- refactors current implementation of ulimits (syscall replaced with ulimit -n) - more accurate than syscall on localhost (risk that executor will run with different limits)
- refactor: name change: no more MaxiumNumberOfOpenFileDescriptors - > NOFILE (systemd, limits.conf convention)

Testing done:
- YES manually (run experiment on developer workstation with remote executors) with two cases, no unit tests, no integration tests (requires "experiment integrations tests") 
