### PR TITLE
SCE-632: NewStringFlag for aggressors and HP task

### DIFF
--- a/pkg/workloads/low_level/l1data/l1data.go
+++ b/pkg/workloads/low_level/l1data/l1data.go
@@ -18,7 +18,7 @@ const (
 )
 
 // PathFlag represents l1 data path flag.
-var PathFlag = conf.NewFileFlag(
+var PathFlag = conf.NewStringFlag(
 	"l1d_path",
 	"Path to L1 Data binary",
 	path.Join(fs.GetSwanWorkloadsPath(), "low-level-aggressors/l1d"),

--- a/pkg/workloads/low_level/l1instruction/l1instruction.go
+++ b/pkg/workloads/low_level/l1instruction/l1instruction.go
@@ -28,7 +28,7 @@ const (
 )
 
 // PathFlag represents l1i path flag.
-var PathFlag = conf.NewFileFlag(
+var PathFlag = conf.NewStringFlag(
 	"l1i_path",
 	"Path to L1 instruction binary",
 	path.Join(fs.GetSwanWorkloadsPath(), "low-level-aggressors/l1i"),

--- a/pkg/workloads/low_level/l3data/l3data.go
+++ b/pkg/workloads/low_level/l3data/l3data.go
@@ -19,7 +19,7 @@ const (
 )
 
 // PathFlag represents l3data path flag.
-var PathFlag = conf.NewFileFlag(
+var PathFlag = conf.NewStringFlag(
 	"l3_path",
 	"Path to L3 Data binary",
 	path.Join(fs.GetSwanWorkloadsPath(), "low-level-aggressors/l3"),

--- a/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
+++ b/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
@@ -19,7 +19,7 @@ const (
 )
 
 // PathFlag represents l3data path flag.
-var PathFlag = conf.NewFileFlag(
+var PathFlag = conf.NewStringFlag(
 	"membw_path",
 	"Path to Memory Bandwidth binary",
 	path.Join(fs.GetSwanWorkloadsPath(), "low-level-aggressors/memBw"),

--- a/pkg/workloads/memcached/memcached.go
+++ b/pkg/workloads/memcached/memcached.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	pathFlag = conf.NewFileFlag("memcached_path", "Path to memcached binary",
+	pathFlag = conf.NewStringFlag("memcached_path", "Path to memcached binary",
 		path.Join(fs.GetSwanWorkloadsPath(), "data_caching/memcached/memcached-1.4.25/build/memcached"))
 	// PortFlag returns port which will be specified for workload services as endpoints.
 	PortFlag = conf.NewIntFlag("memcached_port", "Port for memcached to listen on. (-p)", defaultPort)


### PR DESCRIPTION
Fixes issue : SCE-632

Summary of changes:
- NewStringFlag for aggressors and HP task
- NewFileFlag mainly for check local binaries (mutilate and k8s services)

Testing done:
- run experiment with aggressors inside an docker on k8s

Paths can be override from env variable inside in a docker. Disable
evaluation flag on a host during experiment starts.
