### PR TITLE
added function to store platform metrics

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -61,6 +61,12 @@ func main() {
 		os.Exit(experiment.ExSoftware)
 	}
 
+	err = metadata.RecordPlatformMetrics()
+	if err != nil {
+		logrus.Errorf("Cannot save platform metadata: %q", err.Error())
+		os.Exit(experiment.ExSoftware)
+	}
+
 	experimentDirectory, logFile, err := experiment.CreateExperimentDir(uuid.String(), appName)
 	if err != nil {
 		logrus.Errorf("IO error: %q", err.Error())

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -66,6 +66,12 @@ func main() {
 		os.Exit(experiment.ExSoftware)
 	}
 
+	err = metadata.RecordPlatformMetrics()
+	if err != nil {
+		logrus.Errorf("Cannot save platform metadata: %q", err.Error())
+		os.Exit(experiment.ExSoftware)
+	}
+
 	// Each experiment should have it's own directory to store logs and errors
 	experimentDirectory, logFile, err := experiment.CreateExperimentDir(uuid.String(), appName)
 	if err != nil {

--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gocql/gocql"
 	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
+	"github.com/intelsdi-x/swan/pkg/experiment"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/fs"
 	. "github.com/smartystreets/goconvey/convey"
@@ -136,6 +137,7 @@ func TestExperiment(t *testing.T) {
 					So(metadata["SWAN_PEAK_LOAD"], ShouldEqual, "5000")
 					So(metadata["load_points"], ShouldEqual, "1")
 					So(metadata["load_duration"], ShouldEqual, "1s")
+					So(metadata[experiment.CPUModelNameKey], ShouldNotEqual, "")
 
 				})
 

--- a/pkg/experiment/metadata.go
+++ b/pkg/experiment/metadata.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	metadataKindEmpty   = ""
-	metadataKindFlags   = "flags"
-	metadataKindEnviron = "environ"
+	metadataKindEmpty    = ""
+	metadataKindFlags    = "flags"
+	metadataKindEnviron  = "environ"
+	metadataKindPlatform = "platform"
 )
 
 // MetadataConfig encodes the settings for connecting to the database.
@@ -194,6 +195,13 @@ func (m *Metadata) RecordEnv(prefix string) error {
 		}
 	}
 	return m.storeMap(metadata, metadataKindEnviron)
+}
+
+// RecordPlatformMetrics stores platform specific metadata.
+// Platform metrics are metadataKindPlatform type.
+func (m *Metadata) RecordPlatformMetrics() error {
+	platformMetrics := GetPlatformMetrics()
+	return m.storeMap(platformMetrics, metadataKindPlatform)
 }
 
 // Get retrieves all metadata maps from the database.

--- a/pkg/experiment/platform_metrics.go
+++ b/pkg/experiment/platform_metrics.go
@@ -37,6 +37,7 @@ const (
 // GetPlatformMetrics returns map of strings with platform metrics.
 // If metric could not be retreived value for the key is empty string.
 func GetPlatformMetrics() (platformMetrics map[string]string) {
+	platformMetrics = make(map[string]string)
 	item, err := CPUModelName()
 	if err != nil {
 		logrus.Warn(fmt.Sprintf("GetPlatformMetrics: Failed to get %s metric. Skipping. Error: %s", CPUModelNameKey, err.Error()))


### PR DESCRIPTION
Added function to store platform metrics in Cassandra.
Added platform metrics to memcached and specjbb experiments.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
