### PR TITLE
Move jupyter building to separate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ integration_test_on_docker:
 	(cd integration_tests/docker; ./inside-docker-tests.sh)
 
 # building
-build: 
+build:
 	mkdir -p build/experiments/memcached
 	(cd build/experiments/memcached; go build ../../../experiments/memcached-sensitivity-profile)
 	mkdir -p build/viewer


### PR DESCRIPTION
Fixes issue w/o ticket

Summary of changes:
- Jupyter has got own target in Makefile

Testing done:
- not needed

Our unit tests are running for 15 minutes+ when we are building also jupyter during them. I've moved jupyter outside unit tests to separate target.
