### PR TITLE
Do not use distributed mutilate when run on single hosts

### DIFF
--- a/experiments/memcached-sensitivity-profile/common/common.go
+++ b/experiments/memcached-sensitivity-profile/common/common.go
@@ -36,7 +36,7 @@ var (
 	mutilateAgentsFlag = conf.NewStringSliceFlag(
 		"experiment_mutilate_agent_addresses",
 		"Addresses where Mutilate Agents will be launched, separated by commas (e.g: \"192.168.1.1,192.168.1.2\" Agents generate actual load on Memcached.",
-		[]string{"127.0.0.1"},
+		[]string{},
 	)
 )
 


### PR DESCRIPTION
By default run in non-distributed mode (easier to debug and much less overhead over measurements)

Fixes issue "in single node environment we have much complicated setup that necessary)

Summary of changes:
- just drop localhost mutilate agents address


Testing done:
- yes
