### PR TITLE
[1/2] SCE-1172: baseline flag replaced with explicit "None" aggressor

### DIFF
--- a/experiments/memcached-sensitivity-profile/docs/experiment_config_dump_example.md
+++ b/experiments/memcached-sensitivity-profile/docs/experiment_config_dump_example.md
@@ -336,9 +336,4 @@ EXPERIMENT_BE_WORKLOAD_L3_CPU_RANGE=
 
 # BE cpuset range (e.g: 0-2) for workloads that are targeted as L1-interfering workloads. All three 'range' flags must be set to use this policy.
 EXPERIMENT_BE_WORKLOAD_L1_CPU_RANGE=
-
-# Run Baseline (a phase without a Best Effort workload)
-# Default: true
-EXPERIMENT_BASELINE=true
-
 ```

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/swan/experiments/memcached-sensitivity-profile/common"
-	"github.com/intelsdi-x/swan/pkg/conf"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/experiment"
 	"github.com/intelsdi-x/swan/pkg/experiment/logger"
@@ -41,8 +40,7 @@ import (
 )
 
 var (
-	includeBaselinePhaseFlag = conf.NewBoolFlag("experiment_baseline", "Run Baseline (a phase without a Best Effort workload)", true)
-	appName                  = os.Args[0]
+	appName = os.Args[0]
 )
 
 func main() {
@@ -57,16 +55,10 @@ func main() {
 	logger.Initialize(appName, uid)
 
 	metadata, err := experiment.NewMetadata(uid, experiment.MetadataConfigFromFlags())
-	if err != nil {
-		logrus.Errorf("Cannot connect to Cassandra Metadata Database %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
+	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
+
 	// Save experiment runtime environment (configuration, environmental variables, etc).
 	err = metadata.RecordRuntimeEnv(experimentStart)
-	if err != nil {
-		logrus.Errorf("Cannot save runtime environment %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
 	errutil.CheckWithContext(err, "Cannot save runtime environment in Cassandra Metadata Database")
 
 	// Validate preconditions.
@@ -77,10 +69,7 @@ func main() {
 
 	// Create executors with cleanup function.
 	hpExecutor, beExecutorFactory, cleanup, err := sensitivity.PrepareExecutors(hpIsolation)
-	if err != nil {
-		logrus.Errorf("Cannot create executors: %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
+	errutil.CheckWithContext(err, "cannot prepare executors")
 	defer func() {
 		if cleanup != nil {
 			err := cleanup()
@@ -92,14 +81,7 @@ func main() {
 
 	// Create BE workloads.
 	beLaunchers, err := sensitivity.PrepareAggressors(l1Isolation, llcIsolation, beExecutorFactory)
-	if err != nil {
-		logrus.Errorf("Cannot create Best Effort tasks: %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
-	// Zero-value sensitivity.LauncherSessionPair represents baselining.
-	if includeBaselinePhaseFlag.Value() {
-		beLaunchers = append([]sensitivity.LauncherSessionPair{sensitivity.LauncherSessionPair{}}, beLaunchers...)
-	}
+	errutil.CheckWithContext(err, "cannot prepare aggressors")
 
 	// Create HP workload.
 	memcachedConfig := memcached.DefaultMemcachedConfig()
@@ -107,25 +89,17 @@ func main() {
 
 	// Load generator.
 	loadGenerator, err := common.PrepareMutilateGenerator(memcachedConfig.IP, memcachedConfig.Port)
-	if err != nil {
-		logrus.Errorf("Cannot create Load Generator: %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
+	errutil.CheckWithContext(err, "cannot prepare load generator")
 
 	snapSession, err := mutilatesession.NewSessionLauncherDefault()
-	if err != nil {
-		logrus.Errorf("Cannot create Snap session: %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
+	errutil.CheckWithContext(err, "cannot create mutilate snap session")
 
 	// Retrieve peak load from flags and overwrite it when required.
 	load := sensitivity.PeakLoadFlag.Value()
-	if sensitivity.PeakLoadFlag.Value() == sensitivity.RunTuningPhase {
+	if load == sensitivity.RunTuningPhase {
+		logrus.Info("Tuning phase...")
 		load, err = experiment.GetPeakLoad(hpLauncher, loadGenerator, sensitivity.SLOFlag.Value())
-		if err != nil {
-			logrus.Errorf("Cannot retrieve peak load (using tuning): %q", err.Error())
-			os.Exit(experiment.ExSoftware)
-		}
+		errutil.CheckWithContext(err, "cannot retrieve peak load during tuning")
 		logrus.Infof("Ran tuning and achieved load of %d", load)
 	} else {
 		logrus.Infof("Skipping tuning phase, using peakload %d", load)
@@ -148,10 +122,7 @@ func main() {
 	}
 
 	err = metadata.RecordMap(records)
-	if err != nil {
-		logrus.Errorf("Cannot save metadata: %q", err.Error())
-		os.Exit(experiment.ExSoftware)
-	}
+	errutil.CheckWithContext(err, "cannot save metadata")
 
 	for _, beLauncher := range beLaunchers {
 		for loadPoint := 0; loadPoint < loadPoints; loadPoint++ {

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -40,9 +40,8 @@ import (
 )
 
 var (
-	includeBaselinePhaseFlag = conf.NewBoolFlag("baseline", "Run baseline phase (without aggressors)", true)
-	specjbbTxICountFlag      = conf.NewIntFlag("specjbb_transaction_injectors_count", "Number of Transaction injectors run in one group", 1)
-	specjbbWorkerCountFlag   = conf.NewIntFlag(
+	specjbbTxICountFlag    = conf.NewIntFlag("specjbb_transaction_injectors_count", "Number of Transaction injectors run in one group", 1)
+	specjbbWorkerCountFlag = conf.NewIntFlag(
 		"specjbb_worker_count",
 		"Number of fork join worker threads (defaults to number of logical threads)",
 		runtime.NumCPU())
@@ -86,11 +85,6 @@ func main() {
 	// Prepare session launchers (including Snap session if necessary) for aggressors.
 	aggressorSessionLaunchers, err := sensitivity.PrepareAggressors(l1Isolation, llcIsolation, beExecutorFactory)
 	errutil.Check(err)
-
-	// Zero-value sensitivity.LauncherSessionPair represents baselining.
-	if includeBaselinePhaseFlag.Value() {
-		aggressorSessionLaunchers = append([]sensitivity.LauncherSessionPair{{}}, aggressorSessionLaunchers...)
-	}
 
 	specjbbControllerAddress := specjbb.ControllerAddress.Value()
 	// Create launcher for high priority task (in case of SPECjbb it is a backend).

--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -150,21 +150,21 @@ func TestExperiment(t *testing.T) {
 		defer session.Close()
 
 		Convey("With proper configuration and without aggressor phases", func() {
-			_, err := runExp(memcachedSensitivityProfileBin, true)
+			_, err := runExp(memcachedSensitivityProfileBin, true, "-experiment_be_workloads", "None")
 
 			Convey("Experiment should return with no errors", func() {
 				So(err, ShouldBeNil)
 			})
 		})
 
-		Convey("With caffe aggressor and baseline", func() {
+		Convey("With just caffe aggressor", func() {
 			args := []string{"-experiment_be_workloads", "caffe"}
 			Convey("Experiment should run with no errors and results should be stored in a Cassandra DB", func() {
 				experimentID, err := runExp(memcachedSensitivityProfileBin, true, args...)
 				So(err, ShouldBeNil)
 
 				_, _, swanAggressorsNames, _, _ := loadDataFromCassandra(session, experimentID)
-				So("None", ShouldBeIn, swanAggressorsNames)
+				So("None", ShouldNotBeIn, swanAggressorsNames)
 				So("Caffe", ShouldBeIn, swanAggressorsNames)
 			})
 		})
@@ -177,7 +177,6 @@ func TestExperiment(t *testing.T) {
 
 				_, _, swanAggressorsNames, _, metricsCount := loadDataFromCassandra(session, experimentID)
 				So(metricsCount, ShouldBeGreaterThan, 0)
-				So("None", ShouldBeIn, swanAggressorsNames)
 				So("stress-ng-cache-l1", ShouldBeIn, swanAggressorsNames)
 
 				// Check metadata was saved.
@@ -210,13 +209,13 @@ func TestExperiment(t *testing.T) {
 				So(metricsCount, ShouldBeGreaterThan, 0)
 
 				So("stress-ng-cache-l1", ShouldBeIn, swanAggressorsNames)
-				So("None", ShouldBeIn, swanAggressorsNames)
+				So("None", ShouldNotBeIn, swanAggressorsNames)
 
 				So("0", ShouldBeIn, swanRepetitions)
 				So("1", ShouldBeIn, swanRepetitions)
 
-				So(swanAggressorsNames, ShouldHaveLength, 36)
-				So(swanRepetitions, ShouldHaveLength, 36)
+				So(swanAggressorsNames, ShouldHaveLength, 18)
+				So(swanRepetitions, ShouldHaveLength, 18)
 
 			})
 
@@ -231,19 +230,19 @@ func TestExperiment(t *testing.T) {
 
 				So(tags["swan_repetition"], ShouldEqual, "0")
 
-				So(swanAggressorsNames, ShouldHaveLength, 36)
-				So(swanPhases, ShouldHaveLength, 36)
+				So(swanAggressorsNames, ShouldHaveLength, 18)
+				So(swanPhases, ShouldHaveLength, 18)
 
 				So("stress-ng-cache-l1", ShouldBeIn, swanAggressorsNames)
-				So("None", ShouldBeIn, swanAggressorsNames)
+				So("None", ShouldNotBeIn, swanAggressorsNames)
 
-				So("Aggressor None; load point 0;", ShouldBeIn, swanPhases)
+				So("Aggressor stress-ng-cache-l1; load point 0;", ShouldBeIn, swanPhases)
 
 			})
 		})
 
 		Convey("With proper kubernetes configuration and without phases", func() {
-			args := []string{"-kubernetes"}
+			args := []string{"-kubernetes", "-experiment_be_workloads=None", "-kubernetes_hp_memory_resource=1000000000"}
 			_, err := runExp(memcachedSensitivityProfileBin, true, args...)
 			Convey("Experiment should return with no errors", func() {
 				So(err, ShouldBeNil)
@@ -251,7 +250,7 @@ func TestExperiment(t *testing.T) {
 		})
 
 		Convey("With proper kubernetes configuration and with l1d aggressor", func() {
-			args := []string{"-kubernetes", "-experiment_be_workloads", "stress-ng-cache-l1", "-experiment_baseline=false", "-kubernetes_hp_memory_resource", "1000000000"}
+			args := []string{"-kubernetes", "-experiment_be_workloads", "stress-ng-cache-l1", "-kubernetes_hp_memory_resource", "1000000000"}
 			Convey("Experiment should run with no errors and results should be stored in a Cassandra DB", func() {
 				experimentID, err := runExp(memcachedSensitivityProfileBin, true, args...)
 				So(err, ShouldBeNil)
@@ -264,7 +263,7 @@ func TestExperiment(t *testing.T) {
 		})
 
 		Convey("With proper kubernetes configuration and with stress-ng-stream aggressor", func() {
-			args := []string{"-kubernetes", "-experiment_be_workloads", "stress-ng-stream", "-experiment_baseline=false", "-kubernetes_hp_memory_resource", "1000000000"}
+			args := []string{"-kubernetes", "-experiment_be_workloads", "stress-ng-stream", "-kubernetes_hp_memory_resource", "1000000000"}
 			Convey("Experiment should run with no errors and results should be stored in a Cassandra DB", func() {
 				experimentID, err := runExp(memcachedSensitivityProfileBin, true, args...)
 				So(err, ShouldBeNil)
@@ -277,7 +276,7 @@ func TestExperiment(t *testing.T) {
 		})
 
 		Convey("With proper kubernetes and caffe", func() {
-			args := []string{"-kubernetes", "-experiment_be_workloads", "caffe", "-experiment_baseline=false", "-kubernetes_hp_memory_resource", "1000000000"}
+			args := []string{"-kubernetes", "-experiment_be_workloads", "caffe", "-kubernetes_hp_memory_resource", "1000000000"}
 			Convey("Experiment should run with no errors and results should be stored in a Cassandra DB", func() {
 				experimentID, err := runExp(memcachedSensitivityProfileBin, true, args...)
 				So(err, ShouldBeNil)

--- a/pkg/experiment/sensitivity/topology/isolations.go
+++ b/pkg/experiment/sensitivity/topology/isolations.go
@@ -42,7 +42,7 @@ type defaultTopology struct {
 	SiblingThreadsToHpThreads topo.ThreadSet
 }
 
-// NewIsolations returns HP anb factory of aggressors with applied isolation for BE tasks.
+// NewIsolations returns isolations to be used with HP & set of aggressors depending on kind of stressed resource.
 // TODO: needs update for different isolation per cpu
 func NewIsolations() (hpIsolation, l1Isolation, llcIsolation isolation.Decorator) {
 	if isManualPolicy() {


### PR DESCRIPTION
Fixes issue "cannot run experiment with only "baseline" phase" (env flag is not used when provided as an empty string"

Summary of changes:
- removed "include baseline flag" for all experiments and replaced with "None" dummy aggressor that is constructed by prepareAggressor helpers
- memcached-sensitivity-experiment replaced manual error checking with errorutil.CheckWithContext
- memcached-cat validation that user provided ranges for HP & BE workloads

Testing done:
- yes
