### PR TITLE
fix unshare works for remote executor

### DIFF
--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -117,7 +117,8 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 	// Obligatory Pid namespace and a hint as comment. It will be carried to remote system.
 	// On the server the example command will look the following:
 	// unshare --fork --pid --mount-proc sh -c /opt/mutilate -A #d2857955-942c-4436-4d75-635640d2bbe5
-	stringForSh = fmt.Sprintf(`unshare --fork --pid --mount-proc sh -c '%s #%s'`, stringForSh, unshareUUIDStr)
+	// 'tryue && ' prefix prevents bash over execing into given command and guarantees unshare work as expected.
+	stringForSh = fmt.Sprintf(`unshare --fork --pid --mount-proc sh -c 'true && %s #%s'`, stringForSh, unshareUUIDStr)
 
 	log.Debug("Starting '", stringForSh, "' remotely")
 	err = session.Start(stringForSh)


### PR DESCRIPTION
Fixes issue "unshare doesn't for for mutilate" - mutilate escapes because is first beneath sshd and thus not in separate unshare pid namespace

Summary of changes:
- "force remote shell to fork and become PID1 process in new pid namespace'  

Testing done:
- not
