### PR TITLE
IntSet.Take(n) now return deterministic values.

### DIFF
--- a/pkg/isolation/set.go
+++ b/pkg/isolation/set.go
@@ -124,9 +124,12 @@ func (s IntSet) Take(n int) (IntSet, error) {
 // this set.
 func (s IntSet) AsSlice() []int {
 	result := []int{}
+
 	for elem := range s {
 		result = append(result, elem)
 	}
+
+	sort.Ints(result)
 	return result
 }
 

--- a/pkg/isolation/set_test.go
+++ b/pkg/isolation/set_test.go
@@ -16,7 +16,6 @@ package isolation
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -214,14 +213,13 @@ func TestIntSet(t *testing.T) {
 			So(r.Subset(s), ShouldBeTrue)
 		})
 
-		Convey("IntSet correctly converts to a slice of integers", func() {
+		Convey("IntSet correctly converts to a sorted slice of integers", func() {
 			s1 := NewIntSet()
-			s2 := NewIntSet(1, 3, 5, 7)
+			s2 := NewIntSet(7, 1, 3, 5)
 
 			So(s1.AsSlice(), ShouldResemble, []int{})
 
 			s2slice := s2.AsSlice()
-			sort.Ints(s2slice)
 			So(len(s2slice), ShouldEqual, len(s2))
 			So(s2slice, ShouldResemble, []int{1, 3, 5, 7})
 			for _, elem := range s2slice {


### PR DESCRIPTION
Fixes issue of non-deterministic `Take` method.

Summary of changes:
- AsSlice returns sorted slice

Testing done:
- UT
