### PR TITLE
sane defaults for experiment caffe isolation

### DIFF
--- a/pkg/experiment/sensitivity/factory.go
+++ b/pkg/experiment/sensitivity/factory.go
@@ -82,7 +82,7 @@ var (
 	RunCaffeWithLLCIsolationFlag = conf.NewBoolFlag(
 		"experiment_run_caffe_with_l3_cache_isolation",
 		"If set, the Caffe Best Effort workload will use the same isolation settings as for L3 Best Efforts, otherwise swan won't apply any performance isolation. User can use this flag to compare running task on separate cores and using OS scheduler.",
-		true,
+		false,
 	)
 )
 


### PR DESCRIPTION
Fixes issue "run caffe without core isolation by default" - makes default results more sensible (and with align with presented results)

Summary of changes:
- change LLC isolation for caffe to false by default

Testing done:
- yes
