### PR TITLE
SCE-946: handle interrupt signal (v2 - without unregister and container/list)

### DIFF
--- a/experiments/optimal-core-allocation/main.go
+++ b/experiments/optimal-core-allocation/main.go
@@ -56,6 +56,9 @@ func main() {
 	// Initialize logger.
 	logger.Initialize(appName, uid)
 
+	executorsCleanup := executor.RegisterInterruptHandle()
+	defer executorsCleanup()
+
 	// connect to metadata database
 	metadata, err := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
 	errutil.CheckWithContext(err, "Cannot connect to metadata database")

--- a/pkg/executor/clean.go
+++ b/pkg/executor/clean.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type taskHandleStopper struct {
+	taskHandles []TaskHandle
+	sync.Mutex
+}
+
+var globalTaskHandleStopper *taskHandleStopper
+
+// RegisterInterruptHandle waits for Interrupt signal and stops unconditionally all taskHandles.
+func RegisterInterruptHandle() func() {
+	globalTaskHandleStopper = &taskHandleStopper{}
+	return globalTaskHandleStopper.registerInterruptHandle()
+}
+
+func register(t TaskHandle) {
+	globalTaskHandleStopper.register(t)
+}
+
+func (ths *taskHandleStopper) registerInterruptHandle() func() {
+	ths.Lock()
+	defer ths.Unlock()
+	logrus.Debugf("clean: interupt hanndle initialized")
+
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		logrus.Debugf("clean: stopAllTaskHandles on signal '%v'", <-c)
+		ths.stopAllTaskHandles()
+		os.Exit(1)
+	}()
+	return ths.stopAllTaskHandles
+}
+
+func (ths *taskHandleStopper) stopAllTaskHandles() {
+	ths.Lock()
+	defer ths.Unlock()
+	// Stop in reverse order.
+	if len(ths.taskHandles) > 0 {
+		for i := len(ths.taskHandles); i >= 0; i-- {
+			taskHandle := ths.taskHandles[i-1]
+			logrus.Debugf("clean: stopping '%v'...", taskHandle)
+			logrus.Debugf("clean: taskHandle '%v' Stop() returned '%v'", taskHandle, taskHandle.Stop())
+		}
+	}
+}
+
+func (ths *taskHandleStopper) register(t TaskHandle) {
+	ths.Lock()
+	defer ths.Unlock()
+	if ths.taskHandles != nil {
+		ths.taskHandles = append(ths.taskHandles, t)
+	}
+}

--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -358,6 +358,9 @@ func (k8s *k8s) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	register(taskHandle)
+
 	return taskHandle, nil
 }
 

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -129,6 +129,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+	register(&taskHandle)
 	return &taskHandle, nil
 }
 

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -235,6 +235,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+	register(&taskHandle)
 	return &taskHandle, nil
 }
 


### PR DESCRIPTION
Fixes issue "ctrl-c doesn't stop any running executors - especially painful for remote or k8s based executors" 

Summary of changes:
- register every taskhandle to be stopped when SIGTERM or SIGINT is received or main function panics

Testing done:
- manually

simpler than #617 - but all executors all stored to the end
