### PR TITLE
Adding flag that controls number of stream aggressor's threads

### DIFF
--- a/pkg/workloads/low_level/stream/stream.go
+++ b/pkg/workloads/low_level/stream/stream.go
@@ -13,6 +13,10 @@ const (
 	name = "Stream 100M"
 )
 
+// StreamThreadNumberFlag is a flag that allows to control number of stream aggressor's threads. 0 (default) means use all available threads.
+// (https://gcc.gnu.org/onlinedocs/libgomp/OMP_005fNUM_005fTHREADS.html#OMP_005fNUM_005fTHREADS).
+var StreamThreadNumberFlag = conf.NewIntFlag("stream_thread_number", "Number of threads that stream aggressor is going to launch", 0)
+
 // PathFlag represents stream path flag.
 // You can override it to point binary of stress with different problem size
 // eg. -stream_path=low-level-aggressors/stresm.50M.
@@ -24,16 +28,15 @@ var PathFlag = conf.NewStringFlag(
 
 // Config is a struct for stream aggressor configuration.
 type Config struct {
-	Path string
-	// 0 (default) means use all available threads.
-	// (https://gcc.gnu.org/onlinedocs/libgomp/OMP_005fNUM_005fTHREADS.html#OMP_005fNUM_005fTHREADS).
+	Path       string
 	NumThreads uint
 }
 
 // DefaultConfig is a constructor for l1d aggressor Config with default parameters.
 func DefaultConfig() Config {
 	return Config{
-		Path: PathFlag.Value(),
+		Path:       PathFlag.Value(),
+		NumThreads: uint(StreamThreadNumberFlag.Value()),
 	}
 }
 


### PR DESCRIPTION
Fixes issue of being impossible to set number of stream's threads.

Summary of changes:
- flag added.

Testing done:
- all existing tests should pass.
