### PR TITLE
Workaround for cassandra db. 

### DIFF
--- a/pkg/experiment/metadata.go
+++ b/pkg/experiment/metadata.go
@@ -125,7 +125,19 @@ func (m *Metadata) Connect() error {
 		return err
 	}
 
-	if err := session.Query("CREATE TABLE IF NOT EXISTS swan.metadata (experiment_id text, time timestamp, metadata map<text,text>, PRIMARY KEY ((experiment_id), time),) WITH CLUSTERING ORDER BY (time DESC);").Exec(); err != nil {
+	// NOTE: Schema consistency check is ignored by CREATE query. (https://git-wip-us.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=doc/native_protocol_v4.spec)
+	// To ensure schema consistency we perform a simple SELECT query on 'system_schema.keyspaces'.
+	// Consistency level is taken from 'cluster.Consistency' variable, it can also be defined for individual Query.
+	if err = session.Query("SELECT * FROM system_schema.keyspaces;").Exec(); err != nil {
+		return err
+	}
+
+	if err = session.Query("CREATE TABLE IF NOT EXISTS swan.metadata (experiment_id text, time timestamp, metadata map<text,text>, PRIMARY KEY ((experiment_id), time),) WITH CLUSTERING ORDER BY (time DESC);").Exec(); err != nil {
+		return err
+	}
+
+	// NOTE: Same issue as above.
+	if err = session.Query("SELECT * FROM system_schema.keyspaces;").Exec(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes issue:
 - `Keyspace not found: swan` error was returned when `memcached` experiment was started.

Summary of changes:
- Two "SELECT" queries were introduced to ensure that cassandra have created keyspace and table entries.

Testing done:
- multi node experiment

---
From https://git-wip-us.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=doc/native_protocol_v4.spec
`Note that the consistency is ignored by some queries (USE, CREATE, ALTER,
  TRUNCATE, ...).`. Because of that `CREATE TABLE` failed with `Keyspace not found: swan`.

From @ppalucki comment:
- In `gocql` package, in their tests they implemented following method to check consistency https://github.com/gocql/gocql/blame/3305e81ff12ffcd0bbd256b04057c08153821ab9/conn.go#L1081. 
- Looks like `cqlsh` is doing these `SELECT` queries under the hood after the `CREATE` query.
 http://stackoverflow.com/questions/38891563/cassandra-every-command-issued-in-cqlsh-throws-errors
