### PR TITLE
Increasing default launch timeout to battle-tested value

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -133,7 +133,7 @@ func DefaultKubernetesConfig() KubernetesConfig {
 		Namespace:      v1.NamespaceDefault,
 		Privileged:     false,
 		HostNetwork:    false,
-		LaunchTimeout:  0,
+		LaunchTimeout:  30 * time.Second,
 	}
 }
 


### PR DESCRIPTION
Fixes issue SCE-786 to some extent.

Summary of changes:
- increased default timeout to 30 seconds (seems to work for experiments)

Testing done:
- all existing tests should pass.
