### PR TITLE
fmt placeholders fix for validators

### DIFF
--- a/experiments/memcached-sensitivity-profile/validate.go
+++ b/experiments/memcached-sensitivity-profile/validate.go
@@ -61,7 +61,7 @@ func checkCPUPowerGovernor() {
 // The name NOFILE is based on "limits.conf" and definition from setrlimit.
 func checkNOFILE(nofile, minimum int) {
 	if nofile <= minimum {
-		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d). You can change this value eg. ulimit -n %d or modifying /etc/security/limits.conf.", nofile, minimum)
+		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d). You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.", nofile, minimum)
 	}
 
 }


### PR DESCRIPTION
Fixes issue "warning about ulimit is printed with garbage!" 

``` sh
WARN[] .... ulimit should be set to with command ulimint -n (!nil)%d or in securlity/limits.conf ...
```

Summary of changes:
- removed unnecessary placeholder from printf

Testing done:
- manually
