### PR TITLE
SCE-483 - unifying mutilate output by fixing header

### DIFF
--- a/workloads/data_caching/memcached/mutilate/mutilate.cc
+++ b/workloads/data_caching/memcached/mutilate/mutilate.cc
@@ -557,7 +557,7 @@ int main(int argc, char **argv) {
     int step = atoi(step_ptr);
 
     printf("%-7s %7s %7s %7s %7s %7s %7s %7s %7s %8s %8s\n",
-           "#type", "avg", "min", "1st", "5th", "10th",
+           "#type", "avg", "std", "min", "5th", "10th",
            "90th", "95th", "99th", "QPS", "target");
 
     for (int q = min; q <= max; q += step) {


### PR DESCRIPTION
Fixes issue SCE-438, to some extent

Summary of changes:
- `--qps` and `--scan` use the same sampler anyway
- fixed `--scan` header to reflect what is really being displayed

Testing done:
- all builds should pass.
