### PR TITLE
SCE-935: specjbb log parser fix

### DIFF
--- a/pkg/workloads/specjbb/parser/parse.go
+++ b/pkg/workloads/specjbb/parser/parse.go
@@ -158,8 +158,12 @@ func ParseLatencies(reader io.Reader) (Results, error) {
 	// Regex for line with actual injection rate and processed requests.
 	// 55s: ( 0%) ......|................?............. (rIR:aIR:PR = 4000:4007:4007) (tPR = 60729) [OK]
 	rLocal := regexp.MustCompile("[0-9]+s:[ ()0-9%.|?]+rIR:aIR:PR[ =]+([0-9]+):([0-9]+):([0-9]+)")
+	// Try to match two types logs below:
 	// <Wed Nov 09 18:58:39 UTC 2016> org.spec.jbb.controller: PRESET: IR = 500 finished, steady status = [OK] (rIR:aIR:PR = 500:500:500) (tPR = 7214)
-	rRemote := regexp.MustCompile("[<a-zA-Z:0-9]+PRESET:[a-zA-Z=0-9]+finished,steadystatus=\\[[a-zA-Z]+\\][()]rIR:aIR:PR=([0-9]+):([0-9]+):([0-9]+)")
+	// or
+	// <Fri Dec 16 16:06:35 CET 2016> org.spec.jbb.controller: PRESET: IR = 4000 finished, settle status = [PR is under limit] (rIR:aIR:PR = 4000:3960:3350) (tPR = 48530)
+	// (rIR:aIR:PR = 4000:3960:3350) (tPR = 48530) [PR is under limit]
+	rRemote := regexp.MustCompile("[<a-zA-Z:0-9]+PRESET:[a-zA-Z=0-9]+finished,(steady|settle)status=\\[[a-zA-Z]+\\][()]rIR:aIR:PR=([0-9]+):([0-9]+):([0-9]+)")
 	for scanner.Scan() {
 		if err := scanner.Err(); err != nil {
 			return newResults(), err


### PR DESCRIPTION
Fixes issue SCE-935 - Error reading SpecJBB output

Summary of changes:
- fix regex in log parser
- comment update

Testing done:
- manually  with link : https://play.golang.org/p/vwgmurTgjA 

handle the case from specjbb:
```java
if (settleStatus.isOk() && iterationParams.getMinSteadyDurationMsec() > 0) {
            final int avgWindowSamplesRun = (iterationParams.getMaxSteadyDurationMsec() / windowDelayMsecs + 2) 
                        * iterationParams.getAverageSteadyWindowPercent() / 100;
            
            
            IterationStatus steadyStatus = new IterationStatus(iterationParams.getLabel(), iterationParams.getIR(), avgWindowSamplesRun, iterationParams.getAccuracy(), settleStatus);
            
            Screen.print("|");
            
            runIterationSettleOrSteady(iterationParams.getLabel() + ": steady", false, steadyStatus, iterationParams.getSteadyMinOkInARow(), 
                iterationParams.getMinSteadyDurationMsec(), iterationParams.getMaxSteadyDurationMsec(), !isGrabSamples, iterationParams.getGatherRTInfoEachMsec());

            logger.info(iterationParams.getLabel() + ": IR = " + iterationParams.getIR() + " finished, steady status = " + steadyStatus.toString(true));
            status = steadyStatus;
} else {
            logger.info(iterationParams.getLabel() + ": IR = " + iterationParams.getIR() + " finished, settle status = " + settleStatus.toString(true));
            status = settleStatus;
}
```