### PR TITLE
SCE-728: membw aggressor with parallel decorator

### DIFF
--- a/pkg/experiment/sensitivity/factory.go
+++ b/pkg/experiment/sensitivity/factory.go
@@ -42,7 +42,7 @@ var L3ProcessNumber = conf.NewIntFlag(
 	l3DefaultProcessNumber,
 )
 
-// MembwProcessNumber represents number of L3 data cache aggressor processes to be run
+// MembwProcessNumber represents number of membw aggressor processes to be run
 var MembwProcessNumber = conf.NewIntFlag(
 	"membw_process_number",
 	"Number of membw aggressors to be run",


### PR DESCRIPTION
Fixes issue "cannot see interference with just one membw process"

Summary of changes:
- parallel decorator added if flag says so 

Testing done:
- manually run and can see many processes

```
> ./scripts/isolate-pid.sh memcached-sensitivity-profile --load_points=1 --peak_load=10000 --reps=1 --membw_process_number=2 --snapd_addr="none" --hp_sets=1:0 --mutilate_warmup_time=0s --load_duration=20s --aggr=membw --log=debug

> ps fau

ppalucki  6574  0.0  0.0 113124  1516 pts/1    S+   11:56   0:00  \_ /bin/bash ./scripts/isolate-pid.sh memcached-sensitivity-profile --load_points=1 --peak_load=10000 --reps=1 --membw_process_number=2 --snapd_addr=none --hp_sets=1:0 --mutilate_warmup_time=0s --load_duratio
root      6579  0.0  0.0 193440  2792 pts/1    S+   11:56   0:00      \_ sudo -E unshare --pid --fork --mount-proc /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile --load_points=1 --peak_load=10000 --reps=1 --membw_process_number=2 --snapd_addr=none --hp_sets=1:
root      6580  0.0  0.0 107884   604 pts/1    S+   11:56   0:00          \_ unshare --pid --fork --mount-proc /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile --load_points=1 --peak_load=10000 --reps=1 --membw_process_number=2 --snapd_addr=none --hp_sets=1:0 --
root      6581  0.2  0.0 415092 14568 pts/1    Sl+  11:56   0:00              \_ /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile --load_points=1 --peak_load=10000 --reps=1 --membw_process_number=2 --snapd_addr=none --hp_sets=1:0 --mutilate_warmup_time=0s --load
memcach+  6872 10.6  0.0 318000  4840 pts/1    Sl   11:57   0:00                  \_ /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/workloads/data_caching/memcached/memcached-1.4.25/build/memcached -p 11211 -u memcached -t 4 -m 64 -c 1024
root      6880  0.0  0.0 107884   604 pts/1    S    11:57   0:00                  \_ unshare --fork --pid --mount-proc parallel -j2 sh -c numactl --physcpubind=1 -- /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/workloads/low-level-aggressors/memBw 86400 -- 0 1
root      6882  0.0  0.0   4300   356 pts/1    S    11:57   0:00                      \_ parallel -j2 sh -c numactl --physcpubind=1 -- /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/workloads/low-level-aggressors/memBw 86400 -- 0 1
root      6883 50.8  0.1  59364 33636 pts/1    R    11:57   0:02                          \_ /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/workloads/low-level-aggressors/memBw 86400
root      6884 51.0  0.1  59364 33636 pts/1    R    11:57   0:02                          \_ /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/workloads/low-level-aggressors/memBw 86400

```
