### PR TITLE
SCE-748: Run aggressors in privileged mode because of unshare

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -183,6 +183,7 @@ func prepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Exec
 			config.ContainerImage = "centos_swan_image"
 			config.Decorators = decorators
 			config.PodName = "swan-aggr"
+			config.Privileged = true // swan aggressor use unshare, which requires sudo.
 			return executor.NewKubernetes(config)
 		}
 	} else {


### PR DESCRIPTION
Fixes issue cannot run parallel on k8s because unshare requires privileged mode.

Summary of changes:
- privileged = true

Testing done:
- manully from serernity
