### PR TITLE
Remove excessive SPECjbb flags.

### DIFF
--- a/pkg/workloads/specjbb/backend.go
+++ b/pkg/workloads/specjbb/backend.go
@@ -1,6 +1,8 @@
 package specjbb
 
 import (
+	"path"
+
 	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/pkg/errors"
@@ -12,14 +14,10 @@ const (
 )
 
 var (
-	// PathToBinaryForHpFlag specifies path to a SPECjbb2015 jar file for hp job.
-	PathToBinaryForHpFlag = conf.NewStringFlag("specjbb_path_hp",
-		"Path to SPECjbb jar for high priority job (backend)",
-		"/opt/swan/share/specjbb/specjbb2015.jar")
-	// PathToPropsFileForHpFlag specifies path to a SPECjbb2015 properties file for hp job.
-	PathToPropsFileForHpFlag = conf.NewStringFlag("specjbb_props_path_hp",
-		"Path to SPECjbb properties file for high priority job (backend)",
-		"/opt/swan/share/specjbb/config/specjbb2015.props")
+	// PathToSPECjbb specifies path to a SPECjbb2015 jar file for hp job.
+	PathToSPECjbb = conf.NewStringFlag("specjbb_path",
+		"Path to SPECjbb",
+		"/opt/swan/share/specjbb")
 )
 
 // BackendConfig is a config for a SPECjbb2015 Backend,
@@ -35,7 +33,7 @@ type BackendConfig struct {
 func DefaultSPECjbbBackendConfig() BackendConfig {
 	return BackendConfig{
 		JVMOptions:        DefaultJVMOptions(),
-		PathToBinary:      PathToBinaryForHpFlag.Value(),
+		PathToBinary:      path.Join(PathToSPECjbb.Value(), "specjbb2015.jar"),
 		ControllerAddress: ControllerAddress.Value(),
 		JvmID:             backendJvmID,
 		WorkerCount:       1,

--- a/pkg/workloads/specjbb/backend_test.go
+++ b/pkg/workloads/specjbb/backend_test.go
@@ -13,7 +13,7 @@ func TestBackendWithMockedExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
 	Convey("When using Backend launcher", t, func() {
-		expectedCommand := "java -server -Xms2g -Xmx2g -XX:NativeMemoryTracking=summary -XX:+UseParallelOldGC  -XX:ParallelGCThreads=1 -XX:ConcGCThreads=0 -XX:InitiatingHeapOccupancyPercent=80 -XX:MaxGCPauseMillis=100 -XX:+AlwaysPreTouch  -Dspecjbb.controller.host=127.0.0.1 -Dspecjbb.forkjoin.workers=1 -jar test -m backend -G GRP1 -J specjbbbackend1 -p /opt/swan/share/specjbb/config/specjbb2015.props"
+		expectedCommand := "java -server -Xms2g -Xmx2g -XX:NativeMemoryTracking=summary -XX:+UseParallelOldGC  -XX:ParallelGCThreads=2 -XX:ConcGCThreads=1 -XX:InitiatingHeapOccupancyPercent=80 -XX:MaxGCPauseMillis=100 -XX:+AlwaysPreTouch  -Djava.library.path=/opt/swan/share/specjbb/lib -Dspecjbb.controller.host=127.0.0.1 -Dspecjbb.forkjoin.workers=1 -jar test -m backend -G GRP1 -J specjbbbackend1 -p /opt/swan/share/specjbb/config/specjbb2015.props"
 		expectedHost := "127.0.0.1"
 
 		mockedExecutor := new(mocks.Executor)

--- a/pkg/workloads/specjbb/commands.go
+++ b/pkg/workloads/specjbb/commands.go
@@ -3,6 +3,7 @@ package specjbb
 import (
 	"fmt"
 	"time"
+	"path"
 )
 
 var (
@@ -44,7 +45,7 @@ func getBackendCommand(conf BackendConfig) string {
 		" -m backend",
 		" -G GRP1",
 		" -J ", conf.JvmID,
-		" -p ", PathToPropsFileForHpFlag.Value(),
+		" -p ", path.Join(PathToSPECjbb.Value(), "config/specjbb2015.props"),
 	)
 }
 

--- a/pkg/workloads/specjbb/jvm_options.go
+++ b/pkg/workloads/specjbb/jvm_options.go
@@ -2,6 +2,7 @@ package specjbb
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/intelsdi-x/swan/pkg/conf"
 )
@@ -9,6 +10,8 @@ import (
 var (
 	// JVMHeapMemoryGBs specifies amount of heap memory available to JVM.
 	JVMHeapMemoryGBs = conf.NewIntFlag("specjbb_jvm_heap_size", "Size of JVM heap memory in gigabytes", 2)
+	// ParallelGCThreads specifies number of thread for Garbage Collector
+	ParallelGCThreads = conf.NewIntFlag("specjbb_jvm_gc_threads", "Number of parallel GC threads", 2)
 )
 
 // JVMOptions is group of options used to configure JVM for SPECjbb.
@@ -21,7 +24,7 @@ type JVMOptions struct {
 func DefaultJVMOptions() JVMOptions {
 	return JVMOptions{
 		JVMHeapMemoryGBs:  JVMHeapMemoryGBs.Value(),
-		ParallelGCThreads: 1,
+		ParallelGCThreads: ParallelGCThreads.Value(),
 	}
 }
 
@@ -37,5 +40,6 @@ func (j JVMOptions) GetJVMOptions() string {
 		" -XX:InitiatingHeapOccupancyPercent=80",                                // Using more memory then default 45% before GC kicks in
 		" -XX:MaxGCPauseMillis=100",                                             // Maximum garbage collection pause.
 		" -XX:+AlwaysPreTouch ",                                                 // Touch & zero whole heap memory on initialization.
+		fmt.Sprintf(" -Djava.library.path=%s", path.Join(PathToSPECjbb.Value(), "lib")),
 	)
 }

--- a/pkg/workloads/specjbb/load_generator.go
+++ b/pkg/workloads/specjbb/load_generator.go
@@ -2,6 +2,7 @@ package specjbb
 
 import (
 	"time"
+	"path"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/swan/pkg/conf"
@@ -17,15 +18,6 @@ const (
 )
 
 var (
-	// PathToBinaryForLoadGeneratorFlag specifies path to a SPECjbb2015 jar file for load generator.
-	PathToBinaryForLoadGeneratorFlag = conf.NewStringFlag("specjbb_path_lg", "Path to SPECjbb jar for load generator", "/opt/swan/share/specjbb/specjbb2015.jar")
-
-	// PathToPropsFileForLoadGeneratorFlag specifies path to a SPECjbb2015 properties file for load generator.
-	PathToPropsFileForLoadGeneratorFlag = conf.NewStringFlag("specjbb_props_path_lg", "Path to SPECjbb properties file for load generator", "/opt/swan/share/specjbb/config/specjbb2015.props")
-
-	// PathToOutputTemplateFlag specifies path to a SPECjbb2015 output template file.
-	PathToOutputTemplateFlag = conf.NewStringFlag("specjbb_output_template_path", "Path to SPECjbb output template file", "/opt/swan/share/specjbb/config/template-D.raw")
-
 	// ControllerAddress specifies ControllerAddress address of a controller component of SPECjbb2015 benchmark.
 	ControllerAddress = conf.NewStringFlag("specjbb_controller_ip", "ControllerAddress address of a SPECjbb controller component", defaultControllerIP)
 
@@ -47,7 +39,7 @@ type LoadGeneratorConfig struct {
 	PathToProps          string // PathToProps is a path to property file that stores basic configuration.
 	CustomerNumber       int    // CustomerNumber is a number of customers used to generate load.
 	ProductNumber        int    // ProductNumber is a number of products used to generate load.
-	BinaryDataOutputDir  string // binaryDataOutputDir is a dir where binary raw data file is stored during run of SPECjbb.
+	BinaryDataOutputDir  string // BinaryDataOutputDir is a dir where binary raw data file is stored during run of SPECjbb.
 	PathToOutputTemplate string // PathToOutputTemplate is a path to template used to generate report from.
 	HandshakeTimeoutMs   int    // HandshakeTimeoutMs is timeout (in milliseconds) for initial Controller <-> Agent handshaking.
 	EraseTuningOutput    bool   // Erase stdout & stderr logs from processes ran by Load Generator.
@@ -58,12 +50,12 @@ func DefaultLoadGeneratorConfig() LoadGeneratorConfig {
 	return LoadGeneratorConfig{
 		JVMOptions:           DefaultJVMOptions(),
 		ControllerAddress:    ControllerAddress.Value(),
-		PathToBinary:         PathToBinaryForLoadGeneratorFlag.Value(),
-		PathToProps:          PathToPropsFileForLoadGeneratorFlag.Value(),
+		PathToBinary:         path.Join(PathToSPECjbb.Value(), "specjbb2015.jar"),
+		PathToProps:          path.Join(PathToSPECjbb.Value(), "config/specjbb2015.props"),
 		CustomerNumber:       CustomerNumberFlag.Value(),
 		ProductNumber:        ProductNumberFlag.Value(),
 		BinaryDataOutputDir:  BinaryDataOutputDirFlag.Value(),
-		PathToOutputTemplate: PathToOutputTemplateFlag.Value(),
+		PathToOutputTemplate: path.Join(PathToSPECjbb.Value(), "config/template-D.raw"),
 		HandshakeTimeoutMs:   600000,
 		EraseTuningOutput:    true,
 	}


### PR DESCRIPTION
Removed excessive flags which points to files in SPECjbb directory.
Since they are bind together it is simpler to pass only directory.

Also added flag for setting GC threads and added '-server' flag for
long running tasks.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
