### PR TITLE
SCE-447: Integration testing for multinode mutilate deployment

### DIFF
--- a/integration_tests/pkg/executor/cluster_task_handle_test.go
+++ b/integration_tests/pkg/executor/cluster_task_handle_test.go
@@ -1,0 +1,242 @@
+package executor
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/intelsdi-x/swan/misc/snap-plugin-collector-mutilate/mutilate/parse"
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/utils/env"
+	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
+	"github.com/intelsdi-x/swan/pkg/workloads/mutilate"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	numAgents     = 3
+	memcachedIP   = "10.141.141.10"
+	masterIP      = "10.141.141.20"
+	agent1IP      = "10.141.141.20"
+	agent2IP      = "10.141.141.21"
+	agent3IP      = "10.141.141.22"
+	memcachedPort = 11212
+)
+
+func launchLocalMemcached(t *testing.T) executor.TaskHandle {
+
+	localExecutor := executor.NewLocal()
+	memcachedDefConfig := memcached.DefaultMemcachedConfig()
+	memcachedDefConfig.User = env.GetOrDefault("USER", memcachedDefConfig.User)
+	memcachedDefConfig.Port = memcachedPort
+	memcachedDefConfig.NumThreads = 1
+
+	memcachedLauncher := memcached.New(localExecutor, memcachedDefConfig)
+	taskHandle, err := memcachedLauncher.Launch()
+	if err != nil {
+		t.Fatal("Cannot start local memcached instance: " + err.Error())
+	}
+	return taskHandle
+}
+
+func cleanMemcached(taskHandle executor.TaskHandle, t *testing.T) error {
+	err := taskHandle.Stop()
+	if err != nil {
+		t.Fatal("Failed to stop local memcached instalce: " + err.Error())
+	}
+	taskHandle.Wait(0)
+	exitCode, err := taskHandle.ExitCode()
+	if err != nil {
+		t.Fatal("Failed to get local memcached exit code: " + err.Error())
+	}
+	if exitCode != -1 {
+		t.Fatalf("Local memcached stopped incorrectly! Exit code: %d", exitCode)
+	}
+	err = taskHandle.EraseOutput()
+	if err != nil {
+		t.Fatal("Failed to clean output from local mutilate instance: " + err.Error())
+	}
+	return nil
+}
+
+func newSSHConfig(ip string) *executor.SSHConfig {
+	return &executor.SSHConfig{
+		ClientConfig: &ssh.ClientConfig{
+			User: "root",
+			Auth: []ssh.AuthMethod{ssh.Password("vagrant")},
+		},
+		Host: ip,
+		Port: 22,
+	}
+}
+
+func setupMutilate() executor.LoadGenerator {
+
+	masterRemoteExecutor := executor.NewRemote(newSSHConfig(masterIP))
+	agentsRemoteExecutors := []executor.Executor{}
+
+	agentsRemoteExecutors = append(agentsRemoteExecutors, executor.NewRemote(newSSHConfig(agent1IP)))
+	agentsRemoteExecutors = append(agentsRemoteExecutors, executor.NewRemote(newSSHConfig(agent2IP)))
+	agentsRemoteExecutors = append(agentsRemoteExecutors, executor.NewRemote(newSSHConfig(agent3IP)))
+
+	mutilateConfig := mutilate.DefaultMutilateConfig()
+
+	mutilateConfig.TuningTime = 10 * time.Second
+	// Ensure files are removed afterwards.
+	mutilateConfig.ErasePopulateOutput = true
+	mutilateConfig.EraseTuneOutput = true
+	mutilateConfig.WarmupTime = 3 * time.Second
+	// Note: not sure if custom percentile is working correctly.
+	// TODO: added a custom percentile integration test.
+	mutilateConfig.LatencyPercentile = "99"
+	mutilateConfig.MemcachedHost = memcachedIP
+	mutilateConfig.MemcachedPort = memcachedPort
+	mutilateConfig.ErasePopulateOutput = true
+	mutilateConfig.EraseTuneOutput = true
+
+	mutilateConfig.AgentThreads = 1
+	mutilateConfig.AgentConnections = 1
+	mutilateConfig.AgentConnectionsDepth = 1
+
+	mutilateConfig.MasterThreads = 1
+	mutilateConfig.MasterConnections = 1
+	mutilateConfig.MasterConnectionsDepth = 1
+
+	mutilateLoadGenerator := mutilate.NewCluster(masterRemoteExecutor,
+		agentsRemoteExecutors, mutilateConfig)
+	return mutilateLoadGenerator
+}
+
+// getMemcachedStats helper read and parse "stats" memcached command and return map key -> value.
+// https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L511
+func getLocalMemcachedStats(t *testing.T) (currItems, getCount int) {
+	const (
+		statsCmd         = "stats\n"
+		mcStatsReplySize = 4096 // Enough size to get whole response from memcached.
+	)
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", memcachedPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if n, err := conn.Write([]byte(statsCmd)); err != nil || n != len(statsCmd) {
+		t.Fatalf("couldn't write to memcached expected number err=%s of bytes=%d", err, n)
+	}
+
+	buf := make([]byte, mcStatsReplySize)
+	if _, err = conn.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, line := range strings.Split(string(buf), "\n") {
+		if strings.HasPrefix(line, "END") {
+			break
+		}
+		var key, value string
+		_, err := fmt.Sscanf(line, "STAT %s %s", &key, &value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch key {
+		case "curr_items":
+			if currItems, err = strconv.Atoi(value); err != nil {
+				t.Fatal(err)
+			}
+		case "cmd_get":
+			if getCount, err = strconv.Atoi(value); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return currItems, getCount
+}
+
+func TestClusteredTaskHandle(t *testing.T) {
+	//log.SetLevel(log.DebugLevel)
+	//log.SetOutput(os.Stderr)
+
+	memcachedTaskHandle := launchLocalMemcached(t)
+
+	defer cleanMemcached(memcachedTaskHandle, t)
+
+	stopped := memcachedTaskHandle.Wait(2 * time.Second)
+	if stopped {
+		t.Fatal("Memcached not running! It should now.")
+	}
+
+	Convey("When launched new local memcached", t, func() {
+		Convey("It should be running by now", func() {
+			So(memcachedTaskHandle.Status(), ShouldEqual, executor.RUNNING)
+		})
+
+		Convey("It should have reset statistics", func() {
+			currItem, getCount := getLocalMemcachedStats(t)
+			So(currItem, ShouldEqual, 0)
+			So(getCount, ShouldEqual, 0)
+		})
+	})
+
+	mutilateLG := setupMutilate()
+
+	Convey("With clustered mutilate configured", t, func() {
+		Convey("It shall populate memcached", func() {
+			err := mutilateLG.Populate()
+			So(err, ShouldBeNil)
+			currItems, _ := getLocalMemcachedStats(t)
+			So(currItems, ShouldBeGreaterThan, 0)
+		})
+		Convey("It shall perform tune", func() {
+			_, prevGetCount := getLocalMemcachedStats(t)
+			achievedLoad, achievedSLI, err := mutilateLG.Tune(5000)
+			So(err, ShouldBeNil)
+			So(achievedLoad, ShouldNotEqual, 0)
+			So(achievedSLI, ShouldNotEqual, 0)
+			_, currentGetCount := getLocalMemcachedStats(t)
+			So(currentGetCount, ShouldBeGreaterThan, prevGetCount)
+		})
+		Convey("It shall stress memcached", func() {
+			_, prevGetCount := getLocalMemcachedStats(t)
+			mutilateHandle, err := mutilateLG.Load(10, 10*time.Second)
+			So(err, ShouldBeNil)
+			mutilateHandle.Wait(0)
+			So(mutilateHandle.Status(), ShouldEqual, executor.TERMINATED)
+			exitcode, err := mutilateHandle.ExitCode()
+			So(err, ShouldBeNil)
+			So(exitcode, ShouldEqual, 0)
+
+			if err != nil {
+				t.Fatalf("mutilate didn't stopped correctly err=%q", err)
+			}
+
+			out, err := mutilateHandle.StdoutFile()
+			rawMetrics, err := parse.File(out.Name())
+
+			SoNonZeroMetricExists := func(name string) {
+				v, ok := rawMetrics.Raw[name]
+				So(ok, ShouldBeTrue)
+				So(v, ShouldBeGreaterThan, 0)
+			}
+
+			SoNonZeroMetricExists("qps")
+			SoNonZeroMetricExists("avg")
+			SoNonZeroMetricExists("std")
+			SoNonZeroMetricExists("min")
+			SoNonZeroMetricExists("percentile/99th")
+			SoNonZeroMetricExists("percentile/custom")
+
+			if err := mutilateHandle.EraseOutput(); err != nil {
+				t.Fatal(err)
+
+			}
+			_, currGetCount := getLocalMemcachedStats(t)
+			So(currGetCount, ShouldBeGreaterThan, prevGetCount)
+		})
+	})
+}

--- a/misc/dev/vagrant/multinode/.gitignore
+++ b/misc/dev/vagrant/multinode/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/misc/dev/vagrant/multinode/README.md
+++ b/misc/dev/vagrant/multinode/README.md
@@ -1,0 +1,13 @@
+# Local multi-node development using Vagrant and Virtualbox
+
+Please refer to the ../singleton/README.md for neccessary information about
+setting up and troubleshoting vagrants.
+
+This configuration will set 4 vagrants. Primary is 'swan' is the same as for the
+singleton. Additional 3 vagrants are only for mutilate agent thus they have
+only 512 MB of RAM configured.
+
+It's important to notice that mutilate master and first agent shall be at
+10.141.141.20, the second agent at 10.141.141.21, third at 10.141.141.22.
+To all hosts access is via root account with 'vagrant' password.
+

--- a/misc/dev/vagrant/multinode/Vagrantfile
+++ b/misc/dev/vagrant/multinode/Vagrantfile
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# q -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+#Scripts used in provisioning.
+  $install_packages = <<SCRIPT
+    echo Adding the docker yum repository
+    tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+    echo Updating package lists
+    yum update -y
+    yum install -y epel-release  # Enables EPEL repo
+    yum clean all
+    echo Installing packages
+    yum install -y \
+      docker-engine \
+      etcd \
+      gcc-g++ \
+      gengetopt \
+      git \
+      iptables \
+      libcgroup-tools \
+      libevent-devel \
+      moreutils-parallel \
+      nmap-ncat \
+      perf \
+      psmisc \
+      pssh \
+      python-pip \
+      python-devel \
+      scons \
+      tree \
+      vim \
+      wget \
+      cppzmq-devel 
+    . $HOME_DIR/go/src/github.com/intelsdi-x/swan/workloads/deep_learning/caffe/caffe_deps_centos.sh
+    if [ ! -f /tmp/go1.6.linux-amd64.tar.gz ]; then
+      wget -P /tmp https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz
+      tar xvf /tmp/go1.6.linux-amd64.tar.gz -C /usr/local
+    fi
+SCRIPT
+
+  $configure_etcd = <<SCRIPT
+    echo Configuring etcd
+    systemctl enable etcd
+    systemctl restart etcd
+SCRIPT
+
+  $configure_docker = <<SCRIPT
+    echo Configuring Docker
+    systemctl enable docker
+    # Add the vagrant user to the docker group
+    gpasswd -a $VAGRANT_USER docker
+    systemctl restart docker
+SCRIPT
+
+  $setup_user_env = <<SCRIPT
+    echo "Setting up user environment"
+    # Vagrant user owns $GOPATH
+    chown -R $VAGRANT_USER:$VAGRANT_USER $HOME_DIR/go
+    # Create convenient symlinks in the home directory
+    ln -sf $HOME_DIR/go/src/github.com/intelsdi-x/swan $HOME_DIR
+    # Add GOPATH and Go binaries to PATH in profile
+    echo "export GOPATH=\"$HOME_DIR/go\"" >> $HOME_DIR/.bash_profile
+    echo 'export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"' >> $HOME_DIR/.bash_profile
+    # Add key to SSH agent
+    #ssh-add -l
+    # Rewrite github URLs for fetching private repos
+    sudo -u $VAGRANT_USER git config --global url."git@github.com:".insteadOf "https://github.com/"
+SCRIPT
+  
+  $setup_for_aggressors = <<SCRIPT
+  echo "Setting up access for aggressors agents"
+  echo "Enabling root login"
+  echo PermitRootLogin yes >> /etc/ssh/sshd_config
+  systemctl restart sshd
+  echo "Changing root password to 'vagrant'"
+  echo -e "vagrant\nvagrant\n" | passwd --stdin root
+SCRIPT
+
+  $configure_cassandra = <<SCRIPT
+    echo "Setting up cassandra"
+    # Set up data directory
+    mkdir -p /var/data/cassandra
+    chcon -Rt svirt_sandbox_file_t /var/data/cassandra # SELinux policy
+    # Create and enable systemd unit
+    cp $HOME_DIR/swan/misc/dev/vagrant/singlenode/resources/cassandra.service /usr/lib/systemd/system/
+    mkdir -p /opt/swan/resources
+    cp $HOME_DIR/swan/misc/dev/vagrant/singlenode/resources/keyspace.cql /opt/swan/resources
+    cp $HOME_DIR/swan/misc/dev/vagrant/singlenode/resources/table.cql /opt/swan/resources
+    systemctl daemon-reload
+    systemctl enable cassandra.service
+    systemctl restart cassandra.service
+SCRIPT
+
+
+  #defined virtual machines
+  vms = [
+    {
+      :name => "aggressor1",
+      :eth => "10.141.141.20"
+    },
+    {
+      :name => "aggressor2",
+      :eth => "10.141.141.21"
+    },
+    {
+      :name => "aggressor3",
+      :eth => "10.141.141.22"
+    }
+  ]
+
+  # All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+
+  vagrant_user=ENV['VAGRANT_USER'] || 'vagrant'
+  # if this env is set, it means that we are not building
+  # out a full image, but just bringing up an image with
+  # some of the dependencies installed on it. This is being
+  # used to cache dependencies on an AMI.
+  only_cache_dependencies=(ENV['BUILD_CACHED_IMAGE'] && ENV['BUILD_CACHED_IMAGE'] != '') || false
+
+  # SSH agent forwarding (for host private keys)
+  config.ssh.forward_agent = true
+
+  config.vm.box = "centos/7"
+  config.vm.box_check_update = false
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  if ! only_cache_dependencies
+    home_dir = vagrant_user == 'root' ? '/root/' : "/home/#{vagrant_user}"
+    config.vm.synced_folder "../../../..", "#{home_dir}/go/src/github.com/intelsdi-x/swan", :mount_options => ["umask=0022,dmask=0022,fmask=0022"]
+  end
+
+  config.vm.provider :aws do |aws, override|
+    require 'yaml'
+    # load a file at this location that can be used to set aws specific
+    # information. This allows you to set your own credentials, but also
+    # custom what ami the job runs on.
+    file = "#{ENV['HOME']}/.vagrant/aws-creds"
+    if File.exists?(file)
+      data = YAML.load_file(file)
+    else
+      data = {}
+    end
+    override.nfs.functional = false
+    aws.access_key_id = data['access_key_id']
+    aws.secret_access_key = data['secret_access_key']
+    override.vm.box = "aws"
+    # requiretty cannot be set in sudoers for vagrant to work
+    aws.user_data = "#!/bin/bash\nsed -i 's/Defaults    requiretty/#Defaults    requiretty/' /etc/sudoers"
+    # centos7 for us-east
+    aws.ami = (only_cache_dependencies && data['base_ami']) || data['ami'] || "ami-6d1c2007"
+    aws.keypair_name = data['keypair_name'] || "snapbot-private"
+    aws.instance_type = data['instance_type'] || "m3.medium"
+    override.ssh.username = data['ssh_username'] || "centos"
+    override.ssh.private_key_path = data['ssh_private_key_path'] || nil
+    override.ssh.keys_only = data['keys_only'] || true
+  end
+
+
+  #Default VM - Swan
+  config.vm.define "swan", primary: true do |config|
+    config.vm.hostname = "swan"
+    config.vm.network "private_network", ip: "10.141.141.10"
+    config.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.cpus = 2       # NOTE: integration tests fail with less than 2
+      vb.memory = 4096  # NOTE: integration tests tend to crash with less (gcc)
+    end
+
+    config.vm.provision "shell", inline: $install_packages, env: {'HOME_DIR' => home_dir}
+    config.vm.provision "shell", inline: $configure_etcd, env: {'HOME_DIR' => home_dir}
+    if ! only_cache_dependencies
+      config.vm.provision "shell", inline: $configure_docker, env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+      config.vm.provision "shell", inline: $setup_user_env, env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+      config.vm.provision "shell", inline: $configure_cassandra, env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+    end
+  end
+  # Aggressors - use the same shared folder. They just use mutilated (as agent)
+  vms.each do |opts|
+    config.vm.define opts[:name] do |config|
+      config.vm.hostname = opts[:name]
+      config.vm.network "private_network", ip: opts[:eth]
+      config.vm.provider "virtualbox" do |vb|
+        vb.gui = false
+        vb.cpus = 1
+        vb.memory = 512
+      end
+      config.vm.provision "shell", inline: $install_packages, env: {'HOME_DIR' => home_dir}
+      if ! only_cache_dependencies
+        config.vm.provision "shell", inline: $setup_user_env, env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+      end
+      config.vm.provision "shell", inline: $setup_for_aggressors, env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+    end
+  end
+
+end

--- a/misc/dev/vagrant/multinode/resources/cassandra.service
+++ b/misc/dev/vagrant/multinode/resources/cassandra.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Apache Cassandra
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker rm -f cassandra-swan
+ExecStartPre=/usr/bin/docker pull cassandra:3.5
+ExecStart=/usr/bin/docker run \
+  --name cassandra-swan \
+  --net host \
+  -e CASSANDRA_LISTEN_ADDRESS=127.0.0.1 \
+  -e CASSANDRA_CLUSTER_NAME=cassandra-swan \
+  -v /var/data/cassandra:/var/lib/cassandra \
+  cassandra:3.5
+ExecStartPost=/usr/bin/docker run \
+  --rm \
+  --net host \
+  cassandra:3.5 \
+  bash -c 'while ! echo "show host" | cqlsh localhost ; do sleep 1; done'
+ExecStartPost=/usr/bin/docker run \
+  --rm \
+  --net host \
+  -v /opt/swan/resources:/resources \
+  cassandra:3.5 \
+  cqlsh localhost --file /resources/keyspace.cql
+ExecStartPost=/usr/bin/docker run \
+  --rm \
+  --net host \
+  -v /opt/swan/resources:/resources \
+  cassandra:3.5 \
+  cqlsh localhost --file /resources/table.cql
+[Install]
+WantedBy=multi-user.target

--- a/misc/dev/vagrant/multinode/resources/keyspace.cql
+++ b/misc/dev/vagrant/multinode/resources/keyspace.cql
@@ -1,0 +1,2 @@
+CREATE KEYSPACE IF NOT EXISTS snap WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+DESCRIBE KEYSPACES;

--- a/misc/dev/vagrant/multinode/resources/table.cql
+++ b/misc/dev/vagrant/multinode/resources/table.cql
@@ -1,0 +1,14 @@
+// https://github.com/intelsdi-x/snap-plugin-publisher-cassandra#plugin-database-schema
+CREATE TABLE IF NOT EXISTS snap.metrics (
+    ns  text, 
+    ver int, 
+    host text, 
+    time timestamp, 
+    valtype text,
+    doubleVal double, 
+    boolVal boolean,
+    strVal text,
+    tags map<text,text>, 
+    PRIMARY KEY ((ns, ver, host), time)
+) WITH CLUSTERING ORDER BY (time DESC);
+DESCRIBE snap.metrics;


### PR DESCRIPTION
This commit adds integration tests for multinode mutilate launcher.
Scope of the test is to check: Populate(), Tune() and Load() with 3 remote mutilate agents.

To be able to run tests 4 vagrant instances needs to be launched.
Additional 3 vagrant to the original one are needed for mutilate agents.

Additional swan/misc/dev/vagrant/multinode directory with prepared
configuration was added

Testing was local on development machine with 4 vagrant instances.
Before running full integration tests infrastructure needs to be changed to provide 4 configured VMs. 

Signed-off-by: Maciej Patelczyk maciej.patelczyk@intel.com
