### PR TITLE
SCE-609: Remove output files from TestRemoteProcessPidIsolation

### DIFF
--- a/integration_tests/pkg/executor/remote_test.go
+++ b/integration_tests/pkg/executor/remote_test.go
@@ -74,6 +74,11 @@ func testRemoteProcessPidIsolation() {
 
 	Convey("I should be able to execute remote command and see the processes running", func() {
 		task, err := launcher.Launch()
+		defer func() {
+			task.Stop()
+			task.Clean()
+			task.EraseOutput()
+		}()
 
 		client, err := ssh.Dial("tcp", os.Getenv(EnvHost)+":22", sshConfig.ClientConfig)
 		So(err, ShouldBeNil)
@@ -88,9 +93,6 @@ func testRemoteProcessPidIsolation() {
 				So(err, ShouldBeNil)
 				soProcessIsNotRunning(client, pids[0])
 				soProcessIsNotRunning(client, pids[1])
-
-				So(task.Clean(), ShouldBeNil)
-				So(task.EraseOutput(), ShouldBeNil)
 			})
 	})
 


### PR DESCRIPTION
Fixes issue SCE-609

Summary of changes:
- Remove output when test is ending

Testing done:
- /
