### PR TITLE
Added timeout to pod executor

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -177,7 +177,7 @@ func (k8s *kubernetes) Execute(command string) (TaskHandle, error) {
 		return taskHandle, nil
 
 	case <-timeoutChannel:
-		defer taskHandle.StopCleanAndErase()
+		defer StopCleanAndErase(taskHandle)
 
 		LogUnsucessfulExecution(command, k8s.Name(), taskHandle)
 		return nil, errors.Errorf(


### PR DESCRIPTION
Pod startup can be pending forever if there are no available kubelets to run the pod on. This PR adds an optional launch timeout.
