### PR TITLE
Moved Create*Dir functions to pkg/experiment

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -1,10 +1,6 @@
 package common
 
 import (
-	"os"
-	"path"
-	"strconv"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
@@ -93,43 +89,6 @@ func PrepareMutilateGenerator(memcacheIP string, memcachePort int) (executor.Loa
 		mutilateConfig)
 
 	return mutilateLoadGenerator, nil
-}
-
-// CreateRepetitionDir creates folders that store repetition logs.
-func CreateRepetitionDir(experimentDirectory, phaseName string, repetition int) (string, error) {
-	repetitionDir := path.Join(experimentDirectory, phaseName, strconv.Itoa(repetition))
-	err := os.MkdirAll(repetitionDir, 0777)
-	if err != nil {
-		return "", errors.Wrapf(err, "could not create dir %q", repetitionDir)
-	}
-
-	err = os.Chdir(repetitionDir)
-	if err != nil {
-		return "", errors.Wrapf(err, "could not change to dir %q", repetitionDir)
-	}
-
-	return repetitionDir, nil
-}
-
-// CreateExperimentDir creates directory structure for the experiment.
-func CreateExperimentDir(uuid string) (experimentDirectory string, logFile *os.File, err error) {
-	experimentDirectory = path.Join(os.TempDir(), conf.AppName(), uuid)
-	err = os.MkdirAll(experimentDirectory, 0777)
-	if err != nil {
-		return "", &os.File{}, errors.Wrapf(err, "cannot create experiment directory: ", experimentDirectory)
-	}
-	err = os.Chdir(experimentDirectory)
-	if err != nil {
-		return "", &os.File{}, errors.Wrapf(err, "cannot chdir to experiment directory", experimentDirectory)
-	}
-
-	masterLogFilename := path.Join(experimentDirectory, "master.log")
-	logFile, err = os.OpenFile(masterLogFilename, os.O_WRONLY|os.O_CREATE, 0755)
-	if err != nil {
-		return "", &os.File{}, errors.Wrapf(err, "could not open log file %q", masterLogFilename)
-	}
-
-	return experimentDirectory, logFile, nil
 }
 
 // GetPeakLoad runs tuning in order to determine the peak load.

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -74,7 +74,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	logrus.Info("Starting Experiment ", conf.AppName(), " with uuid ", uuid.String())
 	fmt.Println(uuid.String())
 
