### PR TITLE
kuberentes api run as no-root, verbose mutilate & remote executor

### DIFF
--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -168,7 +168,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 	// 'tryue && ' prefix prevents bash over execing into given command and guarantees unshare work as expected.
 	stringForSh = fmt.Sprintf(`unshare --fork --pid --mount-proc sh -c 'true && %s #%s'`, stringForSh, unshareUUIDStr)
 
-	log.Debug("Starting '", stringForSh, "' remotely")
+	log.Debug("Starting '", stringForSh, "' remotely on '", remote.targetHost, "'")
 	err = session.Start(stringForSh)
 	if err != nil {
 		return nil, errors.Wrapf(err, "session.Start for command %q failed", command)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -273,6 +273,8 @@ func (m k8s) getKubeAPIServerCommand() kubeCommand {
 			fmt.Sprintf(" --insecure-port=%d", m.config.KubeAPIPort),
 			fmt.Sprintf(" --kubelet-timeout=%s", serviceListenTimeout),
 			fmt.Sprintf(" --service-cluster-ip-range=%s", m.config.ServiceAddresses),
+			fmt.Sprintf(" --advertise-address=%s", m.config.KubeAPIAddr),
+			fmt.Sprintf(" --cert-dir=/tmp/kubernetes"),
 			fmt.Sprintf(" %s", m.config.KubeAPIArgs),
 		), m.config.KubeAPIPort}
 }

--- a/pkg/workloads/mutilate/commands.go
+++ b/pkg/workloads/mutilate/commands.go
@@ -23,7 +23,7 @@ import (
 
 // getAgentCommand returns command for agent.
 func getAgentCommand(config Config) string {
-	cmd := fmt.Sprintf("%s -T %d -A -p %d",
+	cmd := fmt.Sprintf("%s -v -T %d -A -p %d",
 		config.PathToBinary,
 		config.AgentThreads,
 		config.AgentPort,
@@ -60,7 +60,7 @@ func getPopulateCommand(config Config) string {
 func getBaseMasterCommand(config Config, agentHandles []executor.TaskHandle) string {
 	baseCommand := fmt.Sprint(
 		fmt.Sprintf("%s", config.PathToBinary),
-		fmt.Sprintf(" -s %s:%d", config.MemcachedHost, config.MemcachedPort),
+		fmt.Sprintf(" -v -s %s:%d", config.MemcachedHost, config.MemcachedPort),
 		fmt.Sprintf(" --warmup %d --noload", int(config.WarmupTime.Seconds())),
 		fmt.Sprintf(" -K %s -V %s -i %s", config.KeySize, config.ValueSize, config.InterArrivalDist),
 		fmt.Sprintf(" -T %d", config.MasterThreads),


### PR DESCRIPTION
Fixes issue "cannot run k8s without root and not enough logs from remote & mutilate for debugging purposes"

Summary of changes:
- verbose mutilate (-v)
- add 'remoto command running on "HOST"'
- kubernetes requires to put cert somewhere (need to access to this dir as non root) --cert-dir
- kubernetes tried automatically find "advertise ip" (which required sudo) - now it is passed explict

Testing done:
- yes, manually durning full expeirments run
