### PR TITLE
set synced folder type for aws to rsync

### DIFF
--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -52,6 +52,7 @@ Vagrant.configure(2) do |config|
     else
       data = {}
     end
+    override.nfs.functional = false
     aws.access_key_id = data['access_key_id']
     aws.secret_access_key = data['secret_access_key']
     override.vm.box = "aws"


### PR DESCRIPTION
Fixes issue ...

Summary of changes:
- explicitly disables nfs for aws provider

Testing done:
verified that it resolves my issue manually. Going to run integration tests

In testing the new environment, I ran
into an issue where the aws provider is trying
to use the nfs provider for shared folders.

This patch is an attempt to work around
that issue.
