### PR TITLE
kubernetes HP memory 4GB by default

### DIFF
--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -41,7 +41,7 @@ var (
 	// HPKubernetesCPUResourceFlag indicates CPU shares that HP task should be allowed to use.
 	HPKubernetesCPUResourceFlag = conf.NewIntFlag("kubernetes_hp_cpu_resource", "Sets CPU resource limit and request for HP workload on Kubernetes [CPU millis, default 1000 * number of CPU].", runtime.NumCPU()*1000)
 	// HPKubernetesMemoryResourceFlag indicates amount of memory that HP task can use.
-	HPKubernetesMemoryResourceFlag = conf.NewIntFlag("kubernetes_hp_memory_resource", "Sets memory limit and request for HP workloads on Kubernetes in bytes (default 1GB).", 1000000000)
+	HPKubernetesMemoryResourceFlag = conf.NewIntFlag("kubernetes_hp_memory_resource", "Sets memory limit and request for HP workloads on Kubernetes in bytes (default 4GB).", 4000000000)
 
 	kubernetesNodeName = conf.NewStringFlag("kubernetes_target_node_name", fmt.Sprintf("Experiment's Kubernetes pods will be run on this node. Helpful when used with %q flag. Default is `$HOSTNAME`", RunOnExistingKubernetesFlag.Name), hostname)
 )


### PR DESCRIPTION
Fixes issue "with 5mln records on kubernetes with facebook key/value distribution sizes" - there is no enough memory to run memcache in docker (and it doesn't match memcached config allowing to use 4gb)

Summary of changes:
- just change default value to 4gb of memory for HP kubernetes workloads

Testing done:
- yes, manually
