### PR TITLE
SCE-1165 [1/2]: Enabled Intel RDT(r) metrics during memcached-CAT experiment 

### DIFF
--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -37,11 +37,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
 	"github.com/intelsdi-x/swan/pkg/utils/uuid"
 	"github.com/intelsdi-x/swan/pkg/workloads/caffe"
-	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1data"
-	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1instruction"
-	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l3"
-	"github.com/intelsdi-x/swan/pkg/workloads/low_level/memoryBandwidth"
-	"github.com/intelsdi-x/swan/pkg/workloads/low_level/stream"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"
 	"github.com/pkg/errors"
 )
@@ -339,10 +334,8 @@ func createLauncherSessionPair(aggressorName string, l1Isolation, llcIsolation i
 		caffeSession, err := caffeinferencesession.NewSessionLauncher(caffeinferencesession.DefaultConfig())
 		errutil.CheckWithContext(err, "Cannot create Caffee session launcher")
 		beLauncher = sensitivity.NewMonitoredLauncher(aggressorPair, caffeSession)
-	case l1data.ID, l1instruction.ID, memoryBandwidth.ID, l3.ID, stream.ID:
-		beLauncher = sensitivity.NewLauncherWithoutSession(aggressorPair)
 	default:
-		logrus.Fatalf("Unknown aggressor: %q", aggressorName)
+		beLauncher = sensitivity.NewLauncherWithoutSession(aggressorPair)
 	}
 
 	return

--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/rdt"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
+	_ "github.com/intelsdi-x/swan/pkg/utils/unshare"
 	"github.com/intelsdi-x/swan/pkg/utils/uuid"
 	"github.com/intelsdi-x/swan/pkg/workloads/caffe"
 	"github.com/intelsdi-x/swan/pkg/workloads/memcached"


### PR DESCRIPTION
Fixes issue "no RDT session used"

Note: requires RDT plugin installed

Summary of changes:
- just add an RDT session during phase run (optionally with new flag `use_RDT_collector`)
- new tags to better expose dimensions,
- fix launcher session pair for new aggressors,

Testing done:
- yes, manually
