### PR TITLE
Fix experiment on k8s.

### DIFF
--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -70,7 +70,6 @@ func PrepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Exec
 			config := executor.DefaultKubernetesConfig()
 			config.ContainerImage = "centos_swan_image"
 			config.Decorators = decorators
-			config.PodName = "swan-aggr"
 			config.Privileged = true // swan aggressor use unshare, which requires sudo.
 			return executor.NewKubernetes(config)
 		}


### PR DESCRIPTION
Currently experiment on k8s hangs after first measurement (at the beginning of second measurement), because on deleting swan-hp pod, which was started for the second measurement. We have to investigate it further. Maybe we receive two events of deleting swan-hp pod and delete pod from first and second measurement. 
This PR uses random pod names, what helps with this issue. This is a temporal fix to be able to run the experiment.

Below is an output with this error:
```
DEBU[0342] 8432 Could not read exit code: task is not terminated
DEBU[0343] K8s task handle: deleting pod "swan-hp"
DEBU[0343] K8s task watcher: event received: api.PodRunning
DEBU[0344] K8s task watcher: event received: watch.Deleted
DEBU[0344] K8s task watcher: exit code retrieved: -1
DEBU[0344] K8s task watcher: exit code sent
DEBU[0344] K8s task watcher: waiting for output to be copied
DEBU[0344] K8s task watcher: closing files' descriptors
DEBU[0344] K8s task watcher: task stopped succesfully
DEBU[0344] K8s task handle: waiting for pod "swan-hp" to stop
DEBU[0344] K8s task handle: pod "swan-hp" stopped
DEBU[0344] Waiting for snap session to complete it's work. &{0xc420562180 [/intel/swan/specjbb/*/min /intel/swan/specjbb/*/percentile/50th /intel/swan/specjbb/*/percentile/90th /intel/sw
an/specjbb/*/percentile/95th /intel/swan/specjbb/*/percentile/99th /intel/swan/specjbb/*/max /intel/swan/specjbb/*/qps /intel/swan/specjbb/*/issued_requests] [{/intel/swan/specjbb stdout
_file /tmp/specjbb-sensitivity-profile/67711096-e0f6-4c8a-5f11-809fad8f3735/baseline_measurement_for_loadpoint_id_1/0/remote_java_014798580/stdout}] 0xc4200de5a0 0xc42047bfc0 0xc4201b260
0}
INFO[0345] Ended baseline_measurement_for_loadpoint_id_1 repetition 0 in 5m17.167067911s
INFO[0345] Finalizing baseline_measurement_for_loadpoint_id_1 after 1 repetitions
INFO[0345] Starting aggressor_nr_0_measurement_for_loadpoint_id_1 repetition 0
DEBU[0345] K8s executor: pod specification = {Volumes:[] InitContainers:[] Containers:[{Name:swan Image:centos_swan_image Command:[sh -c numactl --physcpubind=0,1,2,3 -- java -jar -Dspec
jbb.controller.host=127.0.0.1 /root/go/src/github.com/intelsdi-x/swan/workloads/web_serving/specjbb/specjbb2015.jar -m backend -G GRP1 -J JVM2 -p /root/go/src/github.com/intelsdi-x/swan/
workloads/web_serving/specjbb/config/specjbb2015.props] Args:[] WorkingDir: Ports:[] Env:[] Resources:{Limits:map[cpu:{i:{value:16 scale:0} d:{Dec:<nil>} s:16 Format:DecimalSI} memory:{i
:{value:5 scale:9} d:{Dec:<nil>} s:5G Format:DecimalSI}] Requests:map[cpu:{i:{value:16 scale:0} d:{Dec:<nil>} s:16 Format:DecimalSI} memory:{i:{value:5 scale:9} d:{Dec:<nil>} s:5G Format
:DecimalSI}]} VolumeMounts:[] LivenessProbe:<nil> ReadinessProbe:<nil> Lifecycle:<nil> TerminationMessagePath:/dev/termination-log ImagePullPolicy:IfNotPresent SecurityContext:0xc4200d0d
80 Stdin:false StdinOnce:false TTY:false}] RestartPolicy:Never TerminationGracePeriodSeconds:0xc4202c5c10 ActiveDeadlineSeconds:<nil> DNSPolicy:ClusterFirst NodeSelector:map[] ServiceAcc
ountName: NodeName: SecurityContext:0xc4205840c0 ImagePullSecrets:[] Hostname: Subdomain:}

DEBU[0345] K8s executor: pod "swan-hp" QoS class "Guaranteed"
DEBU[0345] K8s task watcher: event received: api.PodPending
DEBU[0345] K8s task watcher: event received: api.PodPending
DEBU[0345] K8s task watcher: event received: watch.Deleted
DEBU[0345] K8s task watcher: setting up logs for pod "swan-hp"
ERRO[0346] K8s task watcher: cannot create a stream: pods "swan-hp" not found
DEBU[0346] K8s task watcher: exit code retrieved: -1
DEBU[0346] K8s task watcher: exit code sent
DEBU[0346] K8s task watcher: waiting for output to be copied
```