### PR TITLE
Cleaning up dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5409e23d1af1af3ef1d95b622173d50ec6211d425d4f6cd051a165ebefb4b670
-updated: 2017-01-24T12:32:32.906180396+01:00
+hash: 121512000c75490e70591e120cc7e5968106bb248af18c420e79ef17b0543145
+updated: 2017-01-31T15:22:18.260761272+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -23,7 +23,7 @@ imports:
 - name: github.com/blang/semver
   version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/coreos/go-oidc
-  version: d7cb66526fffc811d602b6770581064f4b66b507
+  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
   subpackages:
   - http
   - jose
@@ -35,9 +35,10 @@ imports:
   subpackages:
   - semver
 - name: github.com/coreos/pkg
-  version: fa94270d4bac0d8ae5dc6b71894e251aada93f74
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
   - capnslog
+  - dlopen
   - health
   - httputil
   - timeutil
@@ -92,8 +93,6 @@ imports:
   - js
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
-- name: github.com/hailocab/gocassa
-  version: d3c840df87884c07d5ca67f08ecf62f4877ac79a
 - name: github.com/hashicorp/go-msgpack
   version: fa3f63826f7c23912c15263591e65d54d080b458
   subpackages:
@@ -132,22 +131,21 @@ imports:
   - pkg/stringutils
   - scheduler/wmap
 - name: github.com/intelsdi-x/snap-plugin-processor-tag
-  version: 4bbe338e49bde18040fcc498e8119a35605b6215
+  version: 2c6833e0eac8ed82c08178af43a16b3ab66fd093
   subpackages:
   - tag
 - name: github.com/intelsdi-x/snap-plugin-utilities
   version: 04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf
   subpackages:
   - config
-  - logger
 - name: github.com/jonboulle/clockwork
-  version: 3f831b65b61282ba6bece21b91beea2edc4c887a
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/jtolds/gls
   version: 8ddce2a84170772b95dd5d576c48d517b22cac63
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/mailru/easyjson
-  version: 1049a4acdaf85b6a93bd589976b1e516f6736b66
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
   - buffer
   - jlexer
@@ -155,13 +153,13 @@ imports:
 - name: github.com/mattn/go-runewidth
   version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/montanaflynn/stats
-  version: f8cd06f93c6c1b06028caafb88b540fc820f77c1
+  version: eeaced052adbcfeea372c749c281099ed7fdaa38
 - name: github.com/nu7hatch/gouuid
   version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/pkg/errors
-  version: a22138067af1c4942683050411a841ade67fe1eb
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -173,14 +171,14 @@ imports:
 - name: github.com/robfig/cron
   version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/Sirupsen/logrus
-  version: 081307d9bc1364753142d5962fc1d795c742baaf
+  version: d26492970760ca5d33129d2d799e34be5c4782eb
 - name: github.com/smartystreets/assertions
   version: 443d812296a84445c202c085f19e18fc238f8250
   subpackages:
   - internal/go-render/render
   - internal/oglematchers
 - name: github.com/smartystreets/goconvey
-  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
+  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
   subpackages:
   - convey
   - convey/gotest
@@ -188,9 +186,9 @@ imports:
 - name: github.com/spf13/pflag
   version: 1560c1005499d61b80f865c04d39ca7505bf7f0b
 - name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: e3a8ff8ce36581f87a15341206f205b1da467059
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - mock
@@ -202,8 +200,6 @@ imports:
   - codec
 - name: github.com/urfave/cli
   version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
-- name: github.com/vektra/errors
-  version: c64d83aba85aa4392895aadeefabbd24e89f3580
 - name: github.com/vrischmann/jsonutil
   version: 694784f9315ee9fc763c1d30f28753cba21307aa
 - name: go4.org
@@ -244,9 +240,16 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 11dbc599981ccdf4fb18802a28392a8bcf7a9395
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
   - transform
+  - unicode/bidi
   - unicode/norm
   - width
 - name: google.golang.org/appengine
@@ -394,11 +397,12 @@ imports:
   - 1.5/tools/metrics
   - 1.5/transport
 - name: k8s.io/kubernetes
-  version: 9625926852e215caa35e278c2cd7926744532291
+  version: 82450d03cb057bab0950214ef122b67c83fb11df
   subpackages:
   - pkg/api/resource
-  - pkg/conversion
-  - third_party/forked/reflect
+  - pkg/genericapiserver/openapi/common
 testImports:
 - name: github.com/pivotal-golang/bytefmt
   version: b12c1522f4cbb5f35861bd5dd2c39a4fa996441a
+- name: github.com/vektra/errors
+  version: c64d83aba85aa4392895aadeefabbd24e89f3580

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,16 +1,17 @@
 package: github.com/intelsdi-x/swan
 import:
 - package: github.com/Sirupsen/logrus
-  version: 081307d9bc1364753142d5962fc1d795c742baaf
+  version: ~0.11.0
 - package: github.com/gocql/gocql
-- package: github.com/hailocab/gocassa
+- package: github.com/intelsdi-x/snap-plugin-processor-tag
+  version: ~3.0.0
+  subpackages:
+  - tag
 - package: github.com/intelsdi-x/snap-plugin-utilities
-  version: 04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf
   subpackages:
   - config
-  - logger
 - package: github.com/intelsdi-x/snap
-  version: 1.0.0
+  version: ~1.0.0
   subpackages:
   - control/plugin
   - control/plugin/cpolicy
@@ -19,25 +20,40 @@ import:
   - mgmt/rest/client
   - scheduler/wmap
 - package: github.com/montanaflynn/stats
-- package: github.com/intelsdi-x/snap-plugin-processor-tag
-  subpackages:
-  - tag
+  version: ~0.2.0
 - package: github.com/nu7hatch/gouuid
-  version: 179d4d0c4d8d407a32af483c2354df1d2c91e6c3
 - package: github.com/pkg/errors
-  version: a22138067af1c4942683050411a841ade67fe1eb
+  version: ~0.8.0
+- package: github.com/smartystreets/goconvey
+  version: ~1.6.2
+  subpackages:
+  - convey
 - package: github.com/stretchr/testify
+  version: ~1.1.4
   subpackages:
   - mock
-- package: gopkg.in/cheggaaa/pb.v1
-- package: github.com/vektra/errors
 - package: golang.org/x/crypto
-  version: aedad9a179ec1ea11b7064c57cbc6dc30d7724ec
   subpackages:
   - ssh
 - package: gopkg.in/alecthomas/kingpin.v2
-  version: ~2.2.2
+  version: ~2.2.3
+- package: gopkg.in/cheggaaa/pb.v1
+  version: ~1.0.7
+- package: k8s.io/kubernetes
+  version: 1.5.1
 - package: k8s.io/client-go
-  version: v1.5.0
+  version: 1.5.0
+  subpackages:
+  - 1.5/kubernetes
+  - 1.5/kubernetes/typed/core/v1
+  - 1.5/pkg/api
+  - 1.5/pkg/api/resource
+  - 1.5/pkg/api/unversioned
+  - 1.5/pkg/api/v1
+  - 1.5/pkg/kubelet/qos
+  - 1.5/pkg/labels
+  - 1.5/pkg/watch
+  - 1.5/rest
 testImport:
 - package: github.com/pivotal-golang/bytefmt
+- package: github.com/vektra/errors


### PR DESCRIPTION
Fixes issue of unnecessary entries in `glide.yaml`

Summary of changes:
- deleted `glide.yaml` and `glide.lock`
- recreated files using `glide create`
- added `k8s.io/kubernetes` to `glide.yaml` to force Swan to use expected version

Testing done:
- all existing tests should pass.
