### PR TITLE
KOP-323: Auto delete AWS disks

### DIFF
--- a/misc/dev/vagrant/singlenode/Vagrantfile
+++ b/misc/dev/vagrant/singlenode/Vagrantfile
@@ -62,7 +62,9 @@ Vagrant.configure(2) do |config|
     override.nfs.functional = false
     aws.access_key_id = data['access_key_id']
     aws.secret_access_key = data['secret_access_key']
-    aws.block_device_mapping = [{'DeviceName' => '/dev/sda1', 'Ebs.VolumeSize' => 40}]
+    aws.block_device_mapping = [{'DeviceName' => '/dev/sda1',
+                                 'Ebs.VolumeSize' => 40,
+                                 'Ebs.DeleteOnTermination' => true }]
 
     override.vm.box = "aws"
     # requiretty cannot be set in sudoers for vagrant to work


### PR DESCRIPTION
Fixes issue :
 AWS ESB Volumes not deleted automatically after VM termination.
