### PR TITLE
Fixing linter issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ test_all: test_lint test_unit test_integration
 
 # deps not covered by "vendor" folder (testing/developing env) rather than application (excluding convey)
 deps_godeps:
-	go get github.com/golang/lint/golint
-	go get github.com/GeertJohan/fgt # return exit, fgt runs any command for you and exits with exitcode 1
-	go get github.com/stretchr/testify
-	go get github.com/vektra/mockery/.../
-	go get github.com/Masterminds/glide
+	go get -u github.com/golang/lint/golint
+	go get -u github.com/GeertJohan/fgt # return exit, fgt runs any command for you and exits with exitcode 1
+	go get github.com/stretchr/testify # go get -u github.com/stretchr/testify fails miserably
+	go get -u github.com/vektra/mockery/.../
+	go get -u github.com/Masterminds/glide
 	glide install
 
 deps_jupyter:

--- a/integration_tests/snap-plugins/cassandra-publisher/cassandra_publisher_test.go
+++ b/integration_tests/snap-plugins/cassandra-publisher/cassandra_publisher_test.go
@@ -108,13 +108,13 @@ func runCassandraPublisherWorkflow(snapClient *client.Client) (err error) {
 
 	err = snapSession.Start(tags)
 	if err != nil {
-		return fmt.Errorf("Snap session start failed: %s\n", err.Error())
+		return fmt.Errorf("snap session start failed: %s", err.Error())
 	}
 
 	snapSession.Wait()
 	err = snapSession.Stop()
 	if err != nil {
-		return fmt.Errorf("Snap session stop failed: %s\n", err.Error())
+		return fmt.Errorf("snap session stop failed: %s", err.Error())
 	}
 
 	return err


### PR DESCRIPTION
Updated version of golint dislikes captalized error messages that end with new line

Summary of changes:
- turned ``go get`` into ``go get -u``
- fixed two errors

Testing done:
- all tests should pass

