### PR TITLE
In experiment: do not erase stderr/stdout logs in case of failure.

### DIFF
--- a/pkg/workloads/memcached/memcached.go
+++ b/pkg/workloads/memcached/memcached.go
@@ -121,10 +121,6 @@ func (m Memcached) Launch() (executor.TaskHandle, error) {
 		if err := task.Clean(); err != nil {
 			log.Errorf("failed to cleanup memcached task. Error: %q", err.Error())
 		}
-
-		if err := task.EraseOutput(); err != nil {
-			log.Errorf("failed to erase output of memcached task. Error: %q", err.Error())
-		}
 		return nil, errors.Errorf("failed to connect to memcached instance. Timeout on connection to %q",
 			address)
 	}


### PR DESCRIPTION
Rationale:
- in case of memcached start failure (e.g. local host numactl not available) logs are removed and there is no chance to debug it properly


Discussion:
- two launchers (namely Kubernetes, Memacached, others: caffe, lowlevel don't ) try to do some post start check (readines probes, somehting differnt than liveness using k8s nomenclature) - in my opinion we should drop all this validation and leave it - when dropped I got very clear error message from Service (instead just "couldn't not connect to memcached"

