### PR TITLE
SCE-633: stop helper function for shutting down k8s cluster

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -158,9 +158,7 @@ func (k8s *kubernetes) Execute(command string) (TaskHandle, error) {
 		// TODO(skonefal): We don't have stdout & stderr when pod fails.
 		exitCode, err := taskHandle.ExitCode()
 		if err != nil || exitCode != 0 {
-			defer taskHandle.EraseOutput()
-			defer taskHandle.Clean()
-			defer taskHandle.Stop()
+			defer StopCleanAndErase(taskHandle)
 
 			LogUnsucessfulExecution(command, k8s.Name(), taskHandle)
 			return nil, errors.Errorf(

--- a/pkg/executor/task_handle.go
+++ b/pkg/executor/task_handle.go
@@ -3,6 +3,8 @@ package executor
 import (
 	"os"
 	"time"
+
+	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 )
 
 // TaskState is an enum presenting current task state.
@@ -48,4 +50,13 @@ type TaskControl interface {
 	Clean() error
 	// EraseOutput removes task's stdout & stderr files.
 	EraseOutput() error
+}
+
+// StopCleanAndErase run stop, clean and eraseOutput on taskHandle and add errors to errorCollection
+func StopCleanAndErase(handle TaskHandle) (errorCollection errcollection.ErrorCollection) {
+	errorCollection.Add(handle.Stop())
+	errorCollection.Add(handle.Clean())
+	errorCollection.Add(handle.EraseOutput())
+
+	return
 }


### PR DESCRIPTION
Fixes issue : SCE-633

Summary of changes:
- new method for start k8s cluster
- stop method with step in check errors

Testing done:
- start/stop k8s cluster

Facades methods for start, clean and erase output during start
swan experiment.
