### PR TITLE
SCE-970: Fix that /tmp/caffe is not accessible when make install run as root

### DIFF
--- a/workloads/deep_learning/caffe/caffe_wrapper.sh
+++ b/workloads/deep_learning/caffe/caffe_wrapper.sh
@@ -7,6 +7,8 @@ if [ "$1" == "init" ]; then
         bash ./data/cifar10/get_cifar10.sh
         bash ./examples/cifar10/create_cifar10.sh
         cp ./cifar10_quick_iter_5000.caffemodel.h5 /tmp/caffe
+        # make sure that /tmp/caffe folder is accessible for other users (capital X for search only on directories)
+        chmod o+rX /tmp/caffe
         exit 0
 fi
 ./bin/caffe "$@"


### PR DESCRIPTION
Fixes issue cannot run caffe after 'make inst' because of permission denied.

Summary of changes:
- just set required privileges for caffe temp directory

Testing done:
- on production in OVH server
