### PR TITLE
ServiceHandle is now ready for concurrent use

### DIFF
--- a/pkg/executor/service.go
+++ b/pkg/executor/service.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -27,7 +28,7 @@ User should use them to state intent that these processes should not stop withou
 explicit `Stop()` or `Wait()` invoked on TaskHandle.
 
 If process would stop on it's own, the Stop() and Wait() functions will return error
-and process logs will be available on experiment log stream.
+and process logs will be available on experiment log stream. In this case, each subsequent invocation of Stop() and Wait() will return error.
 */
 
 // ServiceLauncher is a decorator and Launcher implementation that should be used for tasks that do not stop on their own.
@@ -42,31 +43,62 @@ func (sl ServiceLauncher) Launch() (TaskHandle, error) {
 		return nil, err
 	}
 
-	return &ServiceHandle{th}, nil
+	return NewServiceHandle(th), nil
 }
 
-// ServiceHandle is a decorator and TaskHandle implementation that should be used with tasks that do not stop on their own.
-type ServiceHandle struct {
+type serviceHandle struct {
 	TaskHandle
+	taskCanBeTerminated bool
+	err                 error
+	mutex               *sync.Mutex
+}
+
+// NewServiceHandle wraps TaskHandle with serviceHandle.
+func NewServiceHandle(handle TaskHandle) TaskHandle {
+	return &serviceHandle{
+		TaskHandle: handle,
+		mutex:      &sync.Mutex{}}
 }
 
 // Stop implements TaskHandle interface.
-func (s ServiceHandle) Stop() error {
-	if s.TaskHandle.Status() != RUNNING {
-		logrus.Errorf("Stop(): ServiceHandle with command %q has terminated prematurely", s.TaskHandle.Name())
-		logOutput(s.TaskHandle)
-		return errors.Errorf("Service %q has ended prematurely", s.TaskHandle.Name())
+func (s *serviceHandle) Stop() error {
+	err := s.checkError()
+	if err != nil {
+		return err
 	}
 
 	return s.TaskHandle.Stop()
 }
 
 // Wait implements TaskHandle interface.
-func (s ServiceHandle) Wait(duration time.Duration) bool {
-	if s.TaskHandle.Status() != RUNNING {
-		logrus.Errorf("Wait(): ServiceHandle with command %q has terminated prematurely", s.TaskHandle.Name())
-		logOutput(s.TaskHandle)
+func (s *serviceHandle) Wait(duration time.Duration) bool {
+	err := s.checkError()
+	if err != nil {
+		// TODO(skonefal): Return error here when wait will return errors.
+		return s.TaskHandle.Wait(duration)
 	}
 
 	return s.TaskHandle.Wait(duration)
+}
+
+func (s *serviceHandle) checkError() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.err != nil {
+		return s.err
+	}
+
+	if !s.taskCanBeTerminated {
+		s.taskCanBeTerminated = true
+		if s.TaskHandle.Status() == TERMINATED {
+			err := errors.Errorf("ServiceHandle with command %q has terminated prematurely", s.TaskHandle.Name())
+			s.err = err
+
+			logOutput(s.TaskHandle)
+			logrus.Errorf(err.Error())
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -209,7 +209,7 @@ func (m mutilate) runRemoteAgents() ([]executor.TaskHandle, error) {
 			}
 			return nil, err
 		}
-		serviceHandle := executor.ServiceHandle{TaskHandle: handle}
+		serviceHandle := executor.NewServiceHandle(handle)
 		handles = append(handles, serviceHandle)
 	}
 


### PR DESCRIPTION
Fixes issue of invoking Stop twice, and returned error second time.

Summary of changes:
- ServiceHandle remembers that Stop&Wait has been invoked before and does not yields error.
- When task has ended prematurely, same error is returned every time

Testing done:
- UT
