### PR TITLE
SCE-629: new flag for check dir exists

### DIFF
--- a/pkg/conf/flag.go
+++ b/pkg/conf/flag.go
@@ -67,6 +67,23 @@ func NewFileFlag(flagName string, description string, defaultValue string) Strin
 	return strFlag
 }
 
+// NewDirFlag is a constructor of StringFlag struct which checks if dir exists.
+func NewDirFlag(flagName string, description string, defaultValue string) StringFlag {
+	strFlag := StringFlag{
+		flag: flag{
+			name:        flagName,
+			description: description,
+		},
+		defaultValue: defaultValue,
+	}
+
+	strFlag.value = app.Flag(flagName, description).
+		Default(defaultValue).OverrideDefaultFromEnvar(strFlag.envName()).ExistingDir()
+	isEnvParsed = false
+
+	return strFlag
+}
+
 // Value returns value of defined flag after parse.
 // NOTE: If conf is not parsed it returns default value (!)
 func (s StringFlag) Value() string {

--- a/pkg/snap/plugin_loader.go
+++ b/pkg/snap/plugin_loader.go
@@ -32,7 +32,7 @@ var (
 	defaultPluginsPath = path.Join(goPath, "bin")
 
 	snapdAddress = conf.NewStringFlag("snapd_address", "Address to snapd in `http://%s:%s` format", "http://127.0.0.1:8181")
-	pluginsPath  = conf.NewFileFlag("snap_plugins_path", "Path to Snap Plugins directory", defaultPluginsPath)
+	pluginsPath  = conf.NewDirFlag("snap_plugins_path", "Path to Snap Plugins directory", defaultPluginsPath)
 )
 
 // DefaultPluginLoaderConfig returns default config for PluginLoader.


### PR DESCRIPTION
Fixes issue SCE-629
Summary of changes:
-  new dir flag
-  use it in a snap dir

Testing done:
- integration tests & run experiments
