### PR TITLE
SCE-917: metadata environment recorded properly

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -163,12 +163,13 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 		"repetitions":       strconv.Itoa(repetitions),
 		"load_duration":     loadDuration.String(),
 	}
-	// Store environment as metadata with "ENVIRON_" prefix) to make it
-	// distinguishable from other metadata records.
+	// Store SWAN_ environment configuration.
 	for _, env := range os.Environ() {
 		fields := strings.SplitN(env, "=", 2)
-		prefixedKey := "ENVIRON_" + fields[0]
-		records[prefixedKey] = fields[1]
+		key, value := fields[0], fields[1]
+		if strings.HasPrefix(key, "SWAN_") {
+			records[key] = value
+		}
 	}
 	err = metadata.RecordMap(records)
 	if err != nil {

--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -117,6 +117,16 @@ func TestExperiment(t *testing.T) {
 					So(ns, ShouldNotBeBlank)
 					So(tags, ShouldNotBeEmpty)
 					So(tags["swan_aggressor_name"], ShouldEqual, "L1 Data")
+
+					// Check metadata was saved.
+					var metadata map[string]string
+					err = session.Query(`SELECT metadata FROM swan.metadata WHERE experiment_id = ? ALLOW FILTERING`, experimentID).Scan(&metadata)
+					So(err, ShouldBeNil)
+					So(metadata, ShouldNotBeEmpty)
+					So(metadata["SWAN_PEAK_LOAD"], ShouldEqual, "5000")
+					So(metadata["load_points"], ShouldEqual, "1")
+					So(metadata["load_duration"], ShouldEqual, "1s")
+
 				})
 
 				Convey("While having two repetitions to phase", func() {


### PR DESCRIPTION
Fixes issue that it isn't possible to decode environment variables where serialized by simple comma (values can consist this character).


Summary of changes:
- Environment variables are stored in the same map as other values, but prefixed with "ENVIRON_" prefix.

Testing done:
- manually build and run experiment,


when run like this:
```
SWAN_PEAK_LOAD=3124 memcached-sensitivity-profile --log=debug
```

Output is:
```
{
  'SWAN_PEAK_LOAD': '3124',
  'command_arguments': 'memcached-sensitivity-profile,--log=debug',
  'experiment_name': 'memcached-sensitivity-profile',
  'load_duration': '10s',
  'load_points': '10',
  'peak_load': '3124',
  'repetitions': '3'
}
```

you can now easily find all values set explict without prefix or 
configuration with ENVIRON_SWAN_ or any other value with just ENVIRON.