### PR TITLE
SCE-578: Tune in package Mutilate tries to do cleanup twice causing e…

### DIFF
--- a/pkg/workloads/mutilate/mutilate_test.go
+++ b/pkg/workloads/mutilate/mutilate_test.go
@@ -167,15 +167,17 @@ func (s *MutilateTestSuite) TestClusterMutilateTuning() {
 
 	s.mExecutorForAgent1.On("Execute", mock.AnythingOfType("string")).Return(s.mAgentHandle1, nil)
 	s.mAgentHandle1.On("Address").Return("255.255.255.001").Times(numberOfConveys)
-	s.mAgentHandle1.On("Stop").Return(nil).Times(numberOfConveys * 2)
-	s.mAgentHandle1.On("EraseOutput").Return(nil).Times(numberOfConveys * 2)
-	s.mAgentHandle1.On("Clean").Return(nil).Times(numberOfConveys * 2)
+	// Those function shouldn't be called in normal execution path
+	s.mAgentHandle1.On("Stop").Return(nil).Times(0)
+	s.mAgentHandle1.On("EraseOutput").Return(nil).Times(0)
+	s.mAgentHandle1.On("Clean").Return(nil).Times(0)
 
 	s.mExecutorForAgent2.On("Execute", mock.AnythingOfType("string")).Return(s.mAgentHandle2, nil)
 	s.mAgentHandle2.On("Address").Return("255.255.255.002").Times(numberOfConveys)
-	s.mAgentHandle2.On("Stop").Return(nil).Times(numberOfConveys * 2)
-	s.mAgentHandle2.On("EraseOutput").Return(nil).Times(numberOfConveys * 2)
-	s.mAgentHandle2.On("Clean").Return(nil).Times(numberOfConveys * 2)
+	// Those function shouldn't be called in normal execution path
+	s.mAgentHandle2.On("Stop").Return(nil).Times(0)
+	s.mAgentHandle2.On("EraseOutput").Return(nil).Times(0)
+	s.mAgentHandle2.On("Clean").Return(nil).Times(0)
 
 	Convey("When Tuning Memcached.", s.T(), func() {
 		outputFile.Seek(0, 0)
@@ -272,7 +274,7 @@ func (s *MutilateTestSuite) TestClusterMutilateTuningErrors() {
 
 		Convey("Having failure with master's Wait, tune should return error and agents "+
 			"should be stopped and cleaned", func() {
-			const errorMsg = "cannot terminate the Mutilate master. Stopping agents."
+			const errorMsg = "cannot terminate the Mutilate master. Leaving agents running."
 
 			s.mExecutor.On("Execute", mock.AnythingOfType("string")).Return(s.mMasterHandle, nil).Once()
 			// IsTerminated will false.
@@ -281,16 +283,10 @@ func (s *MutilateTestSuite) TestClusterMutilateTuningErrors() {
 			s.mExecutorForAgent1.On(
 				"Execute", mock.AnythingOfType("string")).Return(s.mAgentHandle1, nil).Once()
 			s.mAgentHandle1.On("Address").Return("255.255.255.001").Once()
-			s.mAgentHandle1.On("Stop").Return(nil).Once()
-			s.mAgentHandle1.On("EraseOutput").Return(nil).Once()
-			s.mAgentHandle1.On("Clean").Return(nil).Once()
 
 			s.mExecutorForAgent2.On(
 				"Execute", mock.AnythingOfType("string")).Return(s.mAgentHandle2, nil).Once()
 			s.mAgentHandle2.On("Address").Return("255.255.255.002").Once()
-			s.mAgentHandle2.On("Stop").Return(nil).Once()
-			s.mAgentHandle2.On("EraseOutput").Return(nil).Once()
-			s.mAgentHandle2.On("Clean").Return(nil).Once()
 
 			_, _, err := mutilate.Tune(s.defaultSlo)
 			So(err, ShouldNotBeNil)


### PR DESCRIPTION
When doing clustered mutilate integration test following errors were noticed
ERRO[0019] invalid argument  
ERRO[0019] invalid argument  
ERRO[0019] invalid argument
however test passed.

It was caused from double Close() on stderr and stdout for mutilate agents in mutilate.Tune()

Fix tested on freshly developed integration tests for clustered mutilate.

Commit description:
In Tune() function there is manual cleanup in defer code and proper cleanup at the end of the function.
The result is that there are errors logged during tunning. This is because stderr and stdout are being closed twice.

Signed-off-by: Maciej Patelczyk maciej.patelczyk@intel.com
