### PR TITLE
SCE-887: Turn off Travis notification on successful builds and on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
 - make test_lint 
 - make test_unit
 notifications:
-  slack: intelsdi:k7XiVx2qAV7nCAMPXjRomNJ3
-    on_success: never
+  slack:
+    rooms:
+      - 'intelsdi:k7XiVx2qAV7nCAMPXjRomNJ3'
+    on_success: 'never'
     on_pull_requests: false


### PR DESCRIPTION
Fixes issue SCE-887

Summary of changes:
- removes unneeded notifications from slack channel:
  - removed notifications from pr builds
  - removed notifications from successful builds

Testing done:
- /

