### PR TITLE
Move GetPeakLoad to executor package

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -6,7 +6,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
 	"github.com/intelsdi-x/swan/pkg/workloads/mutilate"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -71,32 +70,4 @@ func PrepareMutilateGenerator(memcacheIP string, memcachePort int) (executor.Loa
 		mutilateConfig)
 
 	return mutilateLoadGenerator, nil
-}
-
-// GetPeakLoad runs tuning in order to determine the peak load.
-func GetPeakLoad(hpLauncher executor.Launcher, loadGenerator executor.LoadGenerator, slo int) (peakLoad int, err error) {
-	prTask, err := hpLauncher.Launch()
-	if err != nil {
-		return 0, errors.Wrap(err, "cannot launch memcached")
-	}
-	defer func() {
-		// If function terminated with error then we do not want to overwrite it with any errors in defer.
-		errStop := prTask.Stop()
-		if err == nil {
-			err = errStop
-		}
-		prTask.Clean()
-	}()
-
-	err = loadGenerator.Populate()
-	if err != nil {
-		return 0, errors.Wrap(err, "cannot populate memcached")
-	}
-
-	peakLoad, _, err = loadGenerator.Tune(slo)
-	if err != nil {
-		return 0, errors.Wrap(err, "tuning failed")
-	}
-
-	return
 }

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -106,7 +106,7 @@ It executes workloads and triggers gathering of certain metrics like latency (SL
 	// Retrieve peak load from flags and overwrite it when required.
 	load := sensitivity.PeakLoadFlag.Value()
 	if sensitivity.PeakLoadFlag.Value() == sensitivity.RunTuningPhase {
-		load, err = common.GetPeakLoad(hpLauncher, loadGenerator, sensitivity.SLOFlag.Value())
+		load, err = experiment.GetPeakLoad(hpLauncher, loadGenerator, sensitivity.SLOFlag.Value())
 		if err != nil {
 			logrus.Errorf("Cannot retrieve peak load (using tuning): %q", err.Error())
 			os.Exit(experiment.ExSoftware)

--- a/experiments/specjbb-sensitivity-profile/common/common.go
+++ b/experiments/specjbb-sensitivity-profile/common/common.go
@@ -3,7 +3,6 @@ package common
 import (
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/workloads/specjbb"
-	"github.com/pkg/errors"
 )
 
 // PrepareSpecjbbLoadGenerator creates new LoadGenerator based on specjbb.
@@ -40,32 +39,4 @@ func PrepareSpecjbbLoadGenerator(ip string) (executor.LoadGenerator, error) {
 		transactionInjectors, specjbbLoadGeneratorConfig)
 
 	return loadGeneratorLauncher, nil
-}
-
-// GetPeakLoad runs tuning in order to determine the peak load.
-func GetPeakLoad(hpLauncher executor.Launcher, loadGenerator executor.LoadGenerator, slo int) (peakLoad int, err error) {
-	prTask, err := hpLauncher.Launch()
-	if err != nil {
-		return 0, errors.Wrap(err, "cannot launch specjbb backend")
-	}
-	defer func() {
-		// If function terminated with error then we do not want to overwrite it with any errors in defer.
-		errStop := prTask.Stop()
-		if err == nil {
-			err = errStop
-		}
-		prTask.Clean()
-	}()
-
-	err = loadGenerator.Populate()
-	if err != nil {
-		return 0, errors.Wrap(err, "cannot populate memcached")
-	}
-
-	peakLoad, _, err = loadGenerator.Tune(slo)
-	if err != nil {
-		return 0, errors.Wrap(err, "tuning failed")
-	}
-
-	return
 }

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -117,7 +117,7 @@ func main() {
 	load := sensitivity.PeakLoadFlag.Value()
 
 	if load == sensitivity.RunTuningPhase {
-		load, err = common.GetPeakLoad(specjbbBackendLauncher, specjbbLoadGeneratorSessionPair.LoadGenerator, sensitivity.SLOFlag.Value())
+		load, err = experiment.GetPeakLoad(specjbbBackendLauncher, specjbbLoadGeneratorSessionPair.LoadGenerator, sensitivity.SLOFlag.Value())
 		if err != nil {
 			logrus.Errorf("Cannot retrieve peak load (using tuning): %q", err.Error())
 			os.Exit(experiment.ExSoftware)

--- a/pkg/experiment/peakload.go
+++ b/pkg/experiment/peakload.go
@@ -1,0 +1,34 @@
+package experiment
+
+import (
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/pkg/errors"
+)
+
+// GetPeakLoad runs tuning in order to determine the peak load.
+func GetPeakLoad(hpLauncher executor.Launcher, loadGenerator executor.LoadGenerator, slo int) (peakLoad int, err error) {
+	prTask, err := hpLauncher.Launch()
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot launch specjbb backend")
+	}
+	defer func() {
+		// If function terminated with error then we do not want to overwrite it with any errors in defer.
+		errStop := prTask.Stop()
+		if err == nil {
+			err = errStop
+		}
+		prTask.Clean()
+	}()
+
+	err = loadGenerator.Populate()
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot populate memcached")
+	}
+
+	peakLoad, _, err = loadGenerator.Tune(slo)
+	if err != nil {
+		return 0, errors.Wrap(err, "tuning failed")
+	}
+
+	return
+}


### PR DESCRIPTION
GetPeakLoad which is defined in both Memcached and SPECjbb
sensitivity experiment shall be moved to pkg/executor package

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
