### PR TITLE
SCE-1140: fix caffee session for both local & kubernetes

### DIFF
--- a/integration_tests/pkg/executor/kubernetes_test.go
+++ b/integration_tests/pkg/executor/kubernetes_test.go
@@ -16,7 +16,6 @@ package executor
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 	"time"
@@ -159,6 +158,7 @@ func TestKubernetesExecutor(t *testing.T) {
 			exitCode, err := taskHandle.ExitCode()
 			So(exitCode, ShouldEqual, 0)
 
+			// Stdout
 			stdout, err := taskHandle.StdoutFile()
 			So(err, ShouldBeNil)
 			defer stdout.Close()
@@ -172,16 +172,19 @@ func TestKubernetesExecutor(t *testing.T) {
 			So(output, ShouldContain, "This is Sparta")
 			So(output, ShouldContain, "This is England")
 
+			// Stderr
 			stderr, err := taskHandle.StderrFile()
 			So(err, ShouldBeNil)
 			defer stderr.Close()
-			buffer = make([]byte, 10)
+			buffer = make([]byte, 31)
 			n, err = stderr.Read(buffer)
 
-			// stderr will always be empty as we are not able to fetch it from K8s.
-			// stdout includes both stderr and stdout of the application run in the pod.
-			So(err, ShouldEqual, io.EOF)
-			So(n, ShouldEqual, 0)
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, 31)
+			output = strings.Split(string(buffer), "\n")
+			So(output, ShouldHaveLength, 3)
+			So(output, ShouldContain, "This is Sparta")
+			So(output, ShouldContain, "This is England")
 		})
 
 		Convey("Long running pod is not deadlocked when deleted externally", func() {

--- a/pkg/snap/sessions/caffe/caffe.go
+++ b/pkg/snap/sessions/caffe/caffe.go
@@ -87,7 +87,7 @@ func (s *SessionLauncher) LaunchSession(
 	tags map[string]interface{}) (snap.SessionHandle, error) {
 
 	// Obtain Caffe Inference output file.
-	stdoutFile, err := task.StdoutFile()
+	stdoutFile, err := task.StderrFile()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes issue "caffe collector doesn't work at the same time" for local and kubernetes executor

reason:
- mutilate session is using stderr to read caffe throughput (it's ok for local executor), but for kubernetes stderr is empty for kubernetes (kubernetes doesn't provide stderr)

Provided solutions clones standard output to error output - **unfortunately it duplicates every error message for every workload run in kubernetes.**

Thanks to that, no matter where caffe outputs it is always available in stderr. 

Summary of changes:
- use `io.Multiwriter` to duplicate output from standard to error stream for kubernetes executor

Testing done:
- yes manually - works for sensitivity experiments for both local & k8s
