### PR TITLE
Mutilate session test package compliance

### DIFF
--- a/integration_tests/pkg/snap/sessions/mutilate/mutilate_test.go
+++ b/integration_tests/pkg/snap/sessions/mutilate/mutilate_test.go
@@ -1,4 +1,4 @@
-package sessions
+package mutilatesession_test
 
 import (
 	"fmt"


### PR DESCRIPTION
**Fixes issue**
w/o number

**Summary of changes:**
-  mutilate session test in integration test moved to separate package to be complaint with existing convention


**Testing done:**
- local vagrant integration tests

