### PR TITLE
clean cached of scons- mutilate can't find zeromq

### DIFF
--- a/workloads/data_caching/memcached/build.sh
+++ b/workloads/data_caching/memcached/build.sh
@@ -7,5 +7,6 @@ id -u memcached &>/dev/null || sudo adduser memcached
 popd
 
 pushd mutilate
+git clean -fdx
 scons
 popd


### PR DESCRIPTION
Fixes issue floating point exception on mutilate

Summary of changes:
- clean mutilate before build

Testing done:
- `mutilate -A` command run
