### PR TITLE
SCE-728 [3/4]: Allow to specify mutilate "--records" flag.

### DIFF
--- a/pkg/workloads/mutilate/commands.go
+++ b/pkg/workloads/mutilate/commands.go
@@ -34,10 +34,11 @@ func getMasterQPSOption(config Config) string {
 
 // getPopulateCommand returns command for master with populate action.
 func getPopulateCommand(config Config) string {
-	return fmt.Sprintf("%s -s %s:%d --loadonly",
+	return fmt.Sprintf("%s -s %s:%d -r %d --loadonly",
 		config.PathToBinary,
 		config.MemcachedHost,
 		config.MemcachedPort,
+		config.Records,
 	)
 }
 
@@ -50,6 +51,7 @@ func getBaseMasterCommand(config Config, agentHandles []executor.TaskHandle) str
 		fmt.Sprintf(" -K %d -V %d", config.KeySize, config.ValueSize),
 		fmt.Sprintf(" -T %d", config.MasterThreads),
 		fmt.Sprintf(" -d %d -c %d", config.AgentConnectionsDepth, config.AgentConnections),
+		fmt.Sprintf(" -r %d", config.Records),
 	)
 
 	if config.MasterAffinity {

--- a/pkg/workloads/mutilate/commands_test.go
+++ b/pkg/workloads/mutilate/commands_test.go
@@ -83,6 +83,7 @@ func (s *MutilateTestSuite) TestGetLoadCommand() {
 	const duration = 10 * time.Second
 
 	s.mutilate.config.MasterQPS = 0
+	s.mutilate.config.Records = 12345
 	command := getLoadCommand(s.mutilate.config, load, duration, []executor.TaskHandle{})
 
 	s.soExpectBaseCommandOptions(command)
@@ -104,6 +105,11 @@ func (s *MutilateTestSuite) TestGetLoadCommand() {
 
 	Convey("Mutilate load command should contain qps option", s.T(), func() {
 		expected := fmt.Sprintf("-q %d", load)
+		So(command, ShouldContainSubstring, expected)
+	})
+
+	Convey("Mutilate load command should contain records option", s.T(), func() {
+		expected := fmt.Sprintf("-r %d", s.mutilate.config.Records)
 		So(command, ShouldContainSubstring, expected)
 	})
 }

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -21,6 +21,7 @@ const (
 	defaultMemcachedHost          = "127.0.0.1"
 	defaultPercentile             = "99"             // TODO: it is not clear if custom values are handled correctly by tune - SCE-443
 	defaultTuningTime             = 10 * time.Second // [s]
+	defaultRecords                = 10000
 	defaultWarmupTime             = 10 * time.Second // [s]
 	defaultAgentThreads           = 8
 	defaultAgentPort              = 5556
@@ -44,6 +45,7 @@ var (
 		path.Join(fs.GetSwanWorkloadsPath(), "data_caching/memcached/mutilate/mutilate"))
 	warmupTimeFlag             = conf.NewDurationFlag("mutilate_warmup_time", "Mutilate warmup time [s] (--warmup).", defaultWarmupTime)
 	tuningTimeFlag             = conf.NewDurationFlag("mutilate_tuning_time", "Mutilate tuning time [s]", defaultTuningTime)
+	recordsFlag                = conf.NewIntFlag("mutilate_records", "Number of memcached records to use (-r).", defaultRecords)
 	agentThreadsFlag           = conf.NewIntFlag("mutilate_agent_threads", "Mutilate agent threads (-T).", defaultAgentThreads)
 	agentAgentPortFlag         = conf.NewIntFlag("mutilate_agent_port", "Mutilate agent port (-P).", defaultAgentPort)
 	agentConnectionsFlag       = conf.NewIntFlag("mutilate_agent_connections", "Mutilate agent connections (-c).", defaultAgentConnections)
@@ -70,6 +72,7 @@ type Config struct {
 	// Mutilate load Parameters
 	TuningTime        time.Duration
 	LatencyPercentile string
+	Records           int
 
 	AgentConnections      int  // -c
 	AgentConnectionsDepth int  // Max length of request pipeline. -d
@@ -109,6 +112,7 @@ func DefaultMutilateConfig() Config {
 		WarmupTime:        warmupTimeFlag.Value(),
 		TuningTime:        tuningTimeFlag.Value(),
 		LatencyPercentile: defaultPercentile,
+		Records:           recordsFlag.Value(),
 
 		AgentThreads:           agentThreadsFlag.Value(),
 		AgentConnections:       agentConnectionsFlag.Value(),

--- a/pkg/workloads/mutilate/mutilate_test.go
+++ b/pkg/workloads/mutilate/mutilate_test.go
@@ -351,7 +351,7 @@ func (s *MutilateTestSuite) TestMutilateLoadExecutorError() {
 
 // Testing successful mutilate populate case.
 func (s *MutilateTestSuite) TestPopulate() {
-	mutilatePopulateCommand := fmt.Sprintf("%s -s %s:%d --loadonly",
+	mutilatePopulateCommand := fmt.Sprintf("%s -s %s:%d -r 0 --loadonly",
 		s.config.PathToBinary,
 		s.config.MemcachedHost,
 		s.config.MemcachedPort,


### PR DESCRIPTION
Fixes issue - memcached is stressed in very limited scope (just 10k keys) and to make memcached more CPU bound, this gives ability to run memcached with eg. 3m keys.

Summary of changes:
- "--records" added to memcached durning load and population (with default to 10k)

Testing done:
- unittests and manually 
