### PR TITLE
SCE-1150: Check enough of CPUs in Makefile for running integration tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,15 @@ test_integration_build:
 
 test_integration:
 	go test -i ./integration_tests/... 
-	# Validate that there is enough cpus to run integration tests.
-	if [[ `nproc` -lt 2 ]]; then \
+	@# Validate that there is enough cpus to run integration tests.
+	@if [[ `nproc` -lt 2 ]]; then \
 		echo 'warning: not enough cpus `nproc` to run integrations tests (two cores are required)'; \
 		exit 1;\
 	fi
-	./scripts/isolate-pid.sh go test -p 1 $(TEST_OPT) ./integration_tests/... 
+	./scripts/isolate-pid.sh go test -p 1 $(TEST_OPT) ./integration_tests
+	./scripts/isolate-pid.sh go test -p 1 $(TEST_OPT) ./integration_tests/pkg/...
+	./scripts/isolate-pid.sh go test -p 1 $(TEST_OPT) ./integration_tests/snap-plugins/...
+	./scripts/isolate-pid.sh go test -p 1 $(TEST_OPT) ./integration_tests/experiments/...
 
 cleanup:
 	rm -fr plugins/**/*log

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ test_integration_build:
 
 test_integration:
 	go test -i ./integration_tests/... 
+	# Validate that there is enough cpus to run integration tests.
+	if [[ `nproc` -lt 2 ]]; then \
+		echo 'warning: not enough cpus `nproc` to run integrations tests (two cores are required)'; \
+		exit 1;\
+	fi
 	./scripts/isolate-pid.sh go test -p 1 $(TEST_OPT) ./integration_tests/... 
 
 cleanup:

--- a/integration_tests/pkg/isolation/cgroup/cpu_set_test.go
+++ b/integration_tests/pkg/isolation/cgroup/cpu_set_test.go
@@ -15,10 +15,12 @@
 package integration
 
 import (
-	"github.com/intelsdi-x/swan/pkg/isolation"
 	"os/exec"
 	pth "path"
 	"testing"
+
+	"github.com/intelsdi-x/swan/pkg/isolation"
+	"github.com/intelsdi-x/swan/pkg/isolation/topo"
 
 	"github.com/intelsdi-x/swan/pkg/isolation/cgroup"
 	. "github.com/smartystreets/goconvey/convey"
@@ -27,6 +29,12 @@ import (
 func TestCPUSet(t *testing.T) {
 
 	Convey("When constructing a new CPUSet", t, func() {
+		topology, err := topo.Discover()
+		So(err, ShouldBeNil)
+		if len(topology.AvailableThreads()) < 2 {
+			t.Skip("this tests requires at least 2 logical threads (cpus) to run")
+		}
+
 		uuid1 := uuidgen(t)
 		uuid2 := uuidgen(t)
 		uuid3 := uuidgen(t)


### PR DESCRIPTION
Fixes issue "just check enough of cpus available to run integration tests"

Summary of changes:
- just a simple check in Makefile
- in case of running experiments manually with go test (just one test `TestCPUSet` is **skipped**)
- explict correct order of integration tests (first run pkg then plugin and then full experiments tests)

If run on single cpu node the results of `make test_integration` is:

```
warning: not enough cpus `nproc` to run integrations tests (two cores are required)
make: *** [test_integration] Error 1
```

Testing done:
- yes manually on vbox with VBOX_CPUS=1 (exit with warning and 1 errorcode)
