### PR TITLE
cat: run baseline phase first

### DIFF
--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -139,7 +139,7 @@ func main() {
 	// Include baseline phase if necessary.
 	aggressors := sensitivity.AggressorsFlag.Value()
 	if includeBaselinePhaseFlag.Value() {
-		aggressors = append(aggressors, "")
+		aggressors = append([]string{""}, aggressors...)
 	}
 
 	useRDTCollector := useRDTCollectorFlag.Value()


### PR DESCRIPTION
Fixes issue "hard to properly baseline memcached-cat experiment"

there remaining phases results aren't trustworthy if baseline fails

Summary of changes:
- just prepend "" none aggressor instead of appending 

Testing done:
- yes,
