### PR TITLE
false error message

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -661,7 +661,12 @@ func (kw *k8sWatcher) setExitCode(pod *v1.Pod) {
 		exitCode = int(status.State.Terminated.ExitCode)
 	}
 	if pod.Status.Phase == v1.PodFailed {
-		log.Errorf("K8s task watcher: pod %q failed with exit code %d", pod.Name, exitCode)
+		if exitCode == 137 {
+			log.Debugf("K8s task watcher: pod %q exited with code %d (killed with SIG_KILL)", pod.Name, exitCode)
+		} else {
+			log.Errorf("K8s task watcher: pod %q failed with exit code %d", pod.Name, exitCode)
+		}
+
 	} else {
 		log.Debugf("K8s task watcher: exit code retrieved: %d", exitCode)
 	}


### PR DESCRIPTION
Fixes issue "sensless error message"

```sh
INFO[2017-04-25 14:17:28.400] Running 8 threads of memcached with load of 240000 QPS
ERRO[2017-04-25 14:18:52.400] K8s task watcher: pod "swan-hp-1d4af81c" failed with exit code 137
INFO[2017-04-25 14:18:52.400] Running 8 threads of memcached with load of 280000 QPS
ERRO[2017-04-25 14:20:15.400] K8s task watcher: pod "swan-hp-5e095ef2" failed with exit code 137
INFO[2017-04-25 14:20:15.400] Running 8 threads of memcached with load of 320000 QPS
ERRO[2017-04-25 14:21:38.400] K8s task watcher: pod "swan-hp-648ee2a3" failed with exit code 137
INFO[2017-04-25 14:21:38.400] Running 8 threads of memcached with load of 360000 QPS
ERRO[2017-04-25 14:23:02.400] K8s task watcher: pod "swan-hp-ebe902d4" failed with exit code 137
INFO[2017-04-25 14:23:02.400] Running 8 threads of memcached with load of 400000 QPS
ERRO[2017-04-25 14:24:25.400] K8s task watcher: pod "swan-hp-39c393d0" failed with exit code 137
``` 

Summary of changes:
- replace senseless error log when pod is killed -9

Testing done:
- manually
