### PR TITLE
Drop PrepareSnapSpecjbbSessionLauncher

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -5,8 +5,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
-	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/workloads/mutilate"
 	"github.com/pkg/errors"
 )
@@ -28,22 +26,6 @@ var (
 		"mutilate_agent",
 		"Mutilate agent hosts for remote executor. Can be specified many times for multiple agents setup.")
 )
-
-// PrepareSnapMutilateSessionLauncher prepares a SessionLauncher that runs mutilate collector and records that into storage.
-// TODO: this should be put into swan:/pkg/snap
-func PrepareSnapMutilateSessionLauncher() (snap.SessionLauncher, error) {
-	// Create connection with Snap.
-	logrus.Info("Connecting to Snapteld on ", snap.SnapteldHTTPEndpoint.Value())
-	// TODO(bp): Make helper for passing host:port or only host option here.
-
-	mutilateConfig := mutilatesession.DefaultConfig()
-	mutilateConfig.SnapteldAddress = snap.SnapteldHTTPEndpoint.Value()
-	mutilateSnapSession, err := mutilatesession.NewSessionLauncher(mutilateConfig)
-	if err != nil {
-		return nil, err
-	}
-	return mutilateSnapSession, nil
-}
 
 // PrepareMutilateGenerator creates new LoadGenerator based on mutilate.
 func PrepareMutilateGenerator(memcacheIP string, memcachePort int) (executor.LoadGenerator, error) {

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/topology"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
+	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	"github.com/nu7hatch/gouuid"
@@ -118,7 +119,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 		os.Exit(ExSoftware)
 	}
 
-	snapSession, err := common.PrepareSnapMutilateSessionLauncher()
+	snapSession, err := mutilatesession.NewSessionLauncherDefault()
 	if err != nil {
 		logrus.Errorf("Cannot create snap session: %q", err.Error())
 		os.Exit(ExSoftware)

--- a/experiments/specjbb-sensitivity-profile/common/common.go
+++ b/experiments/specjbb-sensitivity-profile/common/common.go
@@ -1,33 +1,10 @@
 package common
 
 import (
-	"fmt"
-
-	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
 	"github.com/intelsdi-x/swan/pkg/workloads/specjbb"
 	"github.com/pkg/errors"
 )
-
-// PrepareSnapSpecjbbSessionLauncher prepares a SessionLauncher that runs SPECjbb collector and records that into storage.
-// TODO: this should be put into swan:/pkg/snap
-func PrepareSnapSpecjbbSessionLauncher() (snap.SessionLauncher, error) {
-	// NOTE: For debug it is convenient to disable snap for some experiment runs.
-	if snap.SnapteldHTTPEndpoint.Value() != "none" {
-		// Create connection with Snap.
-		logrus.Info("Connecting to Snapteld on ", snap.SnapteldHTTPEndpoint.Value())
-		specjbbConfig := specjbbsession.DefaultConfig()
-		specjbbConfig.SnapteldAddress = snap.SnapteldHTTPEndpoint.Value()
-		specjbbSnapSession, err := specjbbsession.NewSessionLauncher(specjbbConfig)
-		if err != nil {
-			return nil, err
-		}
-		return specjbbSnapSession, nil
-	}
-	return nil, fmt.Errorf("snap http endpoint is not present, cannot prepare SPECjbb session launcher")
-}
 
 // PrepareSpecjbbLoadGenerator creates new LoadGenerator based on specjbb.
 func PrepareSpecjbbLoadGenerator(ip string) (executor.LoadGenerator, error) {

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/topology"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
+	"github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/workloads/specjbb"
 	"github.com/nu7hatch/gouuid"
@@ -126,7 +127,9 @@ func main() {
 	if err != nil {
 		return
 	}
-	specjbbSnapSession, err := common.PrepareSnapSpecjbbSessionLauncher()
+
+	// Note: DefaultConfig shall set SnaptelAddress.
+	specjbbSnapSession, err := specjbbsession.NewSessionLauncherDefault()
 	if err != nil {
 		return
 	}

--- a/pkg/snap/sessions/mutilate/mutilate.go
+++ b/pkg/snap/sessions/mutilate/mutilate.go
@@ -36,6 +36,12 @@ type SessionLauncher struct {
 	snapClient *client.Client
 }
 
+// NewSessionLauncherDefault creates SessionLauncher based on values
+// returned by DefaultConfig().
+func NewSessionLauncherDefault() (*SessionLauncher, error) {
+	return NewSessionLauncher(DefaultConfig())
+}
+
 // NewSessionLauncher constructs MutilateSnapSessionLauncher.
 func NewSessionLauncher(config Config) (*SessionLauncher, error) {
 	snapClient, err := client.New(config.SnapteldAddress, "v1", true)

--- a/pkg/snap/sessions/specjbb/specjbb.go
+++ b/pkg/snap/sessions/specjbb/specjbb.go
@@ -36,6 +36,12 @@ type SessionLauncher struct {
 	snapClient *client.Client
 }
 
+// NewSessionLauncherDefault creates SessionLauncher based on values
+// returned by DefaultConfig().
+func NewSessionLauncherDefault() (*SessionLauncher, error) {
+	return NewSessionLauncher(DefaultConfig())
+}
+
 // NewSessionLauncher constructs SPECjbbSnapSessionLauncher.
 func NewSessionLauncher(config Config) (*SessionLauncher, error) {
 	snapClient, err := client.New(config.SnapteldAddress, "v1", true)


### PR DESCRIPTION
Removed PrepareSnapSpecjbbSessionLauncher and
PrepareSnapMutilateSessionLauncher since they can be simply replaced
by generic default session launcher from snap session package.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

