### PR TITLE
SCE-1142: allow to run stress-ng based aggressors with experiments

### DIFF
--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -218,6 +218,19 @@ func TestExperiment(t *testing.T) {
 			})
 		})
 
+		Convey("With proper kubernetes configuration and with stress-ng-stream aggressor", func() {
+			args := []string{"-kubernetes", "-aggr", "stress-ng-stream", "-baseline=false", "-kube_allow_privileged"}
+			Convey("Experiment should run with no errors and results should be stored in a Cassandra DB", func() {
+				experimentID, err := runExp(memcachedSensitivityProfileBin, true, args...)
+				So(err, ShouldBeNil)
+
+				tags, _, swanAggressorsNames, _, metricsCount := loadDataFromCassandra(session, experimentID)
+				So(metricsCount, ShouldBeGreaterThan, 0)
+				So(tags["swan_aggressor_name"], ShouldEqual, "stress-ng-stream")
+				So("None", ShouldNotBeIn, swanAggressorsNames)
+			})
+		})
+
 		Convey("With proper kubernetes and caffe", func() {
 			args := []string{"-kubernetes", "-aggr", "caffe", "-baseline=false", "-kube_allow_privileged"}
 			Convey("Experiment should run with no errors and results should be stored in a Cassandra DB", func() {

--- a/pkg/workloads/low_level/stressng/stressng.go
+++ b/pkg/workloads/low_level/stressng/stressng.go
@@ -3,26 +3,77 @@ package stressng
 import (
 	"fmt"
 
+	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 )
 
 const (
-	// ID is used for specifying which aggressors should be used via parameters.
-	ID = "stressng"
+	// IDCustom is used for specifying which aggressors should be used via parameters.
+	IDCustom = "stress-ng-custom"
+	// IDStream is used for specifying which aggressors should be used via parameters.
+	IDStream = "stress-ng-stream"
+	// IDCacheL1 is used for specifying which aggressors should be used via parameters.
+	IDCacheL1 = "stress-ng-cache-l1"
+	// IDCacheL3 is used for specifying which aggressors should be used via parameters.
+	IDCacheL3 = "stress-ng-cache-l3"
+	// IDMemCpy is used for specifying which aggressors should be used via parameters.
+	IDMemCpy = "stress-ng-memcpy"
 )
+
+// StressngCustomArguments custom argument to run stress-ng with.
+var StressngCustomArguments = conf.NewStringFlag("stressng_custom_arguments", "Custom arguments to stress-ng", "")
+
+// StressngStreamProcessNumber represents number of stress-ng aggressor processes to be run.
+var StressngStreamProcessNumber = conf.NewIntFlag("stressng_stream_process_number", "Number of aggressors to be run", 1)
+
+// StressngCacheL1ProcessNumber represents number of stress-ng aggressor processes to be run.
+var StressngCacheL1ProcessNumber = conf.NewIntFlag("stressng_cache_l1_process_number", "Number of aggressors to be run", 1)
+
+// StressngCacheL3ProcessNumber represents number of stress-ng aggressor processes to be run.
+var StressngCacheL3ProcessNumber = conf.NewIntFlag("stressng_cache_l3_process_number", "Number of aggressors to be run", 1)
+
+// StressngMemCpyProcessNumber represents number of stress-ng aggressor processes to be run.
+var StressngMemCpyProcessNumber = conf.NewIntFlag("stressng_memcpy_process_number", "Number of aggressors to be run", 1)
 
 // l1d is a launcher for stress-ng aggressor.
 type stressng struct {
 	executor  executor.Executor
 	arguments string
+	name      string
 }
 
 // New is a constructor for stress-ng aggressor.
-func New(executor executor.Executor, arguments string) executor.Launcher {
+func New(executor executor.Executor, name, arguments string) executor.Launcher {
 	return stressng{
 		executor:  executor,
 		arguments: arguments,
+		name:      name,
 	}
+}
+
+// NewCustom constructor for specifc run of stress-ng.
+func NewCustom(executor executor.Executor) executor.Launcher {
+	return New(executor, fmt.Sprintf("stress-ng-custom %s", StressngCustomArguments.Value()), StressngCustomArguments.Value())
+}
+
+// NewStream constructor for stream based run of stress-ng.
+func NewStream(executor executor.Executor) executor.Launcher {
+	return New(executor, "stress-ng-stream", fmt.Sprintf("--stream=%d", StressngStreamProcessNumber.Value()))
+}
+
+// NewCacheL1 constructor for cache L1 run of stress-ng.
+func NewCacheL1(executor executor.Executor) executor.Launcher {
+	return New(executor, "stress-ng-cache-l1", fmt.Sprintf("--cache=%d --cache-level=1", StressngCacheL1ProcessNumber.Value()))
+}
+
+// NewCacheL3 constructor for cache L3 run of stress-ng.
+func NewCacheL3(executor executor.Executor) executor.Launcher {
+	return New(executor, "stress-ng-cache-l3", fmt.Sprintf("--cache=%d --cache-level=3", StressngCacheL3ProcessNumber.Value()))
+}
+
+// NewMemCpy constructor for memcpy stressor run of stress-ng.
+func NewMemCpy(executor executor.Executor) executor.Launcher {
+	return New(executor, "stress-ng-memcpy", fmt.Sprintf("--memcpy=%d", StressngMemCpyProcessNumber.Value()))
 }
 
 // Launch starts a workload.
@@ -32,5 +83,5 @@ func (s stressng) Launch() (executor.TaskHandle, error) {
 
 // Name returns readable name.
 func (s stressng) Name() string {
-	return "Stress-ng"
+	return s.name
 }

--- a/pkg/workloads/low_level/stressng/stressng_test.go
+++ b/pkg/workloads/low_level/stressng/stressng_test.go
@@ -13,14 +13,13 @@ func TestStressng(t *testing.T) {
 	mockedExecutor := new(mocks.Executor)
 	mockedTask := new(mocks.TaskHandle)
 
-	Convey("While using l1d aggressor launcher", t, func() {
-		const (
-			validCommand = "stress-ng -foo --bar"
-		)
+	Convey("While using stress-ng aggressor launcher", t, func() {
 
 		Convey("Default configuration should be valid", func() {
+			const validCommand = "stress-ng -foo --bar"
 			launcher := New(
 				mockedExecutor,
+				"stress-ng",
 				"-foo --bar",
 			)
 
@@ -45,6 +44,59 @@ func TestStressng(t *testing.T) {
 				So(err.Error(), ShouldEqual, "fail to execute")
 
 				mockedExecutor.AssertExpectations(t)
+			})
+		})
+
+		Convey("and for specific aggressors we got command as expected", func() {
+
+			Convey("for new stream based aggressor", func() {
+				launcher := NewStream(mockedExecutor)
+				So(launcher.Name(), ShouldEqual, "stress-ng-stream")
+				mockedExecutor.On("Execute", "stress-ng --stream=1").Return(mockedTask, nil).Once()
+				_, err := launcher.Launch()
+				So(err, ShouldBeNil)
+				mockedExecutor.AssertExpectations(t)
+
+			})
+
+			Convey("for new l1 intensive aggressor", func() {
+				launcher := NewCacheL1(mockedExecutor)
+				So(launcher.Name(), ShouldEqual, "stress-ng-cache-l1")
+				mockedExecutor.On("Execute", "stress-ng --cache=1 --cache-level=1").Return(mockedTask, nil).Once()
+				_, err := launcher.Launch()
+				So(err, ShouldBeNil)
+				mockedExecutor.AssertExpectations(t)
+
+			})
+
+			Convey("for new l3 intensive aggressor", func() {
+				launcher := NewCacheL3(mockedExecutor)
+				So(launcher.Name(), ShouldEqual, "stress-ng-cache-l3")
+				mockedExecutor.On("Execute", "stress-ng --cache=1 --cache-level=3").Return(mockedTask, nil).Once()
+				_, err := launcher.Launch()
+				So(err, ShouldBeNil)
+				mockedExecutor.AssertExpectations(t)
+
+			})
+
+			Convey("for new memcpy aggressor", func() {
+				launcher := NewMemCpy(mockedExecutor)
+				So(launcher.Name(), ShouldEqual, "stress-ng-memcpy")
+				mockedExecutor.On("Execute", "stress-ng --memcpy=1").Return(mockedTask, nil).Once()
+				_, err := launcher.Launch()
+				So(err, ShouldBeNil)
+				mockedExecutor.AssertExpectations(t)
+
+			})
+
+			Convey("for new custom aggressor", func() {
+				launcher := NewCustom(mockedExecutor)
+				So(launcher.Name(), ShouldEqual, "stress-ng-custom ")
+				mockedExecutor.On("Execute", "stress-ng ").Return(mockedTask, nil).Once()
+				_, err := launcher.Launch()
+				So(err, ShouldBeNil)
+				mockedExecutor.AssertExpectations(t)
+
 			})
 		})
 


### PR DESCRIPTION
Fixes issue "iBench aggressor are not enough (hard to use, depoly)"

Summary of changes:
- stressng launcher exposed in factory for experiments and a bunch of new flags

Testing done:
- both unit and integration included
- run many times manually
