### PR TITLE
SCE-952: restore using local glide cache from host (for local virtualbox environment)

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure(2) do |config|
     override.ssh.insert_key = true
     override.ssh.keys_only = true
     override.vm.provision "shell", path: "provision.sh", env: {'VAGRANT_USER' => vagrant_user, 'HOME_DIR' => home_dir}
+    override.vm.synced_folder "#{ENV['HOME']}/.glide", "#{home_dir}/.glide", :mount_options => ["umask=0022,dmask=0022,fmask=0022"]
   end
 
   config.vm.provider :aws do |aws, override|

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -168,9 +168,11 @@ if [ -e "$HOME_DIR/swan_s3_creds/.s3cfg" ]; then
     cat authorized_keys >> ${HOME_DIR}/.ssh/authorized_keys
     
     echo "Install glide cache"
-    s3cmd get s3://swan-artifacts/glide-cache-2017-03-10.tgz /tmp/glide-cache.tgz
-    tar --strip-components 2 -C ${HOME_DIR} -xzf /tmp/glide-cache.tgz
-    chown -R ${VAGRANT_USER}:${VAGRANT_USER} ${HOME_DIR}/.glide
+    if [ ! -d ${HOME_DIR}/.glide ]; then
+        s3cmd get s3://swan-artifacts/glide-cache-2017-03-10.tgz /tmp/glide-cache.tgz
+        tar --strip-components 2 -C ${HOME_DIR} -xzf /tmp/glide-cache.tgz
+        chown -R ${VAGRANT_USER}:${VAGRANT_USER} ${HOME_DIR}/.glide
+    fi
 
     echo "Synchronize /opt/swan"
     # For manuall installtion


### PR DESCRIPTION
Fixes issue: "slow virtualbox preparation" - this significantly increases the virtual box preparation

Summary of changes:
- mount for virtualbox from $HOME/.glide
- conditional s3 sync of .glide-cache from if .glide folder already exit

Testing done:
- yes locally
