### PR TITLE
Allow to pass -K -V and -i parameters to mutilate

### DIFF
--- a/pkg/workloads/mutilate/commands.go
+++ b/pkg/workloads/mutilate/commands.go
@@ -47,8 +47,8 @@ func getBaseMasterCommand(config Config, agentHandles []executor.TaskHandle) str
 	baseCommand := fmt.Sprint(
 		fmt.Sprintf("%s", config.PathToBinary),
 		fmt.Sprintf(" -s %s:%d", config.MemcachedHost, config.MemcachedPort),
-		fmt.Sprintf(" --warmup %d --noload ", int(config.WarmupTime.Seconds())),
-		fmt.Sprintf(" -K %d -V %d", config.KeySize, config.ValueSize),
+		fmt.Sprintf(" --warmup %d --noload", int(config.WarmupTime.Seconds())),
+		fmt.Sprintf(" -K %s -V %s -i %s", config.KeySize, config.ValueSize, config.InterArrivalDist),
 		fmt.Sprintf(" -T %d", config.MasterThreads),
 		fmt.Sprintf(" -d %d -c %d", config.AgentConnectionsDepth, config.AgentConnections),
 		fmt.Sprintf(" -r %d", config.Records),

--- a/pkg/workloads/mutilate/commands_test.go
+++ b/pkg/workloads/mutilate/commands_test.go
@@ -51,10 +51,12 @@ func (s *MutilateTestSuite) soExpectBaseCommandOptions(command string) {
 		So(command, ShouldContainSubstring, expected)
 	})
 
-	Convey("Mutilate base command should contain keySize and valuSize option", s.T(), func() {
-		expected := fmt.Sprintf("-K %d", s.mutilate.config.KeySize)
+	Convey("Mutilate base command should contain keySize, valuSize and interArrivalDist option", s.T(), func() {
+		expected := fmt.Sprintf("-K %s", s.mutilate.config.KeySize)
 		So(command, ShouldContainSubstring, expected)
-		expected = fmt.Sprintf("-V %d", s.mutilate.config.ValueSize)
+		expected = fmt.Sprintf("-V %s", s.mutilate.config.ValueSize)
+		So(command, ShouldContainSubstring, expected)
+		expected = fmt.Sprintf("-i %s", s.mutilate.config.InterArrivalDist)
 		So(command, ShouldContainSubstring, expected)
 	})
 

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -31,8 +31,9 @@ const (
 	defaultMasterConnectionsDepth = 4
 	defaultMasterAffinity         = false
 	defaultMasterBlocking         = true
-	defaultKeySize                = 30  // [bytes]
-	defaultValueSize              = 200 // [bytes]
+	defaultMasterKeySize          = "30"          // [bytes]
+	defaultMasterValueSize        = "200"         // [bytes]
+	defaultMasterInterArrivalDist = "exponential" // disabled
 	defaultMasterQPS              = 1000
 )
 
@@ -54,6 +55,9 @@ var (
 	masterAffinityFlag         = conf.NewBoolFlag("mutilate_master_affinity", "Mutilate master affinity (--affinity).", defaultMasterAffinity)
 	masterBlockingFlag         = conf.NewBoolFlag("mutilate_master_blocking", "Mutilate master blocking (--blocking -B).", defaultMasterBlocking)
 	masterQPSFlag              = conf.NewIntFlag("mutilate_master_qps", "Mutilate master QPS value (-Q).", defaultMasterQPS)
+	masterKeySizeFlag          = conf.NewStringFlag("mutilate_master_keysize", "Length of memcached keys (-K).", defaultMasterKeySize)
+	masterValueSizeFlag        = conf.NewStringFlag("mutilate_master_valuesize", "Length of memcached values (-V).", defaultMasterValueSize)
+	masterInterArrivalDistFlag = conf.NewStringFlag("mutilate_master_interarrivaldist", "Inter-arrival distribution (-i).", defaultMasterInterArrivalDist)
 )
 
 // Config contains all data for running mutilate.
@@ -70,13 +74,14 @@ type Config struct {
 	LatencyPercentile string
 	Records           int
 
-	AgentConnections      int  // -c
-	AgentConnectionsDepth int  // Max length of request pipeline. -d
-	MasterThreads         int  // -T
-	MasterAffinity        bool // Set CPU affinity for threads, round-robin (for Master)
-	MasterBlocking        bool // -B --blocking:  Use blocking epoll().  May increase latency (for Master).
-	KeySize               int  // Length of memcached keys. -K
-	ValueSize             int  // Length of memcached values. -V
+	AgentConnections      int    // -c
+	AgentConnectionsDepth int    // Max length of request pipeline. -d
+	MasterThreads         int    // -T
+	MasterAffinity        bool   // Set CPU affinity for threads, round-robin (for Master)
+	MasterBlocking        bool   // -B --blocking:  Use blocking epoll().  May increase latency (for Master).
+	KeySize               string // Length of memcached keys. -K
+	ValueSize             string // Length of memcached values. -V
+	InterArrivalDist      string // Inter-arrival distribution. -i
 
 	// Agent-mode options.
 	AgentThreads           int  // Number of threads for all agents. -T
@@ -120,8 +125,9 @@ func DefaultMutilateConfig() Config {
 		MasterConnectionsDepth: masterConnectionsDepthFlag.Value(),
 		MasterAffinity:         masterAffinityFlag.Value(),
 		MasterBlocking:         masterBlockingFlag.Value(),
-		KeySize:                defaultKeySize,
-		ValueSize:              defaultValueSize,
+		KeySize:                masterKeySizeFlag.Value(),
+		ValueSize:              masterValueSizeFlag.Value(),
+		InterArrivalDist:       masterInterArrivalDistFlag.Value(),
 		MasterQPS:              masterQPSFlag.Value(),
 		AgentPort:              agentAgentPortFlag.Value(),
 	}

--- a/pkg/workloads/mutilate/mutilate_test.go
+++ b/pkg/workloads/mutilate/mutilate_test.go
@@ -25,8 +25,9 @@ const (
 	masterThreads          = 4
 	masterConnections      = 23
 	masterConnectionsDepth = 1
-	keySize                = 3
-	valueSize              = 5
+	keySize                = "3"
+	valueSize              = "5"
+	intearrivaldist        = "fb_ia"
 	latencyPercentile      = "99.9234"
 
 	correctMutilateQPS    = 4450
@@ -82,6 +83,7 @@ func (s *MutilateTestSuite) SetupTest() {
 	s.config.MasterConnectionsDepth = masterConnectionsDepth
 	s.config.KeySize = keySize
 	s.config.ValueSize = valueSize
+	s.config.InterArrivalDist = intearrivaldist
 	s.mutilate.config = s.config
 
 	s.mAgentHandle1 = new(mocks.TaskHandle)


### PR DESCRIPTION
Added ability to steer mutilate with parameters KeySize, ValueSize,
InterArrivalDist. It will allow to test use facebook-like workload
(-K fb_key -V fb_value -i fb_ia).

Added flags:
mutilate_master_keysize
mutilate_master_valuesize
mutilate_master_interarrivaldist

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
