### PR TITLE
SCE-734: SSL options for Cassandra

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: 5985d6bca4d1f94b01cf4d5cf5954c0365b4f19f64cfd713fdf4197c416abb12
-updated: 2016-11-25T12:09:30.877149414+01:00
+updated: 2016-12-01T18:12:33.248737532-05:00
 imports:
-- name: bitbucket.org/ww/goautoneg
-  version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
   subpackages:
@@ -27,10 +25,6 @@ imports:
   version: 06b60999766278efd6d2b5d8418a58c3d5b99e87
 - name: github.com/asaskevich/govalidator
   version: 9699ab6b38bee2e02cd3fe8b99ecf67665395c96
-- name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
-  subpackages:
-  - quantile
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/coreos/go-oidc
@@ -59,7 +53,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -74,8 +68,16 @@ imports:
   - swagger
 - name: github.com/ghodss/yaml
   version: c3eb24aeea63668ebdac08d2e252f20df8b6b1ae
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gocql/gocql
-  version: 3ac1aabebaf2705c6f695d4ef2c25ab6239e88b3
+  version: db6f35eb602dd0770a7162e0e23e5cfb1cc05b91
   subpackages:
   - internal/lru
   - internal/murmur
@@ -178,7 +180,7 @@ imports:
 - name: github.com/hashicorp/memberlist
   version: a93fbd426dd831f5a66db3adc6a5ffa6f44cc60a
 - name: github.com/intelsdi-x/athena
-  version: 46027e5a87e312fe03cc4498483c1278f7afa305
+  version: 8c3b5cc56cafc84ee1ab2d60f6f9a0880e286b87
   subpackages:
   - integration_tests/test_helpers
   - pkg/conf
@@ -190,6 +192,7 @@ imports:
   - pkg/kubernetes
   - pkg/snap
   - pkg/snap/mocks
+  - pkg/snap/sessions
   - pkg/snap/sessions/caffe
   - pkg/snap/sessions/mutilate
   - pkg/snap/sessions/specjbb
@@ -228,7 +231,7 @@ imports:
   - pkg/schedule
   - scheduler/wmap
 - name: github.com/intelsdi-x/snap-plugin-processor-tag
-  version: 4bbe338e49bde18040fcc498e8119a35605b6215
+  version: 8f305f7e2c9f5569d438ea2c6ac08713a801102c
   subpackages:
   - tag
 - name: github.com/intelsdi-x/snap-plugin-utilities
@@ -240,10 +243,14 @@ imports:
   version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
-  - pbutil
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/mattn/go-runewidth
+  version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/mitchellh/mapstructure
   version: f3009df150dadf309fdee4a54ed65c124afad715
 - name: github.com/montanaflynn/stats
@@ -258,21 +265,10 @@ imports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
-- name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
-  subpackages:
-  - prometheus
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
-  subpackages:
-  - expfmt
-  - model
-- name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/robfig/cron
   version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/Sirupsen/logrus
@@ -280,9 +276,9 @@ imports:
 - name: github.com/spf13/pflag
   version: 1560c1005499d61b80f865c04d39ca7505bf7f0b
 - name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: e3a8ff8ce36581f87a15341206f205b1da467059
+  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
   subpackages:
   - assert
   - mock
@@ -314,6 +310,7 @@ imports:
   - context/ctxhttp
   - http2
   - http2/hpack
+  - idna
   - lex/httplex
 - name: golang.org/x/oauth2
   version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
@@ -323,9 +320,22 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 9c60d1c508f5134d1ca726b4641db998f2523357
+  version: d5645953809d8b4752afb2c3224b1f1ad73dfa70
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
 - name: google.golang.org/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
@@ -346,74 +356,72 @@ imports:
 - name: gopkg.in/alecthomas/kingpin.v2
   version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
 - name: gopkg.in/cheggaaa/pb.v1
-  version: dd61faab99a777c652bb680e37715fe0cb549856
+  version: d7e6ca3010b6f084d8056847f55d7f572f180678
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
 - name: k8s.io/client-go
-  version: 294573fbeaf0e7136d5112fabb1da0777cea445b
+  version: 5d8c36c93cf544e3bde13caa4c6222b65753ec3c
   subpackages:
