### PR TITLE
SCE-910 - non-zero exit status is being ignored

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ca7205beaf46e444af03130404dd56493c2e837e3738ec5fbe323e84538aaf2f
-updated: 2016-12-21T12:44:45.443058516+01:00
+updated: 2016-12-22T11:53:36.956692129+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -170,7 +170,7 @@ imports:
 - name: github.com/hashicorp/memberlist
   version: a93fbd426dd831f5a66db3adc6a5ffa6f44cc60a
 - name: github.com/intelsdi-x/athena
-  version: 0e7f287e3eb92fc8f0066d090f775b0d8be226ba
+  version: 2460d953e8f96e46533afcd2d161b5cebdf2443f
   subpackages:
   - integration_tests/test_helpers
   - pkg/conf


### PR DESCRIPTION
Fixes issue SCE-910

Summary of changes:
- updated `glide.lock`

Testing done:
- all existing tests should pass
