### PR TITLE
SCE-864: Patch "get_cifar10.patch" is applied incorrectly many times, resulting in broken file - blocks docker image creation (ends with error) with second time

### DIFF
--- a/workloads/deep_learning/caffe/build_caffe.sh
+++ b/workloads/deep_learning/caffe/build_caffe.sh
@@ -32,7 +32,7 @@ cp ${CAFFE_ROOT_DIRECTORY}/get_cifar10.patch ${CAFFE_SRC_DIRECTORY}
 pushd ${CAFFE_SRC_DIRECTORY}
 patch -p1 --forward -s --merge < caffe_cpu_solver.patch
 patch -p1 --forward -s --merge < vagrant_vboxsf_workaround.patch
-patch -p1 --forward -s --merge < get_cifar10.patch
+patch -p1 --forward -s < get_cifar10.patch || true
 export OMP_NUM_THREADS=${CPUS_NUMBER}
 make --quiet all
 popd


### PR DESCRIPTION
Fixes issue SCE-864

Summary of changes:
-remove merge option from patch and skip error checking

patch with merge:
![w_merge](https://cloud.githubusercontent.com/assets/9694425/20600253/f410bbca-b252-11e6-8918-bf1b7a2bd81f.gif)

patch without merge:
![wo_merge](https://cloud.githubusercontent.com/assets/9694425/20600292/287f9bec-b253-11e6-8398-bedfd163ffbf.gif)

Testing done:
- 

