### PR TITLE
SCE-1093: replace moreutils-paralell with seq/xargs

### DIFF
--- a/pkg/executor/parallel.go
+++ b/pkg/executor/parallel.go
@@ -23,20 +23,14 @@ func NewParallel(numberOfClones int) Parallel {
 // Decorate implements isolation.Decorator interface by adding invocation of parallel to a command.
 func (p Parallel) Decorate(command string) string {
 	logrus.Debugf("Attempting to run command %q %d times", command, p.numberOfClones)
-	var values []interface{}
-	values = append(values, p.numberOfClones, command)
-	decorated := "parallel -j%d sh -c %q --"
-	for i := 0; i < p.numberOfClones; i++ {
-		values = append(values, i)
-		decorated += " %d"
-	}
+	decorated := fmt.Sprintf("seq %d | xargs -P%d -l -i sh -c %q", p.numberOfClones, p.numberOfClones, command)
 	// You need to run parallel in new PID namespace to make sure that all the children are killed.
 	unshare, err := isolation.NewNamespace(syscall.CLONE_NEWPID)
 	if err != nil {
 		logrus.Errorf("Impossible to create namespace decorator: %q", err)
 		return command
 	}
-	decorated = unshare.Decorate(fmt.Sprintf(decorated, values...))
+	decorated = unshare.Decorate(decorated)
 	logrus.Debugf("Parallelized command prepared: %q", decorated)
 	logrus.Debug("Be aware that using Parallel decorator will mix output from all the commands executed")
 


### PR DESCRIPTION
Fixes issue we don't need extra dependency

Summary of changes:
- just sh trick to use seq with combination of xargs to have the same result

Testing done:
- not 
