### PR TITLE
[2/2] SCE-1171, SCE-1163: memcached-cat hp throttling flag, run as "Burstable class" by default and "Caffe isolated" aggressor

### DIFF
--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -48,7 +48,7 @@ var (
 	qpsFlag                  = conf.NewStringFlag("cat_qps", "Comma-separated list of QpS to iterate over", "375000")
 	maxCacheWaysToAssignFlag = conf.NewIntFlag("cat_max_cache_ways", "Mask representing maximum number of cache ways to assign to a job. It is assumed that cat_max_cache_ways and cat_min_cache_ways sum to number of all cache ways available.", 11)
 	minCacheWaysToAssignFlag = conf.NewIntFlag("cat_min_cache_ways", "Mask representing minumim number of cache ways to assing to a job. It is assumed that cat_max_cache_ways and cat_min_cache_ways sum to number of all cache ways available.", 1)
-	cacheParitioningFlag     = conf.NewBoolFlag("cat_cache_paritioning", "Enable separate cache parition for HP workload (otherwise HP has access to whole cache, not just rest of not used by BE workload)", false)
+	cacheParitioningFlag     = conf.NewBoolFlag("cat_cache_paritioning", "Enables dedicated sets of cache ways for HP and BE workloads (if disabled then HP workload uses all cache ways all the time).", false)
 	minNumberOfBECPUsFlag    = conf.NewIntFlag("cat_min_be_cpus", "Minimum number of CPUs available to BE job.", 1)
 	maxNumberOfBECPUsFlag    = conf.NewIntFlag("cat_max_be_cpus", "Maximum number of CPUs available to BE job. If set to zero then all availabe cores will be used (taking isolation defined into consideration).", 0)
 	useRDTCollectorFlag      = conf.NewBoolFlag("use_rdt_collector", "Collects Intel RDT metrics.", false)
@@ -372,7 +372,7 @@ func createLauncherSessionPair(aggressorName string, l1Isolation, llcIsolation i
 	errutil.CheckWithContext(err, "Cannot create aggressor pair")
 
 	switch aggressorName {
-	case caffe.ID:
+	case caffe.ID, sensitivity.CaffeAggressorWithIsolation:
 		caffeSession, err := caffeinferencesession.NewSessionLauncher(caffeinferencesession.DefaultConfig())
 		errutil.CheckWithContext(err, "Cannot create Caffee session launcher")
 		beLauncher = sensitivity.NewMonitoredLauncher(aggressor, caffeSession)

--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -103,7 +103,7 @@ func main() {
 	beCores := topology.BeRangeFlag.Value()
 
 	if len(beCores) == 0 || len(hpCores) == 0 {
-		logrus.Errorf("HP & BE workloads ranges required! (please specify -experiment_hp_workload_cpu_range and -experiment_be_workload_l3_cpu_range)")
+		logrus.Errorf("HP & BE workloads ranges required! (please specify -%s and -%s)", topology.HpRangeFlag.Name, topology.BeRangeFlag.Name)
 		os.Exit(experiment.ExUsage)
 	}
 	logrus.Debugf("HP CPU range: %+v", hpCores)
@@ -353,18 +353,16 @@ func main() {
 
 func createLauncherSessionPair(aggressorName string, l1Isolation, llcIsolation isolation.Decorator, beExecutorFactory sensitivity.ExecutorFactoryFunc) (beLauncher sensitivity.LauncherSessionPair) {
 	aggressorFactory := sensitivity.NewMultiIsolationAggressorFactory(l1Isolation, llcIsolation)
-	aggressorPair, err := aggressorFactory.Create(aggressorName, beExecutorFactory)
+	aggressor, err := aggressorFactory.Create(aggressorName, beExecutorFactory)
 	errutil.CheckWithContext(err, "Cannot create aggressor pair")
 
 	switch aggressorName {
-	case sensitivity.NoneAggressorID:
-		beLauncher = sensitivity.LauncherSessionPair{}
 	case caffe.ID:
 		caffeSession, err := caffeinferencesession.NewSessionLauncher(caffeinferencesession.DefaultConfig())
 		errutil.CheckWithContext(err, "Cannot create Caffee session launcher")
-		beLauncher = sensitivity.NewMonitoredLauncher(aggressorPair, caffeSession)
+		beLauncher = sensitivity.NewMonitoredLauncher(aggressor, caffeSession)
 	default:
-		beLauncher = sensitivity.NewLauncherWithoutSession(aggressorPair)
+		beLauncher = sensitivity.NewLauncherWithoutSession(aggressor)
 	}
 
 	return

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -129,7 +129,7 @@ func main() {
 			// Calculate number of QPS in phase.
 			phaseQPS := int(int(load) / sensitivity.LoadPointsCountFlag.Value() * (loadPoint + 1))
 			// Generate name of the phase (taking zero-value LauncherSessionPair aka baseline into consideration).
-			aggressorName := "None"
+			aggressorName := sensitivity.NoneAggressorID
 			if beLauncher.Launcher != nil {
 				aggressorName = beLauncher.Launcher.Name()
 			}

--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 	"github.com/intelsdi-x/swan/pkg/experiment"
+	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
+	"github.com/intelsdi-x/swan/pkg/workloads/low_level/stressng"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -150,7 +152,7 @@ func TestExperiment(t *testing.T) {
 		defer session.Close()
 
 		Convey("With proper configuration and without aggressor phases", func() {
-			_, err := runExp(memcachedSensitivityProfileBin, true, "-experiment_be_workloads", "None")
+			_, err := runExp(memcachedSensitivityProfileBin, true, "-experiment_be_workloads", sensitivity.NoneAggressorID)
 
 			Convey("Experiment should return with no errors", func() {
 				So(err, ShouldBeNil)
@@ -164,7 +166,7 @@ func TestExperiment(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				_, _, swanAggressorsNames, _, _ := loadDataFromCassandra(session, experimentID)
-				So("None", ShouldNotBeIn, swanAggressorsNames)
+				So(sensitivity.NoneAggressorID, ShouldNotBeIn, swanAggressorsNames)
 				So("Caffe", ShouldBeIn, swanAggressorsNames)
 			})
 		})
@@ -177,7 +179,7 @@ func TestExperiment(t *testing.T) {
 
 				_, _, swanAggressorsNames, _, metricsCount := loadDataFromCassandra(session, experimentID)
 				So(metricsCount, ShouldBeGreaterThan, 0)
-				So("stress-ng-cache-l1", ShouldBeIn, swanAggressorsNames)
+				So(stressng.IDCacheL1, ShouldBeIn, swanAggressorsNames)
 
 				// Check metadata was saved.
 				var (
@@ -208,8 +210,8 @@ func TestExperiment(t *testing.T) {
 				_, swanRepetitions, swanAggressorsNames, _, metricsCount := loadDataFromCassandra(session, experimentID)
 				So(metricsCount, ShouldBeGreaterThan, 0)
 
-				So("stress-ng-cache-l1", ShouldBeIn, swanAggressorsNames)
-				So("None", ShouldNotBeIn, swanAggressorsNames)
+				So(stressng.IDCacheL1, ShouldBeIn, swanAggressorsNames)
+				So(sensitivity.NoneAggressorID, ShouldNotBeIn, swanAggressorsNames)
 
 				So("0", ShouldBeIn, swanRepetitions)
 				So("1", ShouldBeIn, swanRepetitions)
@@ -234,7 +236,7 @@ func TestExperiment(t *testing.T) {
 				So(swanPhases, ShouldHaveLength, 18)
 
 				So("stress-ng-cache-l1", ShouldBeIn, swanAggressorsNames)
-				So("None", ShouldNotBeIn, swanAggressorsNames)
+				So(sensitivity.NoneAggressorID, ShouldNotBeIn, swanAggressorsNames)
 
 				So("Aggressor stress-ng-cache-l1; load point 0;", ShouldBeIn, swanPhases)
 
@@ -258,7 +260,7 @@ func TestExperiment(t *testing.T) {
 				tags, _, swanAggressorsNames, _, metricsCount := loadDataFromCassandra(session, experimentID)
 				So(metricsCount, ShouldBeGreaterThan, 0)
 				So(tags["swan_aggressor_name"], ShouldEqual, "stress-ng-cache-l1")
-				So("None", ShouldNotBeIn, swanAggressorsNames)
+				So(sensitivity.NoneAggressorID, ShouldNotBeIn, swanAggressorsNames)
 			})
 		})
 
@@ -271,7 +273,7 @@ func TestExperiment(t *testing.T) {
 				tags, _, swanAggressorsNames, _, metricsCount := loadDataFromCassandra(session, experimentID)
 				So(metricsCount, ShouldBeGreaterThan, 0)
 				So(tags["swan_aggressor_name"], ShouldEqual, "stress-ng-stream")
-				So("None", ShouldNotBeIn, swanAggressorsNames)
+				So(sensitivity.NoneAggressorID, ShouldNotBeIn, swanAggressorsNames)
 			})
 		})
 

--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -44,7 +44,7 @@ var (
 	HPKubernetesMemoryResourceFlag = conf.NewIntFlag("kubernetes_hp_memory_resource", "Sets memory limit and request for HP workloads on Kubernetes in bytes (default 4GB).", 4000000000)
 
 	// HPKubernetesGuaranteedClassFlag indicates tha HP workload will run as guarateed class.
-	HPKubernetesGuaranteedClassFlag = conf.NewBoolFlag("kubernetes_hp_guaranteed_class", "Sets resources limit equal requests effectivlly running this PoD as \"Guranteed class\" (by default runs as \"Burstable\" ", false)
+	HPKubernetesGuaranteedClassFlag = conf.NewBoolFlag("kubernetes_hp_guaranteed_class", "Run HP workload on Kubernetes as Pod with \"QoS Guranteed resources class\" (by default runs as \"Burstable class\").", false)
 
 	kubernetesNodeName = conf.NewStringFlag("kubernetes_target_node_name", fmt.Sprintf("Experiment's Kubernetes pods will be run on this node. Helpful when used with %q flag. Default is `$HOSTNAME`", RunOnExistingKubernetesFlag.Name), hostname)
 )

--- a/pkg/experiment/sensitivity/executors.go
+++ b/pkg/experiment/sensitivity/executors.go
@@ -43,6 +43,9 @@ var (
 	// HPKubernetesMemoryResourceFlag indicates amount of memory that HP task can use.
 	HPKubernetesMemoryResourceFlag = conf.NewIntFlag("kubernetes_hp_memory_resource", "Sets memory limit and request for HP workloads on Kubernetes in bytes (default 4GB).", 4000000000)
 
+	// HPKubernetesGuaranteedClassFlag indicates tha HP workload will run as guarateed class.
+	HPKubernetesGuaranteedClassFlag = conf.NewBoolFlag("kubernetes_hp_guaranteed_class", "Sets resources limit equal requests effectivlly running this PoD as \"Guranteed class\" (by default runs as \"Burstable\" ", false)
+
 	kubernetesNodeName = conf.NewStringFlag("kubernetes_target_node_name", fmt.Sprintf("Experiment's Kubernetes pods will be run on this node. Helpful when used with %q flag. Default is `$HOSTNAME`", RunOnExistingKubernetesFlag.Name), hostname)
 )
 
@@ -99,10 +102,15 @@ func CreateKubernetesHpExecutor(hpIsolation isolation.Decorator) (executor.Execu
 	k8sExecutorConfig.Decorators = isolation.Decorators{hpIsolation}
 	k8sExecutorConfig.HostNetwork = true
 	k8sExecutorConfig.Address = k8sConfig.GetKubeAPIAddress()
-	k8sExecutorConfig.CPULimit = int64(HPKubernetesCPUResourceFlag.Value())
-	k8sExecutorConfig.MemoryLimit = int64(HPKubernetesMemoryResourceFlag.Value())
-	k8sExecutorConfig.CPURequest = k8sExecutorConfig.CPULimit
-	k8sExecutorConfig.MemoryRequest = k8sExecutorConfig.MemoryLimit
+	k8sExecutorConfig.CPURequest = int64(HPKubernetesCPUResourceFlag.Value())
+	k8sExecutorConfig.MemoryRequest = int64(HPKubernetesMemoryResourceFlag.Value())
+
+	// if limits is equal to requests
+	if HPKubernetesGuaranteedClassFlag.Value() {
+		k8sExecutorConfig.CPULimit = int64(HPKubernetesCPUResourceFlag.Value())
+		k8sExecutorConfig.MemoryLimit = int64(HPKubernetesMemoryResourceFlag.Value())
+	}
+
 	k8sExecutorConfig.Privileged = true
 
 	return executor.NewKubernetes(k8sExecutorConfig)

--- a/pkg/experiment/sensitivity/factory.go
+++ b/pkg/experiment/sensitivity/factory.go
@@ -47,7 +47,7 @@ var (
 		"experiment_be_workloads", "Best Effort workloads that will be run sequentially in colocation with High Priority workload. \n"+
 			"# When experiment is run on machine with HyperThreads, user can also add 'stress-ng-cache-l1' to this list. \n"+
 			"# When iBench and Stream is available, user can also add 'l1d,l1i,l3,stream' to this list.",
-		[]string{NoneAggressorID, "stress-ng-cache-l3", "stress-ng-memcpy", "stress-ng-stream", "caffe"},
+		[]string{NoneAggressorID, stressng.IDCacheL3, stressng.IDMemCpy, stressng.IDStream, caffe.ID},
 	)
 
 	theatAggressorsAsService = conf.NewBoolFlag(

--- a/pkg/workloads/caffe/caffe.go
+++ b/pkg/workloads/caffe/caffe.go
@@ -26,6 +26,7 @@ const (
 	// ID is used for specifying which aggressors should be used via parameters.
 	ID = "caffe"
 
+	defaultName         = "Caffe"
 	defaultCaffeWrapper = "caffe.sh"
 	defaultModel        = "examples/cifar10/cifar10_quick_train_test.prototxt" // relative to caffe binary
 	defaultWeights      = "examples/cifar10/cifar10_quick_iter_5000.caffemodel.h5"
@@ -40,6 +41,7 @@ var (
 
 // Config is a config for the Caffe.
 type Config struct {
+	Name             string
 	BinaryPath       string
 	LibPath          string
 	ModelPath        string
@@ -51,6 +53,7 @@ type Config struct {
 // DefaultConfig is a constructor for caffe.Config with default parameters.
 func DefaultConfig() Config {
 	return Config{
+		Name:             defaultName,
 		BinaryPath:       defaultCaffeWrapper,
 		ModelPath:        caffeModel.Value(),
 		WeightsPath:      caffeWeights.Value(),
@@ -96,5 +99,5 @@ func (c Caffe) Launch() (task executor.TaskHandle, err error) {
 
 // Name returns human readable name for job.
 func (c Caffe) Name() string {
-	return "Caffe"
+	return c.conf.Name
 }


### PR DESCRIPTION
Fixes issue "cannot properly baseline memcached-cat experiment"

Summary of changes:
- includes follow up fixes for #695 (using ID instead of hardcode strings and other refactoring)
- two new flags:
  - `-cacheParitioningFlag` default to false, to partition cache between HP an BE workloads
  - `-kubernetes_hp_guaranteed_class` default to false, to run as HP as Burstable (degraded performance because os linux BWC cfs quota/period capping)

Testing done:
- yes manually, without integration tests
