### PR TITLE
Fixed dir for storing logs in memcached-experiment.

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -120,7 +120,6 @@ func CreateExperimentDir(uuid string) (experimentDirectory string, logFile *os.F
 		return "", &os.File{}, errors.Wrapf(err, "cannot create experiment directory: ", experimentDirectory)
 	}
 	err = os.Chdir(experimentDirectory)
-	os.Chdir(os.TempDir())
 	if err != nil {
 		return "", &os.File{}, errors.Wrapf(err, "cannot chdir to experiment directory", experimentDirectory)
 	}


### PR DESCRIPTION
We used random temp dir in memcached experiment.
We should use created `experimentDirectory`.