### PR TITLE
Better error for out-of-date schema in metadata

### DIFF
--- a/pkg/experiment/metadata.go
+++ b/pkg/experiment/metadata.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/intelsdi-x/swan/pkg/conf"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -156,7 +157,8 @@ func (m *Metadata) Connect() error {
 
 // storeMap
 func (m *Metadata) storeMap(metadata MetadataMap, kind string) error {
-	return m.session.Query(`INSERT INTO swan.metadata (experiment_id, kind, time, timeuuid, metadata) VALUES (?, ?, ?, ?, ?)`, m.experimentID, kind, time.Now(), gocql.TimeUUID(), metadata).Exec()
+	err := m.session.Query(`INSERT INTO swan.metadata (experiment_id, kind, time, timeuuid, metadata) VALUES (?, ?, ?, ?, ?)`, m.experimentID, kind, time.Now(), gocql.TimeUUID(), metadata).Exec()
+	return errors.Wrapf(err, "cannot publish metadata of kind %q", kind)
 }
 
 // Record stores a key and value and associates with the experiment id.


### PR DESCRIPTION
Fixes issue "cryptographic" errors message if metadata schema is out of date.

Fixes:
```sh
➜  swan (master)  SWAN_LOG=debug go run ./experiments/memcached-sensitivity-profile/main.go
INFO[0000] Starting Experiment memcached-sensitivity-profile with uuid 7769d49d-8539-4b7b-554c-4445d1880dec
7769d49d-8539-4b7b-554c-4445d1880dec
DEBU[0000] Undefined column name kind
FATA[0000] Undefined column name kind
``` 
or even fancier (old cassandra) `**Unknown identifier kind**' into something like this
```
➜  swan (ppalucki/schema-better-error)  SWAN_LOG=debug go run ./experiments/memcached-sensitivity-profile/main.go
INFO[0000] Starting Experiment memcached-sensitivity-profile with uuid f0e60dc7-0b07-4f55-46a1-7eb5b16f6a33
f0e60dc7-0b07-4f55-46a1-7eb5b16f6a33
DEBU[0000] Undefined column name kind
cannot publish metadata of kind "flags"
github.com/intelsdi-x/swan/pkg/experiment.(*Metadata).storeMap
        /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/pkg/experiment/metadata.go:161
github.com/intelsdi-x/swan/pkg/experiment.(*Metadata).RecordFlags
        /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/pkg/experiment/metadata.go:184
main.main
        /home/ppalucki/work/gopath/src/github.com/intelsdi-x/swan/experiments/memcached-sensitivity-profile/main.go:54
FATA[0000] cannot publish metadata of kind "flags": Undefined column name kind
``` 

Summary of changes:
- wrap error with message


Testing done:
- manually (check outputs above)
