### PR TITLE
sane mutilate warmup times 

### DIFF
--- a/pkg/workloads/mutilate/mutilate.go
+++ b/pkg/workloads/mutilate/mutilate.go
@@ -32,7 +32,7 @@ const (
 	defaultPercentile             = "99"
 	defaultTuningTime             = 10 * time.Second // [s]
 	defaultRecords                = 5000000
-	defaultWarmupTime             = 1 * time.Second // [s]
+	defaultWarmupTime             = 0 * time.Second // [s] Note: with high load in distribute mode can warmup phase can deadlock.
 	defaultAgentThreads           = 8
 	defaultAgentPort              = 5556
 	defaultAgentConnections       = 16


### PR DESCRIPTION
Fixes issue "warmup phase can deadlock with higher loads when run in distriubted mode with more than 4 nodes"

Summary of changes:
- just change default 1s to 0

Testing done:
- yes - used in production