-  - 1.4/pkg/api
-  - 1.4/pkg/api/endpoints
-  - 1.4/pkg/api/errors
-  - 1.4/pkg/api/meta
-  - 1.4/pkg/api/meta/metatypes
-  - 1.4/pkg/api/pod
-  - 1.4/pkg/api/resource
-  - 1.4/pkg/api/service
-  - 1.4/pkg/api/unversioned
-  - 1.4/pkg/api/unversioned/validation
-  - 1.4/pkg/api/util
-  - 1.4/pkg/api/v1
-  - 1.4/pkg/api/validation
-  - 1.4/pkg/apis/autoscaling
-  - 1.4/pkg/apis/batch
-  - 1.4/pkg/apis/extensions
-  - 1.4/pkg/auth/user
-  - 1.4/pkg/capabilities
-  - 1.4/pkg/conversion
-  - 1.4/pkg/conversion/queryparams
-  - 1.4/pkg/fields
-  - 1.4/pkg/labels
-  - 1.4/pkg/runtime
-  - 1.4/pkg/runtime/serializer
-  - 1.4/pkg/runtime/serializer/json
-  - 1.4/pkg/runtime/serializer/protobuf
-  - 1.4/pkg/runtime/serializer/recognizer
-  - 1.4/pkg/runtime/serializer/streaming
-  - 1.4/pkg/runtime/serializer/versioning
-  - 1.4/pkg/third_party/forked/golang/reflect
-  - 1.4/pkg/types
-  - 1.4/pkg/util
-  - 1.4/pkg/util/clock
-  - 1.4/pkg/util/crypto
-  - 1.4/pkg/util/errors
-  - 1.4/pkg/util/flowcontrol
-  - 1.4/pkg/util/framer
-  - 1.4/pkg/util/hash
-  - 1.4/pkg/util/integer
-  - 1.4/pkg/util/intstr
-  - 1.4/pkg/util/json
-  - 1.4/pkg/util/labels
-  - 1.4/pkg/util/net
-  - 1.4/pkg/util/net/sets
-  - 1.4/pkg/util/parsers
-  - 1.4/pkg/util/rand
-  - 1.4/pkg/util/runtime
-  - 1.4/pkg/util/sets
-  - 1.4/pkg/util/uuid
-  - 1.4/pkg/util/validation
-  - 1.4/pkg/util/validation/field
-  - 1.4/pkg/util/wait
-  - 1.4/pkg/util/yaml
-  - 1.4/pkg/version
-  - 1.4/pkg/watch
-  - 1.4/pkg/watch/versioned
   - 1.4/rest
-  - 1.4/tools/clientcmd/api
-  - 1.4/tools/metrics
-  - 1.4/transport
+  - pkg/api
+  - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/resource
+  - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/api/validation/path
+  - pkg/apis/autoscaling
+  - pkg/apis/batch
+  - pkg/apis/certificates
+  - pkg/apis/certificates/v1alpha1
+  - pkg/apis/extensions
+  - pkg/auth/user
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/genericapiserver/openapi/common
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/third_party/forked/golang/reflect
+  - pkg/types
+  - pkg/util
+  - pkg/util/cert
+  - pkg/util/clock
+  - pkg/util/errors
+  - pkg/util/flowcontrol
+  - pkg/util/framer
+  - pkg/util/integer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/labels
+  - pkg/util/net
+  - pkg/util/parsers
+  - pkg/util/rand
+  - pkg/util/ratelimit
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/uuid
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - pkg/watch/versioned
+  - tools/clientcmd/api
+  - tools/metrics
+  - transport
 - name: k8s.io/kubernetes
   version: a16c0a7f71a6f93c7e0f222d961f4675cd97a46b
   subpackages:

