### PR TITLE
SCE-952: Fix wrong glide.sh install issue link.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ restart_snap:
 	sudo systemctl restart snap-telemetry
 
 glide:
-	# Workaround for https://github.com/minishift/minishift/issues/571
+	# Workaround for https://github.com/Masterminds/glide/issues/784
 	mkdir -p ${GOPATH}/bin
 	wget -q https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-386.tar.gz -O - | tar xzv --strip-components 1 -C ${GOPATH}/bin linux-386/glide
 	curl -s https://glide.sh/get | sh


### PR DESCRIPTION
Fixes issue wrong link in comment.