### PR TITLE
SCE-1149: shell executor that wraps remote&local

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -49,14 +49,14 @@ func PrepareMutilateGenerator(memcachedIP string, memcachedPort int) (executor.L
 
 	agentsLoadGeneratorExecutors := []executor.Executor{}
 
-	masterLoadGeneratorExecutor, err := executor.NewRemoteFromIP(mutilateMasterFlag.Value())
+	masterLoadGeneratorExecutor, err := executor.NewShell(mutilateMasterFlag.Value())
 	if err != nil {
 		return nil, err
 	}
 
 	// Pack agents.
 	for _, agent := range mutilateAgentsFlag.Value() {
-		remoteExecutor, err := executor.NewRemoteFromIP(agent)
+		remoteExecutor, err := executor.NewShell(agent)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/executor/shell.go
+++ b/pkg/executor/shell.go
@@ -1,0 +1,9 @@
+package executor
+
+// NewShell is a wrapper constructor for NewLocal or NewRemote executor depending on ip provided.
+func NewShell(ip string) (Executor, error) {
+	if ip == "127.0.0.1" || ip == "localhost" {
+		return NewLocal(), nil
+	}
+	return NewRemoteFromIP(ip)
+}

--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -71,7 +71,7 @@ func PrepareExecutors(hpIsolation isolation.Decorator) (hpExecutor executor.Exec
 //LaunchKubernetesCluster starts new Kubernetes cluster using configuration provided with flags.
 func LaunchKubernetesCluster() (cleanup func() error, err error) {
 	k8sConfig := kubernetes.DefaultConfig()
-	masterExecutor, err := executor.NewRemoteFromIP(k8sConfig.KubeAPIAddr)
+	masterExecutor, err := executor.NewShell(k8sConfig.KubeAPIAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes issue 'not need to root' when connecting to localhost

Summary of changes:
- just an wrapper for local&remote executor constructor 

Testing done:
- not 
