### PR TITLE
Updated vagrantfile to work with new agent version

### DIFF
--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure(2) do |config|
 
   # SSH agent forwarding (for host private keys)
   config.ssh.forward_agent = true
+  config.ssh.keys_only = false
   config.ssh.insert_key = false
   config.vm.box = "centos/7"
   config.vm.box_check_update = false
@@ -74,8 +75,6 @@ Vagrant.configure(2) do |config|
     aws.instance_type = (ENV['SWAN_INSTANCE_TYPE'] != '' && ENV['SWAN_INSTANCE_TYPE']) || data['instance_type'] || "m4.large"
     aws.keypair_name = "snapbot-private"
     override.ssh.username = data['ssh_username'] || "centos"
-    override.ssh.private_key_path = data['ssh_private_key_path'] || nil
-    override.ssh.keys_only = data['keys_only'] || true
   end
 
   config.vm.provision "shell", path: "resources/scripts/copy_configuration.sh", env: {'HOME_DIR' => home_dir}


### PR DESCRIPTION
Adds support for SSH agent support in unit tests

Summary of changes:
- Removes unneeded key config from vagrantfile
- Adds config to use the SSH agent properly

Testing done:
- Integration tests run successfully against new agents

Requires [these](https://github.com/intelsdi-x/docker-kopernik/pull/46) [PRs](https://github.com/intelsdi-x/k8s-kopernik/pull/112) to be merged first.

This is the same as #381 but moved to origin so testing will work properly
