### PR TITLE
SCE-455 [1/2]: k8s based experiment: k8s configuration privlieged containers configuration with flag

### DIFF
--- a/pkg/kubernetes/commands.go
+++ b/pkg/kubernetes/commands.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+
 	"github.com/intelsdi-x/swan/pkg/executor"
 )
 
@@ -10,7 +11,7 @@ func getKubeAPIServerCommand(config Config) string {
 	return fmt.Sprint(
 		fmt.Sprintf("%s", config.PathToKubeAPIServer),
 		fmt.Sprintf(" --v=%d", config.LogLevel),
-		fmt.Sprintf(" --allow-privileged=false"), // Privileged containers are not allowed.
+		fmt.Sprintf(" --allow-privileged=%v", config.AllowPrivileged),
 		fmt.Sprintf(" --etcd-servers=%s", config.ETCDServers),
 		fmt.Sprintf(" --insecure-bind-address=0.0.0.0"),
 		fmt.Sprintf(" --insecure-port=%d", config.KubeAPIPort),
@@ -48,7 +49,7 @@ func getKubeSchedulerCommand(kubeAPIAddr executor.TaskHandle, config Config) str
 func getKubeletCommand(kubeAPIAddr executor.TaskHandle, config Config) string {
 	return fmt.Sprint(
 		fmt.Sprintf("%s", config.PathToKubelet),
-		fmt.Sprintf(" --allow-privileged=false"), // Privileged containers are not allowed.
+		fmt.Sprintf(" --allow-privileged=%v", config.AllowPrivileged),
 		fmt.Sprintf(" --v=%d", config.LogLevel),
 		fmt.Sprintf(" --address=0.0.0.0"),
 		fmt.Sprintf(" --port=%d", config.KubeletPort),

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -2,13 +2,14 @@ package kubernetes
 
 import (
 	"fmt"
+	"path"
+	"time"
+
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
 	"github.com/intelsdi-x/swan/pkg/utils/netutil"
 	"github.com/pkg/errors"
-	"path"
-	"time"
 )
 
 const serviceListenTimeout = 5 * time.Second
@@ -22,6 +23,7 @@ var (
 	pathKubeSchedulerFlag  = conf.NewFileFlag("kube_scheduler_path", "Path to kube-scheduler binary", path.Join(fs.GetSwanBinPath(), "kube-scheduler"))
 	kubeletArgsFlag        = conf.NewStringFlag("kubelet_args", "Additional args for kubelet binary.", "")
 	logLevelFlag           = conf.NewIntFlag("kube_loglevel", "Log level for kubernetes servers", 0)
+	allowPrivilegedFlag    = conf.NewBoolFlag("kube_allow_privileged", "Allow containers to request privileged mode on cluster and node level (api server and kubelete ).", false)
 )
 
 // Config contains all data for running kubernetes master & kubelet.
@@ -35,12 +37,13 @@ type Config struct {
 	// TODO(bp): Consider exposing these via flags (SCE-547)
 	// Comma separated list of nodes in the etcd cluster
 	ETCDServers        string
-	LogLevel           int // 0 is debug.
+	LogLevel           int // 0 is info, 4 - debug (https://github.com/kubernetes/kubernetes/blob/master/docs/devel/logging.md).
 	KubeAPIPort        int
 	KubeControllerPort int
 	KubeSchedulerPort  int
 	KubeProxyPort      int
 	KubeletPort        int
+	AllowPrivileged    bool // Defaults to false.
 	// Address range to use for services.
 	ServiceAddresses string
 
@@ -62,6 +65,7 @@ func DefaultConfig() Config {
 		PathToKubelet:        pathKubeletFlag.Value(),
 		ETCDServers:          "http://127.0.0.1:2379",
 		LogLevel:             logLevelFlag.Value(),
+		AllowPrivileged:      allowPrivilegedFlag.Value(),
 		KubeAPIPort:          8080,
 		KubeletPort:          10250,
 		KubeControllerPort:   10252,

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -3,14 +3,15 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
-	"github.com/intelsdi-x/swan/pkg/executor/mocks"
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/intelsdi-x/swan/pkg/executor/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
 var serviceNames = []string{
@@ -64,6 +65,22 @@ func (s *KubernetesTestSuite) TestKubernetesLauncher() {
 			for _, mTaskHandle := range s.mTaskHandles {
 				So(mTaskHandle.AssertExpectations(s.T()), ShouldBeTrue)
 			}
+		})
+	})
+
+	Convey("Check configuration privileged flag", s.T(), func() {
+		config := DefaultConfig()
+		handle := &mocks.TaskHandle{}
+		handle.On("Address").Return("127.0.0.1")
+		Convey("default disallow run privileged containers", func() {
+			So(getKubeAPIServerCommand(config), ShouldContainSubstring, "--allow-privileged=false")
+			So(getKubeletCommand(handle, config), ShouldContainSubstring, "--allow-privileged=false")
+
+		})
+		Convey("but can be changed to allow.", func() {
+			config.AllowPrivileged = true
+			So(getKubeAPIServerCommand(config), ShouldContainSubstring, "--allow-privileged=true")
+			So(getKubeletCommand(handle, config), ShouldContainSubstring, "--allow-privileged=true")
 		})
 	})
 }


### PR DESCRIPTION
Fixes issue SCE-455 (cannot run memcached in unprivileged mode - don't know why yet) 

Summary of changes:
- ability to pass flag when setting up k8s cluster is it allowed to start privileged containers

Testing done:
- unit tests for configuration
