### PR TITLE
SCE-1052: stressng workload

### DIFF
--- a/integration_tests/pkg/workloads/stressng/stressng_test.go
+++ b/integration_tests/pkg/workloads/stressng/stressng_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/swan/pkg/executor"
+	"github.com/intelsdi-x/swan/pkg/workloads/low_level/stressng"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// TestStressng  is an integration test with local executor
+func TestStressng(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	Convey("While using Local Shell in stress-ng launcher", t, func() {
+		l := executor.NewLocal()
+		stressngLauncher := stressng.New(l, "-c 1")
+
+		Convey("When binary is launched", func() {
+			taskHandle, err := stressngLauncher.Launch()
+			if taskHandle != nil {
+				defer taskHandle.Stop()
+				defer taskHandle.EraseOutput()
+			}
+
+			Convey("There should be no error", func() {
+				stopErr := taskHandle.Stop()
+
+				So(err, ShouldBeNil)
+				So(stopErr, ShouldBeNil)
+			})
+
+			Convey("workload should be running", func() {
+				So(taskHandle.Status(), ShouldEqual, executor.RUNNING)
+			})
+
+			Convey("When we stop the task", func() {
+				err := taskHandle.Stop()
+				Convey("There should be no error", func() {
+					So(err, ShouldBeNil)
+				})
+				Convey("The task should be terminated and the task status should be -1", func() {
+					taskState := taskHandle.Status()
+					So(taskState, ShouldEqual, executor.TERMINATED)
+
+					exitCode, err := taskHandle.ExitCode()
+
+					So(err, ShouldBeNil)
+					So(exitCode, ShouldEqual, -1)
+				})
+			})
+		})
+
+	})
+
+}

--- a/pkg/workloads/low_level/stressng/stressng.go
+++ b/pkg/workloads/low_level/stressng/stressng.go
@@ -1,0 +1,36 @@
+package stressng
+
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/swan/pkg/executor"
+)
+
+const (
+	// ID is used for specifying which aggressors should be used via parameters.
+	ID = "stressng"
+)
+
+// l1d is a launcher for stress-ng aggressor.
+type stressng struct {
+	executor  executor.Executor
+	arguments string
+}
+
+// New is a constructor for stress-ng aggressor.
+func New(executor executor.Executor, arguments string) executor.Launcher {
+	return stressng{
+		executor:  executor,
+		arguments: arguments,
+	}
+}
+
+// Launch starts a workload.
+func (s stressng) Launch() (executor.TaskHandle, error) {
+	return s.executor.Execute(fmt.Sprintf("stress-ng %s", s.arguments))
+}
+
+// Name returns readable name.
+func (s stressng) Name() string {
+	return "Stress-ng"
+}

--- a/pkg/workloads/low_level/stressng/stressng_test.go
+++ b/pkg/workloads/low_level/stressng/stressng_test.go
@@ -1,0 +1,52 @@
+package stressng
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/intelsdi-x/swan/pkg/executor/mocks"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStressng(t *testing.T) {
+
+	mockedExecutor := new(mocks.Executor)
+	mockedTask := new(mocks.TaskHandle)
+
+	Convey("While using l1d aggressor launcher", t, func() {
+		const (
+			validCommand = "stress-ng -foo --bar"
+		)
+
+		Convey("Default configuration should be valid", func() {
+			launcher := New(
+				mockedExecutor,
+				"-foo --bar",
+			)
+
+			Convey("When executor is able to run this command then it should return mocked taskHandle "+
+				"without error", func() {
+
+				mockedExecutor.On("Execute", validCommand).Return(mockedTask, nil).Once()
+
+				task, err := launcher.Launch()
+				So(err, ShouldBeNil)
+				So(task, ShouldEqual, mockedTask)
+
+				mockedExecutor.AssertExpectations(t)
+			})
+			Convey("When executor isn't able to run this command then it should return error without "+
+				"mocked taskHandle", func() {
+
+				mockedExecutor.On("Execute", validCommand).Return(nil, errors.New("fail to execute")).Once()
+
+				task, err := launcher.Launch()
+				So(task, ShouldBeNil)
+				So(err.Error(), ShouldEqual, "fail to execute")
+
+				mockedExecutor.AssertExpectations(t)
+			})
+		})
+
+	})
+}


### PR DESCRIPTION
Fixes issue "stressng is more robust, mature and maintained than iBench"  

Summary of changes:
- just new Launcher

Testing done:
- ut and it

to use it in sensititivity experiment you need update sensitivity experiments common.executor prepareExecutors first or create it manually in main.go