### PR TITLE
remove transpose, use numpy instead

### DIFF
--- a/jupyter/experiment.py
+++ b/jupyter/experiment.py
@@ -76,7 +76,7 @@ class Experiment(object):
 
         if read_csv:
             self.frame = pd.read_csv(self.cached_experiment)
-            self.meta = pd.read_csv(self.cached_meta_data_experiment)
+            self._meta = pd.read_csv(self.cached_meta_data_experiment)
         else:
             data, meta = self.read_data_from_cassandra(cassandra_cluster, port, keyspace, ssl_options, experiment_id)
 
@@ -145,8 +145,8 @@ class Experiment(object):
         frame = pd.DataFrame(data, columns=columns)
 
         if not os.path.exists(self.cached_experiment):
-            self.get_frame().to_csv(self.cached_experiment)
-            self.get_metadata().to_csv(self.cached_meta_data_experiment)
+            frame.to_csv(self.cached_experiment)
+            self._meta.to_csv(self.cached_meta_data_experiment)
 
         return frame
 

--- a/jupyter/profile.py
+++ b/jupyter/profile.py
@@ -67,8 +67,8 @@ class Profile(object):
         loadpoints_for_all_aggressors = [df['swan_loadpoint_qps'].astype(float).tolist() for (_, df) in
                                          self.p99_by_aggressor]
 
-        meta_load_points = int(self.metadata.get_value('metadata', 'load_points')
-        longest_loadpoints = max(loadpoints_for_all_aggressors, key=lambda lps: lps == meta_load_points)
+        meta_load_points = self.metadata['load_points'].astype(int).iloc[0]
+        longest_loadpoints = np.amax(loadpoints_for_all_aggressors, axis=0)
 
         data = []
         index = []
@@ -97,7 +97,7 @@ class Profile(object):
             self.latency_qps_aggrs[name] = aggressor_frame['value'].as_matrix()
             self.latency_qps_aggrs['slo'] = [slo for i in qps]
 
-        self.latency_qps_aggrs_frame = pd.DataFrame.from_dict(self.latency_qps_aggrs, orient='index').T
+        self.latency_qps_aggrs_frame = pd.DataFrame.from_dict(self.latency_qps_aggrs)
 
         peak = np.amax(longest_loadpoints)
         loadpoints = map(lambda c: (float(c) / peak) * 100, longest_loadpoints)


### PR DESCRIPTION
Fixes issue: some refactor

Summary of changes:
- remove unnecessary matrix transpose 
- use numpy for select max from array of arrays
- fix bugs with: csv file save,  and get_value from pandas return unicode in notebook

Testing done:
- yes
