### PR TITLE
k8s: Default config  not returns error anymore

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -122,10 +122,10 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	mutilateConfig := mutilate.DefaultMutilateConfig()
 
 	if runOnKubernetesFlag.Value() {
-		k8sConfig, err := kubernetes.DefaultConfig()
-		errutil.Check(err)
+		k8sConfig := kubernetes.DefaultConfig()
 		k8sLauncher := kubernetes.New(executor.NewLocal(), executor.NewLocal(), k8sConfig)
 		k8sClusterTaskHandle, err := k8sLauncher.Launch()
+		errutil.Check(err)
 		defer executor.StopCleanAndErase(k8sClusterTaskHandle)
 
 		hpExecutorConfig := executor.DefaultKubernetesConfig()


### PR DESCRIPTION
Fixes issue : wrong Config signature in k8s

Summary of changes:
- fix return signature of `DefaultConfig` in `main.go` experiment

Testing done:
- yes
