### PR TITLE
SCE-616: mv setupLogs before watch in task handle

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -147,6 +147,7 @@ func (k8s *kubernetes) Execute(command string) (TaskHandle, error) {
 		pod:     pod,
 	}
 
+	taskHandle.setupLogs()
 	taskHandle.watch()
 
 	// NOTE: We should have timeout for the amount of time we want to wait for the pod to appear.
@@ -170,8 +171,6 @@ func (k8s *kubernetes) Execute(command string) (TaskHandle, error) {
 		LogSuccessfulExecution(command, k8s.Name(), taskHandle)
 		return taskHandle, nil
 	}
-
-	taskHandle.setupLogs()
 
 	return taskHandle, nil
 }


### PR DESCRIPTION
Fixes issue: SCE-616
We don't have stdout & stderr of Kubernetes pod when it fails to start

Summary of changes:
- mv method `setupLogs` before `watch`

Testing done:
- yes. integration + manual
