### PR TITLE
SCE-876, SCE-889: Give enough time before killing snap sessions (workaround).

### DIFF
--- a/pkg/experiment/sensitivity/measurement.go
+++ b/pkg/experiment/sensitivity/measurement.go
@@ -94,6 +94,11 @@ func (m *measurementPhase) clean() (err error) {
 	}
 	m.activeLoadGeneratorTasks = []executor.TaskHandle{}
 
+	// Give enough time for executors to cleanup, before stopping the session.
+	// It is workaround for metrics from publisher of loadgenerator session not always available in the storage.
+	// See the description of SCE-876.
+	time.Sleep(10 * time.Second)
+
 	// Stopping only active Snap sessions.
 	for _, snapSession := range m.activeSnapSessions {
 		log.Debug("Waiting for snap session to complete it's work. ", snapSession)


### PR DESCRIPTION
Fixes issue: SCE-876,SCE-889 "may" solve problem with missing data from cassandra, was confirmed by Alicja and Iwan that it helps and actually we know that hit means that metrics was collected not yet processed by publisher which can cause that mutilate snap task is killed before cassandra have a chance to send data.

It can help with "flaky" experiment tests when cassandra is missing data.

Summary of changes:
- simple stupid sleep before kill snap sessions,

Testing done:
- yes - with inplace code on ovh setup,

