### PR TITLE
Extending Makefile, fixing issues with CAT experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 - TEST_SUITE=test_jupyter_lint
 - TEST_SUITE=test_jupyter_unit
 - TEST_SUITE=test_integration_build
+- TEST_SUITE=build
 before_script:
 - make deps
 script: "make $TEST_SUITE"

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,11 @@ build_plugins:
 	(cd build/plugins; go build ../../plugins/snap-plugin-collector-caffe-inference)
 
 build_swan:
-	mkdir -p build/experiments/memcached build/experiments/specjbb
+	go build -i -v ./experiments/...
+	mkdir -p build/experiments/memcached build/experiments/specjbb build/experiments/memcached-cat
 	(cd build/experiments/memcached; go build ../../../experiments/memcached-sensitivity-profile)
 	(cd build/experiments/specjbb; go build ../../../experiments/specjbb-sensitivity-profile)
+	(cd build/experiments/memcached-cat; go build ../../../experiments/memcached-cat)
 
 
 # testing
@@ -98,6 +100,7 @@ show_env:
 dist:
 	tar -C ./build/experiments/memcached -cvf swan.tar memcached-sensitivity-profile 
 	tar -C ./build/experiments/specjbb -rvf swan.tar specjbb-sensitivity-profile
+	tar -C ./build/experiments/memcached-cat -rvf swan.tar memcached-cat
 	tar -C ./build/plugins -rvf swan.tar snap-plugin-collector-caffe-inference snap-plugin-collector-mutilate snap-plugin-collector-specjbb snap-plugin-publisher-session-test
 	gzip -f swan.tar
 

--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
+	"github.com/intelsdi-x/swan/pkg/utils/uuid"
 	"github.com/intelsdi-x/swan/pkg/workloads/caffe"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1data"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1instruction"
@@ -29,7 +30,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/memoryBandwidth"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/stream"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
-	"github.com/nu7hatch/gouuid"
 	"github.com/pkg/errors"
 )
 
@@ -55,16 +55,15 @@ func main() {
 	}
 
 	// Generate an experiment ID and start the metadata session.
-	uid, err := uuid.NewV4()
-	errutil.CheckWithContext(err, "Cannot generate experiment ID")
+	uid := uuid.New()
 
 	// Connect to metadata database
-	metadata := experiment.NewMetadata(uid.String(), experiment.MetadataConfigFromFlags())
-	err = metadata.Connect()
+	metadata := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
+	err := metadata.Connect()
 	errutil.CheckWithContext(err, "Cannot connect to metadata database")
 
-	logrus.Info("Starting Experiment ", appName, " with uid ", uid.String())
-	fmt.Println(uid.String())
+	logrus.Info("Starting Experiment ", appName, " with uid ", uid)
+	fmt.Println(uid)
 
 	// Write configuration as metadata.
 	err = metadata.RecordFlags()
@@ -81,7 +80,7 @@ func main() {
 	errutil.CheckWithContext(err, "Cannot save hostname and time to metadata database")
 
 	// Create experiment directory
-	experimentDirectory, logFile, err := experiment.CreateExperimentDir(uid.String(), appName)
+	experimentDirectory, logFile, err := experiment.CreateExperimentDir(uid, appName)
 	errutil.CheckWithContext(err, "Cannot create experiment logs directory")
 
 	// Setup logging set to both output and logFile.
@@ -152,7 +151,7 @@ func main() {
 	}
 
 	// We need to calculate mask for all cache ways to be able to calculate non-overlapping cache partitions.
-	var wholeCacheMask int = 1<<(maxCacheWaysToAssign+minCacheWaysToAssign) - 1
+	wholeCacheMask := 1<<(maxCacheWaysToAssign+minCacheWaysToAssign) - 1
 	for _, aggressorName := range aggressors {
 		logrus.Debugf("starting aggressor: %s", aggressorName)
 		for _, qps := range qpsList {
@@ -229,7 +228,7 @@ func main() {
 					executeRepetition := func() error {
 						// Building snap workload tags.
 						snapTags := fmt.Sprintf("%s:%s,%s:%s,%s:%d,%s:%d,%s:%s,%s:%#x,%s:%#x,%s:%d,%s:%d",
-							experiment.ExperimentKey, uid.String(),
+							experiment.ExperimentKey, uid,
 							experiment.PhaseKey, phaseName,
 							experiment.RepetitionKey, 0,
 							experiment.LoadPointQPSKey, beCacheMask,
@@ -335,7 +334,7 @@ func main() {
 			beIteration++
 		}
 	}
-	logrus.Infof("Ended experiment %s with uid %s in %s", appName, uid.String(), time.Since(experimentStart).String())
+	logrus.Infof("Ended experiment %s with uid %s in %s", appName, uid, time.Since(experimentStart).String())
 }
 
 func launchKubernetesCluster() (func() error, error) {


### PR DESCRIPTION
Fixes issue of not buildable CAT experiment.

Summary of changes:
- extended `Makefile`
- removed gouuid from the experiment
- removed unnecessary type declaration

Testing done:
- the experiment should now build on Travis.