--- a/misc/snap-plugin-publisher-cassandra.patch
+++ b/misc/snap-plugin-publisher-cassandra.patch
@@ -1,31 +1,34 @@
-t a/cassandra/client.go b/cassandra/client.go
-index 37b8c72..9093574 100644
---- a/cassandra/client.go
-+++ b/cassandra/client.go
-@@ -118,7 +118,7 @@ func worker(s *gocql.Session, m plugin.MetricType) error {
- 			m.Namespace().String(),
- 			m.Version(),
- 			m.Tags()[core.STD_TAG_PLUGIN_RUNNING_ON],
--			time.Now(),
-+			m.Timestamp(),
- 			"doubleval",
- 			value,
- 			m.Tags()).Exec(); err != nil {
-@@ -132,7 +132,7 @@ func worker(s *gocql.Session, m plugin.MetricType) error {
- 			m.Namespace().String(),
- 			m.Version(),
- 			m.Tags()[core.STD_TAG_PLUGIN_RUNNING_ON],
--			time.Now(),
-+			m.Timestamp(),
- 			"strval",
- 			value,
- 			m.Tags()).Exec(); err != nil {
-@@ -146,7 +146,7 @@ func worker(s *gocql.Session, m plugin.MetricType) error {
- 			m.Namespace().String(),
- 			m.Version(),
- 			m.Tags()[core.STD_TAG_PLUGIN_RUNNING_ON],
--			time.Now(),
-+			m.Timestamp(),
- 			"boolval",
- 			value,
- 			m.Tags()).Exec(); err != nil {
+diff --git a/glide.lock b/glide.lock
+index 0883fc6..be36ef9 100644
+--- a/glide.lock
++++ b/glide.lock
+@@ -1,5 +1,5 @@
+-hash: 336023be1e3b912d3f202165b07319d4190e4c59edd016e65355cbc412fe7f22
+-updated: 2016-11-16T19:32:00.959436057-08:00
++hash: 12d26ec28924994e5bad2a526c7b3b80583491cb2e2c615d0bb01110b6514586
++updated: 2016-12-01T18:38:59.689870735-05:00
+ imports:
+ - name: github.com/gocql/gocql
+   version: 03ae28ccfc4fa086afea7fcec681bf7ff60f0346
+@@ -16,7 +16,7 @@ imports:
+ - name: github.com/hailocab/go-hostpool
+   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
+ - name: github.com/intelsdi-x/snap
+-  version: 8f3ac356e8d56a59b65a728fc94d2241030db535
++  version: 506318ebb84a8fefc5ef966edc4318c9cf5b2002
+   subpackages:
+   - control/plugin
+   - control/plugin/cpolicy
+diff --git a/glide.yaml b/glide.yaml
+index fa90f67..d51e397 100644
+--- a/glide.yaml
++++ b/glide.yaml
+@@ -17,7 +17,7 @@ import:
+ - package: github.com/hailocab/go-hostpool
+   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
+ - package: github.com/intelsdi-x/snap
+-  version: 8f3ac356e8d56a59b65a728fc94d2241030db535
++  version: ~0.14.0-beta
+   subpackages:
+   - control/plugin
+   - control/plugin/cpolicy

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -20,7 +20,7 @@ function installPlugin() {
 pushd $GOPATH/src/github.com/intelsdi-x
 
 # See SCE-895
-installPlugin snap-plugin-publisher-cassandra 188b78e3e6b29dc3b80d8a9e9dd21eb5a5a8a81a build/rootfs/snap-plugin-publisher-cassandra $(pwd)/swan/misc/snap-plugin-publisher-cassandra.patch
+installPlugin snap-plugin-publisher-cassandra 0869f977e7c3da4aaa330c2df42cf82806383c4a build/linux/x86_64/snap-plugin-publisher-cassandra $(pwd)/swan/misc/snap-plugin-publisher-cassandra.patch
 installPlugin snap-plugin-processor-tag 3ccdb7de499ff92d7b7c9812c497a6e6f124a64d build/linux/x86_64/snap-plugin-processor-tag
 installPlugin kubesnap-plugin-collector-docker 81a60d8276054a95dde4a72429bf320c89e31ded build/rootfs/snap-plugin-collector-docker $(pwd)/swan/misc/kubesnap_docker_collector.patch
 popd


### PR DESCRIPTION
Fixes issue SCE-734 and wires up the last piece of enabling a SSL connection for Cassandra metrics publishing.

Example usage:
```
export SWAN_CASSANDRA_ADDR="foobar"
export SWAN_CASSANDRA_SSL=1
export SWAN_CASSANDRA_USERNAME="xyz"
export SWAN_CASSANDRA_PASSWORD="xyz"
export SWAN_CASSANDRA_SSL_KEY_PATH="/home/bar/foo.key.pem"
export SWAN_CASSANDRA_SSL_CA_PATH="/home/bar/foo.ca.cer.pem"
export SWAN_CASSANDRA_SSL_CERT_PATH="/home/bar/foo.cer.pem"
./build/experiments/memcached/memcached-sensitivity-profile
```

Summary of changes:
- Changes cassandra plugin to master (as of today, including the timestamp fix)

Testing done:
- Integration tests
- Manual testing

