### PR TITLE
SCE-946: handle interrupt signal

### DIFF
--- a/experiments/optimal-core-allocation/main.go
+++ b/experiments/optimal-core-allocation/main.go
@@ -56,6 +56,9 @@ func main() {
 	// Initialize logger.
 	logger.Initialize(appName, uid)
 
+	cleanupExecutors := executor.RegisterInterruptHandle()
+	defer cleanupExecutors()
+
 	// connect to metadata database
 	metadata, err := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
 	errutil.CheckWithContext(err, "Cannot connect to metadata database")

--- a/pkg/executor/clean.go
+++ b/pkg/executor/clean.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"container/list"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type taskHandleStopper struct {
+	taskHandles *list.List
+	mutex       sync.Mutex
+}
+
+var globalTaskHandleStopper taskHandleStopper
+
+// RegisterInterruptHandle waits for Interrupt signal and stops unconditionally all taskHandles.
+// Additionall returns a function that can be used in defer to handle panics in main function.
+func RegisterInterruptHandle() func() {
+	return globalTaskHandleStopper.registerInterruptHandle()
+}
+
+func register(t TaskHandle) {
+	globalTaskHandleStopper.register(t)
+}
+
+func unregister(t TaskHandle) {
+	globalTaskHandleStopper.unregister(t)
+}
+
+func (ths *taskHandleStopper) registerInterruptHandle() func() {
+	ths.mutex.Lock()
+	defer ths.mutex.Unlock()
+	logrus.Debugf("clean: interupt hanndle initialized")
+	ths.taskHandles = list.New()
+
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		logrus.Debugf("clean: stopAllTaskHandles on signal '%v'", <-c)
+		ths.stopAllTaskHandles()
+		os.Exit(1)
+	}()
+	return ths.stopAllTaskHandles
+}
+
+func (ths *taskHandleStopper) stopAllTaskHandles() {
+	ths.mutex.Lock()
+	defer ths.mutex.Unlock()
+	if ths.taskHandles != nil {
+		// Stop in reverse order.
+		for e := ths.taskHandles.Back(); e != nil; e = e.Prev() {
+			taskHandle := e.Value.(TaskHandle)
+			logrus.Debugf("clean: taskHandle '%v' Stop() returned '%v'", taskHandle, taskHandle.Stop())
+		}
+	}
+}
+
+func (ths *taskHandleStopper) register(t TaskHandle) {
+	ths.mutex.Lock()
+	defer ths.mutex.Unlock()
+	if ths.taskHandles != nil {
+		ths.taskHandles.PushBack(t)
+	}
+}
+
+func (ths *taskHandleStopper) unregister(t TaskHandle) {
+	ths.mutex.Lock()
+	defer ths.mutex.Unlock()
+	if ths.taskHandles != nil {
+		for e := ths.taskHandles.Front(); e != nil; e = e.Next() {
+			taskHandle := e.Value.(TaskHandle)
+			if t == taskHandle {
+				ths.taskHandles.Remove(e)
+			}
+		}
+	}
+}

--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -358,6 +358,9 @@ func (k8s *k8s) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	register(taskHandle)
+
 	return taskHandle, nil
 }
 
@@ -634,6 +637,7 @@ func (kw *k8sWatcher) whenPodReady() {
 // Additionally call whenPodReady handler to setupLogs and mark pod as running.
 func (kw *k8sWatcher) whenPodFinished(pod *v1.Pod) {
 	kw.oncePodFinished.Do(func() {
+		unregister(kw.taskHandle)
 		kw.whenPodReady()
 		kw.setExitCode(pod)
 		log.Debug("K8s task watcher: pod finished")

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -102,7 +102,9 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 		// NOTE: Wait() returns an error. We grab the process state in any case
 		// (success or failure) below, so the error object matters less in the
 		// status handling for now.
-		if err := cmd.Wait(); err != nil {
+		err := cmd.Wait()
+		unregister(&taskHandle)
+		if err != nil {
 			if _, ok := err.(*exec.ExitError); !ok {
 				// In case of NON Exit Errors we are not sure if task does
 				// terminate so panic.
@@ -129,6 +131,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+	register(&taskHandle)
 	return &taskHandle, nil
 }
 

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -208,6 +208,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 		*exitCode = successExitCode
 		// Wait for task completion.
 		err := session.Wait()
+		unregister(&taskHandle)
 		if err != nil {
 			if exitError, ok := err.(*ssh.ExitError); !ok {
 				// In case of NON Exit Errors we are not sure if task does
@@ -236,6 +237,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+	register(&taskHandle)
 	return &taskHandle, nil
 }
 


### PR DESCRIPTION
Fixes issue "ctrl+c even with unshare doesn't stop remote executors"

Summary of changes:
- register at the end of Execute()
- unregister at the begging of Stop/Wait
- `RegisterInterruptHandle()` to handle SIG_INT signal


Testing done:
- manually with optimal-core-allocation with remote and k8s

first version before #619 


**WARNING**:

- when run together with unshare user will experience very unfriendly logs after stopping process manually and getting access to sh (taskHandles happening in background) - not stopping user from running experiment again 

like this:

```
# optimal-core-allocation
ctr-c
#
DEBUG: clean stopping taskHandles....
#
DEBUG: clean stopping taskHandles....
#
```

explanation:
- with unshare with have such process tree
```
optimal-core-allocation (foreground process)
  unshare
    optimal-core-allocation (actuall SIGINT handling)
       hyberkube
       memcached
```

when interrupted with signal (SIGINT) which is send to whole process group, the first foreground stops immediately (now tasks to wait for!), - we need patch unshare package to wait for children to stop!
