### PR TITLE
SCE-739 [2/2]: Enable admission-control plugin to "AddTolerance" for HP tasks in kuber…

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -150,6 +150,7 @@ func prepareMutilateGenerator(memcacheIP string, memcachePort int) (executor.Loa
 func prepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Executor, beExecutorFactory sensitivity.ExecutorFactoryFunc, cleanup func(), err error) {
 	if runOnKubernetesFlag.Value() {
 		k8sConfig := kubernetes.DefaultConfig()
+		k8sConfig.KubeAPIArgs = "--admission-control=\"AlwaysAdmit,AddToleration\"" // Enable AddToleration path by default.
 		k8sLauncher := kubernetes.New(executor.NewLocal(), executor.NewLocal(), k8sConfig)
 		k8sClusterTaskHandle, err := k8sLauncher.Launch()
 		if err != nil {


### PR DESCRIPTION
Fixes issue "HP are blocked because the don't get tolerations' with serenity.

Summary of changes:
- enable "AddToleration" plugin by default

Testing done:
- NOT
