### PR TITLE
Default log level to "warn"

### DIFF
--- a/experiments/memcached-sensitivity-profile/README.md
+++ b/experiments/memcached-sensitivity-profile/README.md
@@ -338,7 +338,7 @@ export SWAN_LOAD_DURATION=15s
 export SWAN_PEAK_LOAD=650000
 export SWAN_LOAD_POINTS=10
 export SWAN_REPS=1
-export SWAN_LOG=error
+export SWAN_LOG=warn
 
 ## --- snap configuration
 export SWAN_SNAPD_ADDR=192.168.10.9

--- a/pkg/conf/conf_test.go
+++ b/pkg/conf/conf_test.go
@@ -1,13 +1,14 @@
 package conf
 
 import (
-	"github.com/Sirupsen/logrus"
-	"github.com/intelsdi-x/swan/pkg/utils/fs"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/utils/fs"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (


### PR DESCRIPTION
follow up on "violations OS" tickets https://github.com/intelsdi-x/swan/pull/286

Fixes issue "warnings from validation in experiment aren't be default presented to user"

Summary of changes:
- docs (memcached experiment) defaults to "warn"

Testing done:
- no