-	experimentDirectory, logFile, err := common.CreateExperimentDir(uuid.String())
+	experimentDirectory, logFile, err := experiment.CreateExperimentDir(uuid.String(), conf.AppName())
 	if err != nil {
 		logrus.Errorf("IO error: %q", err.Error())
 		os.Exit(ExIOErr)
@@ -209,7 +209,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 
 					logrus.Infof("Starting %s repetition %d", phaseName, repetition)
 
-					_, err := common.CreateRepetitionDir(experimentDirectory, phaseName, repetition)
+					err := experiment.CreateRepetitionDir(experimentDirectory, phaseName, repetition)
 					if err != nil {
 						return errors.Wrapf(err, "cannot create repetition log directory in %s, repetition %d", phaseName, repetition)
 					}

--- a/experiments/specjbb-sensitivity-profile/common/common.go
+++ b/experiments/specjbb-sensitivity-profile/common/common.go
@@ -2,55 +2,14 @@ package common
 
 import (
 	"fmt"
-	"os"
-	"path"
-	"strconv"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
 	"github.com/intelsdi-x/swan/pkg/workloads/specjbb"
 	"github.com/pkg/errors"
 )
-
-// CreateRepetitionDir creates folders that store repetition logs inside experiment's directory.
-func CreateRepetitionDir(experimentDirectory, phaseName string, repetition int) (string, error) {
-	repetitionDir := path.Join(experimentDirectory, phaseName, strconv.Itoa(repetition))
-	err := os.MkdirAll(repetitionDir, 0777)
-	if err != nil {
-		return "", errors.Wrapf(err, "could not create dir %q", repetitionDir)
-	}
-
-	err = os.Chdir(repetitionDir)
-	if err != nil {
-		return "", errors.Wrapf(err, "could not change to dir %q", repetitionDir)
-	}
-
-	return repetitionDir, nil
-}
-
-// CreateExperimentDir creates directory structure for the experiment.
-func CreateExperimentDir(uuid string) (experimentDirectory string, logFile *os.File, err error) {
-	experimentDirectory = path.Join(os.TempDir(), conf.AppName(), uuid)
-	err = os.MkdirAll(experimentDirectory, 0777)
-	if err != nil {
-		return "", &os.File{}, errors.Wrapf(err, "cannot create experiment directory: ", experimentDirectory)
-	}
-	err = os.Chdir(experimentDirectory)
-	if err != nil {
-		return "", &os.File{}, errors.Wrapf(err, "cannot chdir to experiment directory", experimentDirectory)
-	}
-
-	masterLogFilename := path.Join(experimentDirectory, "master.log")
-	logFile, err = os.OpenFile(masterLogFilename, os.O_WRONLY|os.O_CREATE, 0755)
-	if err != nil {
-		return "", &os.File{}, errors.Wrapf(err, "could not open log file %q", masterLogFilename)
-	}
-
-	return experimentDirectory, logFile, nil
-}
 
 // PrepareSnapSpecjbbSessionLauncher prepares a SessionLauncher that runs SPECjbb collector and records that into storage.
 // TODO: this should be put into swan:/pkg/snap

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -82,7 +82,7 @@ func main() {
 	fmt.Println(uuid.String())
 
 	// Each experiment should have it's own directory to store logs and errors
-	experimentDirectory, logFile, err := common.CreateExperimentDir(uuid.String())
+	experimentDirectory, logFile, err := experiment.CreateExperimentDir(uuid.String(), conf.AppName())
 	if err != nil {
 		logrus.Errorf("IO error: %q", err.Error())
 		os.Exit(ExIOErr)
@@ -221,7 +221,7 @@ func main() {
 
 					logrus.Infof("Starting %s repetition %d", phaseName, repetition)
 
-					_, err := common.CreateRepetitionDir(experimentDirectory, phaseName, repetition)
+					err := experiment.CreateRepetitionDir(experimentDirectory, phaseName, repetition)
 					if err != nil {
 						return errors.Wrapf(err, "cannot create repetition log directory in %s, repetition %d", phaseName, repetition)
 					}

--- a/pkg/experiment/experiment.go
+++ b/pkg/experiment/experiment.go
@@ -218,3 +218,40 @@ func (e *Experiment) logInitialize() (err error) {
 
 	return err
 }
+
+// CreateExperimentDir creates directory structure for the experiment.
+func CreateExperimentDir(uuid, appName string) (experimentDirectory string, logFile *os.File, err error) {
+	experimentDirectory = path.Join(os.TempDir(), appName, uuid)
+	err = os.MkdirAll(experimentDirectory, 0777)
+	if err != nil {
+		return "", &os.File{}, errors.Wrapf(err, "cannot create experiment directory: ", experimentDirectory)
+	}
+	err = os.Chdir(experimentDirectory)
+	if err != nil {
+		return "", &os.File{}, errors.Wrapf(err, "cannot chdir to experiment directory", experimentDirectory)
+	}
+
+	masterLogFilename := path.Join(experimentDirectory, "master.log")
+	logFile, err = os.OpenFile(masterLogFilename, os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return "", &os.File{}, errors.Wrapf(err, "could not open log file %q", masterLogFilename)
+	}
+
+	return experimentDirectory, logFile, nil
+}
+
+// CreateRepetitionDir creates folders that store repetition logs inside experiment's directory.
+func CreateRepetitionDir(experimentDirectory, phaseName string, repetition int) error {
+	repetitionDir := path.Join(experimentDirectory, phaseName, strconv.Itoa(repetition))
+	err := os.MkdirAll(repetitionDir, 0777)
+	if err != nil {
+		return errors.Wrapf(err, "could not create dir %q", repetitionDir)
+	}
+
+	err = os.Chdir(repetitionDir)
+	if err != nil {
+		return errors.Wrapf(err, "could not change to dir %q", repetitionDir)
+	}
+
+	return nil
+}


### PR DESCRIPTION
In Memcached and SPECjbb experiment CreateExperimentDir and
CreateRepetitionDir functions were the same and were moved
to pkg/experiment as utility functions.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>