### PR TITLE
Running k8s master on remote host

### DIFF
--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -41,7 +41,7 @@ func PrepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Exec
 	if runOnKubernetesFlag.Value() {
 		k8sConfig := kubernetes.DefaultConfig()
 		masterAddress := kubernetesMaster.Value()
-		apiAddress := fmt.Sprintf("%s:%s", masterAddress, 8080)
+		apiAddress := fmt.Sprintf("%s:%s", masterAddress, "8080")
 		masterExecutor, err := NewRemote(masterAddress)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
Fixes part of issue SCE-768

Summary of changes:
- Running k8s master on remote host
- Getting rid of unused toleration patch

Testing done:
- All existing tests should pass
