### PR TITLE
Grabbing L3 size from /sys/devices instead of /proc/cpuinfo

### DIFF
--- a/workloads/low-level-aggressors/l3.c
+++ b/workloads/low-level-aggressors/l3.c
@@ -8,49 +8,66 @@
 #include <time.h>
 #include <sched.h>
 
-#define CACHE_SIZE 20*1024*1024
+// Returns the size of the L3 cache in bytes, otherwise -1 on error.
+int cache_size() {
+    // We grab the cache size from cpu 0, assuming that all cpu caches are the
+    // same size.
+    const char* cache_size_path =
+        "/sys/devices/system/cpu/cpu0/cache/index3/size";
 
-void remove_all_chars(char* str, char c) {
-	char *pr = str, *pw = str;
-	while (*pr) {
-		*pw = *pr++;
-		pw += (*pw != c);
-	}
-	*pw = '\0';
-}
-
-int cache_size_kb(void) {
-	char line[512], buffer[32];
-	int column;
-	FILE *cpuinfo;
-
-
-	if (!(cpuinfo = fopen("/proc/cpuinfo", "r"))) {
-		perror("/proc/cpuinfo: fopen");
+	FILE *cache_size_fd;
+	if (!(cache_size_fd = fopen(cache_size_path, "r"))) {
+		perror("could not open cache size file");
 		return -1;
 	}
 
-
-	while (fgets(line, sizeof(line), cpuinfo)) {
-		if (strstr(line, "cache size")) {
-			char* colStr;
-			colStr = strstr(line, ":");
-			remove_all_chars(colStr, ':'); 
-			remove_all_chars(colStr, 'K'); 
-			remove_all_chars(colStr, 'B');
-			column = atoi(colStr); 
-			fclose(cpuinfo);
-			return (int) column; 
-		}
+	char line[512];
+	if(!fgets(line, 512, cache_size_fd)) {
+		fclose(cache_size_fd);
+		perror("could not read from cache size file");
+		return -1;
 	}
-	fclose(cpuinfo);
-	return -1;
+
+	// Strip newline
+	const int newline_pos = strlen(line) - 1;
+	if (line[newline_pos] == '\n') {
+		line[newline_pos] = '\0';
+	}
+
+	// Get multiplier
+	int multiplier = 1;
+	const int multiplier_pos = newline_pos - 1;
+	switch (line[multiplier_pos]) {
+		case 'K':
+			multiplier = 1024;
+		break;
+		case 'M':
+			multiplier = 1024 * 1024;
+		break;
+		case 'G':
+			multiplier = 1024 * 1024 * 1024;
+		break;
+	}
+
+	// Remove multiplier
+	if (multiplier != 1) {
+		line[multiplier_pos] = '\0';
+	}
+
+	// Line should now be clear of non-numeric characters
+	int value = atoi(line);
+
+	int cache_size = value * multiplier;
+
+	fclose(cache_size_fd);
+
+	return cache_size;
 }
 
 int main(int argc, char **argv) {
 	char* volatile block;
-	// int CACHE_SIZE = cache_size_kb(); 
-	printf("%d\n", CACHE_SIZE);
+	int CACHE_SIZE = cache_size(); 
+	printf("Detected L3 cache size: %d bytes\n", CACHE_SIZE);
 
 	/*Usage: ./l3 <duration in sec>*/
 	if (argc < 2) { 


### PR DESCRIPTION
We assume that the L3 cache is 20MB in size. That is a not a good assumption to make and will not stress the L3 cache optimally.

Summary of changes:
- Changes the cache_size_kb to cache_size
- Gets cache information from /sys/devices such that we can grab the L2 and L1 sizes in a similar manner.

Testing done:
- Tested manually with an Xeon D host and monitoring with `pqos`
