### PR TITLE
Glide update - new athena

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 5985d6bca4d1f94b01cf4d5cf5954c0365b4f19f64cfd713fdf4197c416abb12
-updated: 2016-09-19T15:46:43.905511913+02:00
+updated: 2016-10-04T17:12:02.057633052+02:00
 imports:
 - name: cloud.google.com/go
   version: d1a7c8b8ea705725fb7cc392d923cb7f335e8ae4
@@ -111,7 +111,7 @@ imports:
 - name: github.com/hashicorp/memberlist
   version: 0c5ba075f8520c65572f001331a1a43b756e01d7
 - name: github.com/intelsdi-x/athena
-  version: 64dfccc3c2fa1a2f9863ed81c303804edd7793dc
+  version: 215e1f00c674d566271793c2d1dfa7cb911e0122
   subpackages:
   - integration_tests/test_helpers
   - pkg/conf


### PR DESCRIPTION
Fixes issue 'old athena as dependency'

Summary of changes:
- glide.lock with new athena from master

Testing done:
- yes, make test_lint test_unit
