### PR TITLE
Reorder of function order in service handle.

### DIFF
--- a/pkg/executor/output_files_utils.go
+++ b/pkg/executor/output_files_utils.go
@@ -9,9 +9,13 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/pkg/errors"
 )
+
+// LogLinesCount is the number of lines printed from stderr & stdout in case of task failure.
+var LogLinesCount = conf.NewIntFlag("output_lines_count", "Number of lines printed from stderr & stdout in case of task unsucessful termination", 5)
 
 const outputFilePrivileges = os.FileMode(0644)
 

--- a/pkg/executor/service.go
+++ b/pkg/executor/service.go
@@ -5,16 +5,12 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/pkg/errors"
 )
 
 var (
 	// ErrServiceStopped indicates that task supposed to run endlessly stopped unexpectedly.
 	ErrServiceStopped = errors.New("Task is not running")
-
-	// LogLinesCount is the number of lines printed from stderr & stdout in case of task failure.
-	LogLinesCount = conf.NewIntFlag("output_lines_count", "Number of lines printed from stderr & stdout in case of task unsucessful termination", 5)
 )
 
 /**


### PR DESCRIPTION
Moved output printing functions to output_files_utils for further reuse.