### PR TITLE
SCE-1143 Encapsulating metadata saving a bit

### DIFF
--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -60,23 +60,12 @@ func main() {
 	logger.Initialize(appName, uid)
 
 	// Connect to metadata database
-	metadata := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
-	err := metadata.Connect()
+	metadata, err := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
 	errutil.CheckWithContext(err, "Cannot connect to metadata database")
 
-	// Write configuration as metadata.
-	err = metadata.RecordFlags()
-	errutil.CheckWithContext(err, "Cannot save flags to metadata database")
-
-	// Store SWAN_ environment configuration.
-	err = metadata.RecordEnv(conf.EnvironmentPrefix)
-	errutil.CheckWithContext(err, "Cannot save environment metadata")
-
-	// Store host and time in metadata
-	hostname, err := os.Hostname()
-	errutil.CheckWithContext(err, "Cannot determine hostname")
-	err = metadata.RecordMap(map[string]string{"time": time.Now().Format(time.RFC822Z), "host": hostname})
-	errutil.CheckWithContext(err, "Cannot save hostname and time to metadata database")
+	// Save experiment runtime environment (configuration, environmental variables, etc).
+	err = metadata.RecordRuntimeEnv(experimentStart)
+	errutil.CheckWithContext(err, "Cannot save runtime environment")
 
 	// Validate preconditions.
 	validate.OS()

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -42,32 +42,18 @@ func main() {
 	// Initialize logger.
 	logger.Initialize(appName, uid)
 
-	metadata := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
-	err := metadata.Connect()
+	metadata, err := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
 	if err != nil {
 		logrus.Errorf("Cannot connect to metadata database %q", err.Error())
 		os.Exit(experiment.ExSoftware)
 	}
-
-	logrus.Info("Starting Experiment ", appName, " with uid ", uid)
-	fmt.Println(uid)
-
-	// Write configuration as metadata.
-	err = metadata.RecordFlags()
-	errutil.Check(err)
-
-	// Store SWAN_ environment configuration.
-	err = metadata.RecordEnv(conf.EnvironmentPrefix)
+	// Save experiment runtime environment (configuration, environmental variables, etc).
+	err = metadata.RecordRuntimeEnv(experimentStart)
 	if err != nil {
-		logrus.Errorf("Cannot save environment metadata: %q", err.Error())
+		logrus.Errorf("Cannot save runtime environment %q", err.Error())
 		os.Exit(experiment.ExSoftware)
 	}
-
-	err = metadata.RecordPlatformMetrics()
-	if err != nil {
-		logrus.Errorf("Cannot save platform metadata: %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
+	errutil.CheckWithContext(err, "Cannot save runtime environment")
 
 	// Validate preconditions.
 	validate.OS()

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -36,24 +36,18 @@ var (
 )
 
 func main() {
+	experimentStart := time.Now()
 	experiment.Configure()
 
 	// Generate an experiment ID and start the metadata session.
-	uid := uuid.New()
-
-	// Initialize logger.
+	uid := uuid.New()// Initialize logger.
 	logger.Initialize(appName, uid)
-
 	// Create metadata associated with experiment
-	metadata := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
-	errutil.Check(metadata.Connect())
+	metadata, err := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
+	errutil.Check(err)
 
-	// Write configuration as metadata.
-	errutil.Check(metadata.RecordFlags())
-
-	// Store SWAN_ environment configuration.
-	errutil.Check(metadata.RecordEnv(conf.EnvironmentPrefix))
-	errutil.Check(metadata.RecordPlatformMetrics())
+	err = metadata.RecordRuntimeEnv(experimentStart)
+	errutil.CheckWithContext(err, "Cannot save runtime environment details to metadata database.")
 
 	// Validate preconditions: for SPECjbb we only check if CPU governor is set to performance.
 	validate.CheckCPUPowerGovernor()

--- a/integration_tests/pkg/experiment/metadata_test.go
+++ b/integration_tests/pkg/experiment/metadata_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/intelsdi-x/swan/pkg/experiment"
 	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"time"
 )
 
 func TestMetadata(t *testing.T) {
-	metadata := experiment.NewMetadata("foobar-experiment", experiment.DefaultMetadataConfig())
 	Convey("Connecting to the Cassandra database", t, func() {
-		err := metadata.Connect()
+		metadata, err := experiment.NewMetadata("foobar-experiment", experiment.DefaultMetadataConfig())
 		So(err, ShouldBeNil)
 
 		// If a test failed midway, there may be metadata associated with the 'foobar-experiment' above.
@@ -19,6 +20,24 @@ func TestMetadata(t *testing.T) {
 		// Make sure that metadata is cleared when test ends.
 		Reset(func() {
 			metadata.Clear()
+			os.Unsetenv("SWAN_LOG")
+		})
+
+		Convey("Recording runtime environment", func() {
+			os.Setenv("SWAN_LOG", "error")
+			err := metadata.RecordRuntimeEnv(time.Now())
+			So(err, ShouldBeNil)
+
+			Convey("It should be possible to retrive environment variables, hostname, start time, flags and platform data", func() {
+				metadataCollection, err := metadata.Get()
+				So(err, ShouldBeNil)
+				So(metadataCollection, ShouldHaveLength, 4)
+				So(metadataCollection[0]["cpu_model"], ShouldNotBeNil)
+				So(metadataCollection[1]["host"], ShouldNotBeNil)
+				So(metadataCollection[1]["time"], ShouldNotBeNil)
+				So(metadataCollection[2]["SWAN_LOG"], ShouldNotBeNil)
+				So(metadataCollection[3]["cassandra_password"], ShouldNotBeNil)
+			})
 		})
 
 		Convey("Recoding a metadata pair", func() {

--- a/pkg/experiment/conf.go
+++ b/pkg/experiment/conf.go
@@ -42,8 +42,7 @@ func Configure() bool {
 	if *dumpConfig {
 		previousExperimentID := *dumpConfigExperimentID
 		if previousExperimentID != "" {
-			metadata := NewMetadata(previousExperimentID, MetadataConfigFromFlags())
-			err := metadata.Connect()
+			metadata, err := NewMetadata(previousExperimentID, MetadataConfigFromFlags())
 			errutil.Check(err)
 			flags, err := metadata.GetGroup("flags")
 			errutil.Check(err)


### PR DESCRIPTION
Fixes issue of copy-pasted code for storing metadata in all the experiments.

Summary of changes:
- unexporting few functions
- platform metadata should now be stored for every experiment
- using newly created function in all four experiments

Testing done:
- added integration test
