### PR TITLE
Environment validation shows address of remote host which failed

### DIFF
--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -119,7 +119,7 @@ func getAuthMethod(keyPath string) (ssh.AuthMethod, error) {
 
 // Name returns User-friendly name of executor.
 func (remote Remote) Name() string {
-	return "Remote Executor"
+	return fmt.Sprintf("Remote executor on (%s:%s)", remote.config.User, remote.targetHost)
 }
 
 // Execute runs the command given as input.

--- a/pkg/experiment/sensitivity/validate/validate.go
+++ b/pkg/experiment/sensitivity/validate/validate.go
@@ -73,9 +73,9 @@ func CheckCPUPowerGovernor() {
 // checkNOFILE checks if the number of maximum file descriptors
 // opened by a process is more than minimum requested.
 // The name NOFILE is based on "limits.conf" and definition from setrlimit.
-func checkNOFILE(nofile, minimum int) {
+func checkNOFILE(executor executor.Executor, nofile, minimum int) {
 	if nofile <= minimum {
-		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d). You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.", nofile, minimum)
+		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d) on (%s). You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.", nofile, minimum, executor.Name())
 	}
 
 }
@@ -83,10 +83,13 @@ func checkNOFILE(nofile, minimum int) {
 // OS checks experiment local OS environment to help identify potential issues.
 // Note: in case of some requirements not met, only warns user.
 func OS() {
+
 	checkTCPSyncookies()
 	CheckCPUPowerGovernor()
+	executor := executor.NewLocal()
 	checkNOFILE(
-		getNOFILE(executor.NewLocal()),
+		executor,
+		getNOFILE(executor),
 		minimalNOFILERequirement,
 	)
 }
@@ -96,6 +99,7 @@ func OS() {
 func ExecutorsNOFILELimit(executors []executor.Executor) {
 	for _, executor := range executors {
 		checkNOFILE(
+			executor,
 			getNOFILE(executor),
 			minimalNOFILERequirement,
 		)


### PR DESCRIPTION
Fixes issue "couldn't find which host had a problem during validation"

before:
```
WARN[2017-05-18 16:47:15.500] 
Maximum number of open file descriptors (1000) is lower than required (10240). 
You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.
```

after:
```
WARN[2017-05-18 16:47:15.500] 
Maximum number of open file descriptors (1000) is lower than required (10240) on (Remote executor on (swan:ovh10)). 
You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.
```

Summary of changes:
- information about host that validator was running on

Testing done:
- yes
