### PR TITLE
SCE-592: Integration test fails in TestParallel

### DIFF
--- a/integration_tests/pkg/executor/parallel_test.go
+++ b/integration_tests/pkg/executor/parallel_test.go
@@ -26,9 +26,9 @@ func TestParallel(t *testing.T) {
 		Convey("Process should be executed 5 times", func() {
 			cmdStr := fmt.Sprintf("tailf %s", file.Name())
 			task, err := parallel.Execute(cmdStr)
-			defer task.Stop()
-			defer task.Clean()
 			defer task.EraseOutput()
+			defer task.Clean()
+			defer task.Stop()
 
 			So(err, ShouldBeNil)
 			So(task, ShouldNotBeNil)


### PR DESCRIPTION
Fixes issue SCE-592

Summary of changes:
TestParallel was affected by K8s's integration tests, because they are in the same package and Golang is running them parallel. TestParallel was running `sleep` via `parallel` for test purposes and looking for them in following assertions with `pgrep`. It's working fine, when TestParallel is exclusively running `sleep`. When K8s's integration tests is running also `sleep` few times in the same time, `TestParallel` was able to see it's `sleep`s and fails assertions.

I'm creating now temporary file and I'm running `tailf` on them.

Testing done:
- 2x integration tests on Kopernik CI
- multiple times running TestParallel on vagrant locally
