### PR TITLE
Allow ami and instance type env vars

### DIFF
--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -59,9 +59,9 @@ Vagrant.configure(2) do |config|
     # requiretty cannot be set in sudoers for vagrant to work
     aws.user_data = "#!/bin/bash\nsed -i 's/Defaults    requiretty/#Defaults    requiretty/' /etc/sudoers"
     # centos7 for us-east
-    aws.ami = (only_cache_dependencies && data['base_ami']) || data['ami'] || "ami-6d1c2007"
+    aws.ami = (ENV['SWAN_AMI'] != '' && ENV['SWAN_AMI']) || data['ami'] || "ami-6d1c2007"
+    aws.instance_type = (ENV['SWAN_INSTANCE_TYPE'] != '' && ENV['SWAN_INSTANCE_TYPE']) || data['instance_type'] || "m3.medium"
     aws.keypair_name = data['keypair_name'] || "snapbot-private"
-    aws.instance_type = data['instance_type'] || "m3.medium"
     override.ssh.username = data['ssh_username'] || "centos"
     override.ssh.private_key_path = data['ssh_private_key_path'] || nil
     override.ssh.keys_only = data['keys_only'] || true


### PR DESCRIPTION
Fixes issue ...

This is part of the feature: https://intelsdi.atlassian.net/browse/KOP-135

Allows for environment variables to override
the ami and instance type used and give
these environment variables the highest precedence.

This is to allow us to perform builds from the
Jenknis GUI where we set these variables.

The SWAN_AMI variable is intended to support
building out an AMI snapshot from any given
AMI ID.
