### PR TITLE
SCE-455 [2/3]: k8s executor: own image name, privileged containers and host networking

### DIFF
--- a/pkg/executor/kubernetes_test.go
+++ b/pkg/executor/kubernetes_test.go
@@ -1,0 +1,16 @@
+package executor
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestKubernetes(t *testing.T) {
+	Convey("Kubernetes config is sane by default", t, func() {
+		config := DefaultKubernetesConfig()
+		So(config.Privileged, ShouldEqual, false)
+		So(config.HostNetwork, ShouldEqual, false)
+		So(config.ContainerImage, ShouldEqual, defaultContainerImage)
+	})
+}


### PR DESCRIPTION
Fixes issue depedencies to be able to run experiment on k8s.

Summary of changes:
- ability to start container in privileged mode
- one can start conatiner in host network mode
- default conatiner image as const

Testing done:
- unit test for creating default configuration 
- manually with experiment that requires hostnetwork/privilege for hp memcache job
