### PR TITLE
SCE-768 - wrong parameter order

### DIFF
--- a/jupyter/experiment.py
+++ b/jupyter/experiment.py
@@ -92,7 +92,7 @@ class Experiment(object):
         return rows, qps, throughputs
 
     def read_data_from_cassandra(self, cassandra_cluster, port, keyspace, ssl_options, experiment_id):
-        session = Experiment._create_or_get_session(cassandra_cluster, port, keyspace, ssl_options)
+        session = Experiment._create_or_get_session(cassandra_cluster, port, ssl_options, keyspace)
         query = """SELECT ns, ver, host, time, boolval, doubleval, strval, tags, valtype
                         FROM snap.metrics WHERE tags['swan_experiment'] = \'%s\'""" % experiment_id
         statement = SimpleStatement(query, fetch_size=100)


### PR DESCRIPTION
Fixes issue of broken Jupyter notebook

Summary of changes:
- changed order of arguments in function call

Testing done:
- all existing tests should pass
