### PR TITLE
SCE- 1144: isolate-pid.sh as package not as shell script

### DIFF
--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
+	_ "github.com/intelsdi-x/swan/pkg/utils/unshare"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 
 	"github.com/Sirupsen/logrus"

--- a/pkg/utils/unshare/unshare.go
+++ b/pkg/utils/unshare/unshare.go
@@ -1,0 +1,46 @@
+/*Package unshare when blank imported reexecutes process in isolated pid namespace.*/
+package unshare
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+)
+
+func init() {
+	if os.Getenv("UNSHARE_PID_READY") == "" {
+		if os.Getuid() != 0 {
+			fmt.Println("Error: unshare requires privileged user - please run as root!")
+			os.Exit(1)
+		}
+
+		runtime.LockOSThread()
+		para := []string{"--pid", "--fork", "--mount-proc"}
+		args := append(para, os.Args...)
+
+		fp, err := exec.LookPath("unshare")
+		if err != nil {
+			fmt.Printf("Error: cannot locate unshare binary!")
+			os.Exit(1)
+		}
+
+		cmd := exec.Command(fp, args...)
+		cmd.Env = append(os.Environ(), "UNSHARE_PID_READY=true")
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		err = cmd.Run()
+		if err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok {
+					os.Exit(waitStatus.ExitStatus())
+				}
+			}
+			panic(err)
+		}
+		// No error return from parent process means error code 0.
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
Fixes issue "isolate-pid.sh need to be depoloyed in production if we want pid namspace killing feature"

Summary of changes:
- reimplmenent isolate-pid.sh in go (as optional package)

Testing done:
- no tests for just this feature MISSSING but used in experiment for tests and tested by expriment integration tests
- tested manually - when run with nohup or local experiment after ctrl-c memcached+mutilate are killed - without they stay


after importing
```
import _ "github.com/intelsdi-x/swan/pkg/utils/unshare"
```
and running
```
sudo memcached-senstifiity-profile -log debug
```
ps output
```
ppalucki  7956  0.0  0.0 145276  6196 pts/8    Ss   17:05   0:00  \_ -zsh
root      9073  0.0  0.0 193388  2792 pts/8    S+   17:06   0:00  |   \_ sudo /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile -log debug
root      9074  1.3  0.0 258808 15808 pts/8    Sl+  17:06   0:00  |       \_ /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile -log debug
root      9085  0.0  0.0 107884   596 pts/8    S+   17:06   0:00  |           \_ /bin/unshare --pid --fork --mount-proc /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile -log debug
root      9086  2.0  0.0 332540 16780 pts/8    Sl+  17:06   0:00  |               \_ /home/ppalucki/work/gopath/bin/memcached-sensitivity-profile -log debug
root      9129  472  0.0 643340  6300 pts/8    Sl   17:06   0:09  |                   \_ mutilate -s 127.0.0.1:11211 --warmup 10 --noload -K 30 -V 200 -i exponential -T 8 -d 1 -c 1 -r 10000 -B --search 99:500 -t 10
```

after ctrl-c mutilate/memcached are killed
nsenter or /proc/PID/ns/pid show new namespace is used for children with memcached-sensitiviy-profile  visiable as PID 1