### PR TITLE
SCE-952: enable virtualbox based provisioning by default

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -43,6 +43,7 @@ Vagrant.configure(2) do |config|
 
     override.ssh.insert_key = true
     override.ssh.keys_only = true
+    override.vm.provision "shell", path: "provision.sh", env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
   end
 
   config.vm.provider :aws do |aws, override|
@@ -79,11 +80,10 @@ Vagrant.configure(2) do |config|
     ### USE BASE/CACHED IMAGE
     #aws.ami = "ami-6d1c2007" # base image
     aws.ami = (ENV['SWAN_AMI'] != '' && ENV['SWAN_AMI'] || "ami-3a66cf2c") # 2017-03-15 11:00 UTC
+    if build_cached_image
+      override.vm.provision "shell", path: "provision.sh", env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+    end
 
-  end
- 
-  if build_cached_image
-    config.vm.provision "shell", path: "provision.sh", env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
   end
   
 end


### PR DESCRIPTION
Fixes issue - simplify local developer experience 

Summary of changes:
- enable provisioingin for virtualbox by default

Testing done:
- yes locally, yes for jenkins