### PR TITLE
Move NewRemote from sensitivity package.

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
 	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
@@ -63,7 +62,7 @@ func PrepareMutilateGenerator(memcacheIP string, memcachePort int) (executor.Loa
 	agentsLoadGeneratorExecutors := []executor.Executor{}
 	if mutilateMasterFlag.Value() != mutilateMasterFlagDefault {
 		var err error
-		masterLoadGeneratorExecutor, err = sensitivity.NewRemote(mutilateMasterFlag.Value())
+		masterLoadGeneratorExecutor, err = executor.NewRemoteFromIP(mutilateMasterFlag.Value())
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +71,7 @@ func PrepareMutilateGenerator(memcacheIP string, memcachePort int) (executor.Loa
 	}
 	// Pack agents.
 	for _, agent := range mutilateAgentsFlag.Value() {
-		remoteExecutor, err := sensitivity.NewRemote(agent)
+		remoteExecutor, err := executor.NewRemoteFromIP(agent)
 		if err != nil {
 			return nil, err
 		}

--- a/experiments/specjbb-sensitivity-profile/common/common.go
+++ b/experiments/specjbb-sensitivity-profile/common/common.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
 	"github.com/intelsdi-x/swan/pkg/workloads/specjbb"
@@ -78,12 +77,12 @@ func PrepareSpecjbbLoadGenerator(ip string) (executor.LoadGenerator, error) {
 	txICount := specjbb.TxICountFlag.Value()
 	if ip != "127.0.0.1" {
 		var err error
-		loadGeneratorExecutor, err = sensitivity.NewRemote(ip)
+		loadGeneratorExecutor, err = executor.NewRemoteFromIP(ip)
 		if err != nil {
 			return nil, err
 		}
 		for i := 1; i <= txICount; i++ {
-			transactionInjector, err := sensitivity.NewRemote(ip)
+			transactionInjector, err := executor.NewRemoteFromIP(ip)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -3,15 +3,17 @@ package executor
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"strings"
 	"time"
+
+	"path/filepath"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/isolation"
 	"github.com/nu7hatch/gouuid"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
-	"path/filepath"
 )
 
 // Remote provisioning is responsible for providing the execution environment
@@ -22,6 +24,20 @@ type Remote struct {
 	commandDecorators isolation.Decorators
 	// Unique ID for the command which will be searched on the remote host.
 	unshareUUID string
+}
+
+// NewRemoteFromIP retrurns a Remote instance.
+// It takes IP to the destination host as parameter.
+func NewRemoteFromIP(ip string) (Executor, error) {
+	user, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+	sshConfig, err := NewSSHConfig(ip, DefaultSSHPort, user)
+	if err != nil {
+		return nil, err
+	}
+	return NewRemote(sshConfig), nil
 }
 
 // NewRemote returns a Remote instance.

--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -2,7 +2,6 @@ package sensitivity
 
 import (
 	"fmt"
-	"os/user"
 	"runtime"
 
 	"github.com/intelsdi-x/swan/pkg/conf"
@@ -18,25 +17,8 @@ var (
 	runOnKubernetesFlag = conf.NewBoolFlag("run_on_kubernetes", "Launch HP and BE tasks on Kubernetes.", false)
 
 	// KubernetesMasterFlag represents address of a host where Kubernetes master components are to be run
-	KubernetesMasterFlag    = conf.NewStringFlag("kubernetes_master", "Address of a host where Kubernetes master components are to be run", "127.0.0.1")
+	KubernetesMasterFlag = conf.NewStringFlag("kubernetes_master", "Address of a host where Kubernetes master components are to be run", "127.0.0.1")
 )
-
-// NewRemote is helper for creating remotes with default sshConfig.
-// TODO: this should be put into swan:/pkg/executors
-func NewRemote(ip string) (executor.Executor, error) {
-	// TODO: Have ability to choose user using parameter here.
-	user, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-
-	sshConfig, err := executor.NewSSHConfig(ip, executor.DefaultSSHPort, user)
-	if err != nil {
-		return nil, err
-	}
-
-	return executor.NewRemote(sshConfig), nil
-}
 
 // PrepareExecutors gives an executor to deploy your workloads with applied isolation on HP.
 func PrepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Executor, beExecutorFactory ExecutorFactoryFunc, cleanup func(), err error) {
@@ -44,7 +26,7 @@ func PrepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Exec
 		k8sConfig := kubernetes.DefaultConfig()
 		masterAddress := KubernetesMasterFlag.Value()
 		apiAddress := fmt.Sprintf("%s:%s", masterAddress, "8080")
-		masterExecutor, err := NewRemote(masterAddress)
+		masterExecutor, err := executor.NewRemoteFromIP(masterAddress)
 		if err != nil {
 			return nil, nil, nil, err
 		}


### PR DESCRIPTION
NewRemote has been moved from sensitivity to executor package as
NewRemoteFromIP(ip string).

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

Addition to SCE-903 (PR 498)
