### PR TITLE
SCE-483 - preparing mutilate parser to be used in Serenity

### DIFF
--- a/misc/snap-plugin-collector-mutilate/mutilate/parse/parse.go
+++ b/misc/snap-plugin-collector-mutilate/mutilate/parse/parse.go
@@ -57,19 +57,12 @@ func File(path string) (Results, error) {
 	return Parse(file)
 }
 
-// OpenedFile parse the file from given file handle and gather all metrics
-// including (custom percentile). It leaves the responsibilities of this handler to the caller.
-// NOTE: Public to allow use it without snap infrastructure.
-func OpenedFile(file *os.File) (Results, error) {
-	return Parse(file)
-}
-
 // Parse retrieves latency metrics from mutilate output. Following format is expected:
 // #type       avg     std     min     5th    10th    90th    95th    99th
 // read      109.6   231.8    17.4    49.4    55.9   137.2   216.1   916.0
-func Parse(file io.Reader) (Results, error) {
+func Parse(reader io.Reader) (Results, error) {
 	metrics := newResults()
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			return newResults(), err

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -242,7 +242,7 @@ func (m mutilate) Populate() (err error) {
 }
 
 func (m mutilate) getQPSAndLatencyFrom(stdoutFile *os.File) (qps int, achievedSLI int, err error) {
-	results, err := parse.OpenedFile(stdoutFile)
+	results, err := parse.Parse(stdoutFile)
 	if err != nil {
 		return qps, achievedSLI, errors.Wrap(err, "could not retrieve QPS from Mutilate Tune output")
 	}


### PR DESCRIPTION
Fixes issue SCE-483, to some extent

Summary of changes:
- exporting Parse() function so it can be used outside its original package
- depending on interface rather then implementation so we can pass any `io.Reader`.

Testing done:
- existing tests pass
