### PR TITLE
SCE-455: hp and be task on kubernetes cluster V2

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/kubernetes"
 	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
@@ -30,6 +31,7 @@ var (
 	mutilateAgentsFlag = conf.NewSliceFlag(
 		"mutilate_agent",
 		"Mutilate agent hosts for remote executor. Can be specified many times for multiple agents setup.")
+	runOnKubernetesFlag = conf.NewBoolFlag("run_on_kubernetes", "Launch HP and BE tasks on Kubernetes.", false)
 
 	mutilateMasterFlagDefault = "local"
 )
@@ -68,6 +70,14 @@ func isManualPolicy() bool {
 	return hpSetsFlag.Value() != "" && beSetsFlag.Value() != ""
 }
 
+// DecoratorFunc is a dummy decorator as a workaround for a isolation for inside a docker.
+type DecoratorFunc func(string) string
+
+// Decorate wrap method for a command.
+func (df DecoratorFunc) Decorate(command string) string {
+	return df(command)
+}
+
 // Check README.md for details of this experiment.
 func main() {
 	// Setup conf.
@@ -87,26 +97,48 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	// TODO: needs update for different isolation per cpu
 	var hpIsolation, beIsolation, l1Isolation, llcIsolation isolation.Isolation
 	var aggressorFactory sensitivity.AggressorFactory
-	if isManualPolicy() {
-		hpIsolation, beIsolation = manualPolicy()
-		aggressorFactory = sensitivity.NewSingleIsolationAggressorFactory(beIsolation)
-		defer beIsolation.Clean()
+
+	if runOnKubernetesFlag.Value() {
+		var dummyIsolation DecoratorFunc = func(s string) string { return s }
+		aggressorFactory = sensitivity.NewSingleIsolationAggressorFactory(dummyIsolation)
+	} else if isManualPolicy() {
+	 	hpIsolation, beIsolation = manualPolicy()
+	 	aggressorFactory = sensitivity.NewSingleIsolationAggressorFactory(beIsolation)
+	 	defer beIsolation.Clean()
+		defer hpIsolation.Clean()
 	} else {
-		// NOTE: Temporary hack for having multiple isolations in Sensitivity Profile.
-		hpIsolation, l1Isolation, llcIsolation = sensitivityProfileIsolationPolicy()
-		aggressorFactory = sensitivity.NewMultiIsolationAggressorFactory(l1Isolation, llcIsolation)
-		defer l1Isolation.Clean()
-		defer llcIsolation.Clean()
+	 	// NOTE: Temporary hack for having multiple isolations in Sensitivity Profile.
+	 	hpIsolation, l1Isolation, llcIsolation = sensitivityProfileIsolationPolicy()
+	 	aggressorFactory = sensitivity.NewMultiIsolationAggressorFactory(l1Isolation, llcIsolation)
+	 	defer l1Isolation.Clean()
+	 	defer llcIsolation.Clean()
+		defer hpIsolation.Clean()
 	}
-	defer hpIsolation.Clean()
 
-	// Initialize Memcached Launcher.
-	localForHP := executor.NewLocalIsolated(hpIsolation)
+	var hpExecutor executor.Executor
+	var err error
+	var memcachedLauncher memcached.Memcached
 	memcachedConfig := memcached.DefaultMemcachedConfig()
-	memcachedLauncher := memcached.New(localForHP, memcachedConfig)
-
-	// Initialize Mutilate Load Generator.
 	mutilateConfig := mutilate.DefaultMutilateConfig()
+
+	if runOnKubernetesFlag.Value() {
+		k8sConfig, err := kubernetes.DefaultConfig()
+		errutil.Check(err)
+		k8sLauncher := kubernetes.New(executor.NewLocal(), executor.NewLocal(), k8sConfig)
+		k8sClusterTaskHandle, err := k8sLauncher.Launch()
+		defer executor.StopCleanAndErase(k8sClusterTaskHandle)
+
+		hpExecutorConfig := executor.DefaultKubernetesConfig()
+		hpExecutorConfig.ContainerImage = "centos_swan_image"
+		hpExecutorConfig.PodName = "swan-hp"
+		hpExecutor, err = executor.NewKubernetes(hpExecutorConfig)
+		errutil.Check(err)
+	} else {
+		hpExecutor = executor.NewLocalIsolated(hpIsolation)
+	}
+
+	memcachedLauncher = memcached.New(hpExecutor, memcachedConfig) // Initialize Memcached Launcher.
+
 	mutilateConfig.MemcachedHost = memcachedConfig.IP
 	mutilateConfig.MemcachedPort = memcachedConfig.Port
 	mutilateConfig.LatencyPercentile = percentileFlag.Value()
@@ -134,6 +166,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 		append(agentsLoadGeneratorExecutors, masterLoadGeneratorExecutor),
 	)
 
+	// Initialize Mutilate Load Generator.
 	mutilateLoadGenerator := mutilate.NewCluster(
 		masterLoadGeneratorExecutor,
 		agentsLoadGeneratorExecutors,
@@ -142,10 +175,10 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	// Initialize aggressors with BE isolation.
 	aggressors := []sensitivity.LauncherSessionPair{}
 	for _, aggressorName := range aggressorsFlag.Value() {
-		aggressor, err := aggressorFactory.Create(aggressorName)
+		aggressor, err := aggressorFactory.Create(aggressorName, runOnKubernetesFlag.Value())
 		errutil.Check(err)
 
-		aggressors = append(aggressors, aggressor)
+		aggressors = append(aggressors, sensitivity.NewLauncherWithoutSession(aggressor))
 	}
 
 	// Snap Session for mutilate.
@@ -162,6 +195,6 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	)
 
 	// Run Experiment.
-	err := sensitivityExperiment.Run()
+	err = sensitivityExperiment.Run()
 	errutil.Check(err)
 }

