### PR TITLE
Updating defaults

### DIFF
--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -73,7 +73,7 @@ func runExp(command string, dumpOutputOnError bool, args ...string) (string, err
 }
 
 func loadDataFromCassandra(session *gocql.Session, experimentID string) (tags map[string]string, swanRepetitions, swanAggressorsNames, swanPhases []string, metricsCount int) {
-
+	time.Sleep(5 * time.Second)
 	var ns string
 	iter := session.Query(`SELECT ns, tags FROM snap.metrics WHERE tags['swan_experiment'] = ? ALLOW FILTERING`, experimentID).Iter()
 	for iter.Scan(&ns, &tags) {
@@ -134,7 +134,10 @@ func TestExperiment(t *testing.T) {
 		"SWAN_EXPERIMENT_LOAD_POINTS":              "1",
 		"SWAN_EXPERIMENT_PEAK_LOAD":                "5000",
 		"SWAN_EXPERIMENT_LOAD_DURATION":            "1s",
-		"SWAN_MUTILATE_WARMUP_TIME":                "1s",
+		"SWAN_MUTILATE_RECORDS":                    "10000",
+		"SWAN_MUTILATE_AGENT_CONNECTIONS":          "1",
+		"SWAN_MUTILATE_AGENT_AFFINITY":             "false",
+		"SWAN_MUTILATE_MASTER_AFFINITY":            "false",
 	}
 
 	Convey("With environment prepared for experiment", t, func() {

--- a/pkg/workloads/memcached/memcached.go
+++ b/pkg/workloads/memcached/memcached.go
@@ -29,12 +29,13 @@ import (
 const (
 	name = "Memcached"
 	// DefaultPort represents default memcached port.
-	defaultPort           = 11211
-	defaultUser           = "root"
-	defaultNumThreads     = 4
-	defaultMaxMemoryMB    = 4096
-	defaultNumConnections = 1024
-	defaultListenIP       = "127.0.0.1"
+	defaultPort            = 11211
+	defaultUser            = "root"
+	defaultNumThreads      = 4
+	defaultMaxMemoryMB     = 4096
+	defaultNumConnections  = 2048
+	defaultListenIP        = "127.0.0.1"
+	defaultThreadsAffinity = false
 )
 
 var (

--- a/pkg/workloads/memcached/memcached_test.go
+++ b/pkg/workloads/memcached/memcached_test.go
@@ -42,7 +42,7 @@ func TestMemcachedWithMockedExecutor(t *testing.T) {
 	log.SetLevel(log.ErrorLevel)
 
 	const (
-		expectedCommand = "test -p 11211 -u root -t 4 -m 4096 -c 1024"
+		expectedCommand = "test -p 11211 -u root -t 4 -m 4096 -c 2048"
 		expectedHost    = "127.0.0.1"
 	)
 	Convey("When I create PID namespace isolation", t, func() {

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -31,18 +31,18 @@ import (
 const (
 	defaultPercentile             = "99"
 	defaultTuningTime             = 10 * time.Second // [s]
-	defaultRecords                = 10000
-	defaultWarmupTime             = 10 * time.Second // [s]
+	defaultRecords                = 5000000
+	defaultWarmupTime             = 1 * time.Second // [s]
 	defaultAgentThreads           = 8
 	defaultAgentPort              = 5556
-	defaultAgentConnections       = 1
+	defaultAgentConnections       = 16
 	defaultAgentConnectionsDepth  = 1
-	defaultAgentAffinity          = false
+	defaultAgentAffinity          = true
 	defaultAgentBlocking          = true
 	defaultMasterThreads          = 8
 	defaultMasterConnections      = 4
-	defaultMasterConnectionsDepth = 4
-	defaultMasterAffinity         = false
+	defaultMasterConnectionsDepth = 1
+	defaultMasterAffinity         = true
 	defaultMasterBlocking         = true
 	defaultMasterKeySize          = "30"          // [bytes]
 	defaultMasterValueSize        = "200"         // [bytes]


### PR DESCRIPTION
Fixes issue of outdated default values of memcached and mutilate configuration flags.

Summary of changes:
- updated some default values to reflect currently used

Testing done:
- all existing tests should pass
