### PR TITLE
SCE-615: Local executor doesn't cleanup output files when Execute() fails

### DIFF
--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -250,7 +250,7 @@ func (taskHandle *localTaskHandle) EraseOutput() error {
 // eraseOutput requires only one file from stdout and stderr files. It's looking for parent dir and remove it.
 func eraseOutput(outputFile *os.File) error {
 	// Remove temporary directory created for stdout and stderr.
-	if outputFile != nil {
+	if outputFile == nil {
 		return nil
 	}
 	outputDir := filepath.Dir(outputFile.Name())


### PR DESCRIPTION
Fixes issue SCE-615

Summary of changes:
- Local executor is now secured with removing output files when command fails 

Testing done:
- /