--- a/misc/dev/docker/Dockerfile_centos
+++ b/misc/dev/docker/Dockerfile_centos
@@ -20,6 +20,7 @@ RUN yum install -y epel-release && \
         libcgroup-tools \
         nc \
         numactl \
+        moreutils-parallel \
         scons \
         sudo \
         wget \

--- a/misc/dev/docker/Dockerfile_ubuntu
+++ b/misc/dev/docker/Dockerfile_ubuntu
@@ -20,6 +20,7 @@ RUN apt-get update && \
         libzmq5-dev \
         netcat \
         numactl \
+        moreutils-parallel \
         scons \
         sudo \
         wget && \

--- a/pkg/experiment/sensitivity/factory.go
+++ b/pkg/experiment/sensitivity/factory.go
@@ -4,6 +4,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/utils/errutil"
 	"github.com/intelsdi-x/swan/pkg/workloads/caffe"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1data"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1instruction"
@@ -70,33 +71,28 @@ func NewMultiIsolationAggressorFactory(
 	}
 }
 
-// Create returns aggressor of chosen type with Snap session.
-func (f AggressorFactory) Create(name string) (LauncherSessionPair, error) {
-	var aggressor LauncherSessionPair
+// Create returns aggressor of chosen type.
+func (f AggressorFactory) Create(name string, onK8s bool) (executor.Launcher, error) {
+	var aggressor executor.Launcher
 
-	exec := f.createIsolatedExecutor(name)
+	exec, err := f.createIsolatedExecutor(name, onK8s)
+	errutil.Check(err)
 
 	switch name {
 	case l1data.ID:
-		aggressor = NewLauncherWithoutSession(
-			l1data.New(exec, l1data.DefaultL1dConfig()))
+		aggressor = l1data.New(exec, l1data.DefaultL1dConfig())
 	case l1instruction.ID:
-		aggressor = NewLauncherWithoutSession(
-			l1instruction.New(exec, l1instruction.DefaultL1iConfig()))
+		aggressor = l1instruction.New(exec, l1instruction.DefaultL1iConfig())
 	case memoryBandwidth.ID:
-		aggressor = NewLauncherWithoutSession(
-			memoryBandwidth.New(exec, memoryBandwidth.DefaultMemBwConfig()))
+		aggressor = memoryBandwidth.New(exec, memoryBandwidth.DefaultMemBwConfig())
 	case caffe.ID:
-		aggressor = NewLauncherWithoutSession(
-			caffe.New(exec, caffe.DefaultConfig()))
+		aggressor = caffe.New(exec, caffe.DefaultConfig())
 	case l3data.ID:
-		aggressor = NewLauncherWithoutSession(
-			l3data.New(exec, l3data.DefaultL3Config()))
+		aggressor = l3data.New(exec, l3data.DefaultL3Config())
 	case stream.ID:
-		aggressor = NewLauncherWithoutSession(
-			stream.New(exec, stream.DefaultConfig()))
+		aggressor = stream.New(exec, stream.DefaultConfig())
 	default:
-		return aggressor, errors.Errorf("aggressor %q not found", name)
+		return nil, errors.Errorf("aggressor %q not found", name)
 	}
 
 	return aggressor, nil
@@ -105,27 +101,39 @@ func (f AggressorFactory) Create(name string) (LauncherSessionPair, error) {
 // CreateIsolatedExecutor returns local executor with prepared isolation.
 // L1-Data and L1-Instruction cache aggressor receives l1AggressorIsolation
 // Other aggressors receive otherAggressorIsolation
-func (f AggressorFactory) createIsolatedExecutor(name string) executor.Executor {
+func (f AggressorFactory) createIsolatedExecutor(name string, isRunOnK8s bool) (executor.Executor, error) {
+	// Create specific executor dependent of enviroment.
+	getSpecializedExecutor := func(decorators isolation.Decorators) (executor.Executor, error) {
+		if isRunOnK8s {
+			config := executor.DefaultKubernetesConfig()
+			config.ContainerImage = "centos_swan_image"
+			config.Decorators = decorators
+			config.PodName = "swan-aggr"
+			return executor.NewKubernetes(config)
+		}
+		return executor.NewLocalIsolated(decorators), nil
+	}
+
 	switch name {
 	case l1data.ID:
 		decorators := isolation.Decorators{f.l1AggressorIsolation}
 		if L1dProcessNumber.Value() != 1 {
 			decorators = append(decorators, executor.NewParallel(L1dProcessNumber.Value()))
 		}
-		return executor.NewLocalIsolated(decorators)
+		return getSpecializedExecutor(decorators)
 	case l1instruction.ID:
 		decorators := isolation.Decorators{f.l1AggressorIsolation}
 		if L1iProcessNumber.Value() != 1 {
 			decorators = append(decorators, executor.NewParallel(L1iProcessNumber.Value()))
 		}
-		return executor.NewLocalIsolated(decorators)
+		return getSpecializedExecutor(decorators)
 	case l3data.ID:
 		decorators := isolation.Decorators{f.otherAggressorIsolation}
 		if L3ProcessNumber.Value() != 1 {
 			decorators = append(decorators, executor.NewParallel(L3ProcessNumber.Value()))
 		}
-		return executor.NewLocalIsolated(decorators)
+		return getSpecializedExecutor(decorators)
 	default:
-		return executor.NewLocalIsolated(f.otherAggressorIsolation)
+		return getSpecializedExecutor(isolation.Decorators{f.otherAggressorIsolation})
 	}
 }


### PR DESCRIPTION
Fixes issue: SCE-455:

Summary of changes:
- dummy isolator for k8s
- change in factory func
- new flag `run_on_kubernetes`
- add `parallel` to docker images

Testing done:
- exp run manually - with/without k8s on vagrant

(pp) TODOs:
- [x] priviledged - #314 
- [x] nethost with flags - #318 
- [x] snapd directory fix - #324 (cannot start experiment!)
- [x] disable file validation (replace FileFlag with StringFlag) - "SWAN_PATH idea" or hardcode hp/aggrs paths in experiments cosidering --kubernetes_hp_be flag - #329 
- [x] k8s is stopped after experiment - #330 

follow up PR:
- [ ] refactor aggressor factor to accept ExecutorCreateFunc - SCE-658
- [ ] isolations (with numactl instead of cgroups/cpusets) (another PR after this) SCE-657
- [ ] add "make centos_swan_image docker" target to Makefile - SCE-656
- [ ] configurable file image name SCE-655
