### PR TITLE
Added logs when watcher goroutine exits.  K8s pod timeout escalated to error.

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -565,12 +565,11 @@ func (kw *k8sWatcher) watch(timeout time.Duration) error {
 			case event, ok := <-watcher.ResultChan():
 				if !ok {
 					// In some cases sender may close watcher channel. Usually it is safe to recreate it.
-					log.Warnf("Pod %s: watcher event channel was unexpectly closed!", kw.pod.Name)
+					log.Debugf("Pod %s: watcher event channel was unexpectedly closed. Recreating.", kw.pod.Name)
 					var err error
-					log.Debugf("Pod %s: recreating watcher stream", kw.pod.Name)
 					watcher, err = kw.podsAPI.Watch(metav1.ListOptions{LabelSelector: selectorRaw})
 					if err != nil {
-						// We do not know what to do when error occurs.
+						// We cannot recover from here.
 						log.Panicf("Pod %s: cannot recreate watcher stream - %q", kw.pod.Name, err)
 					}
 					continue
@@ -633,7 +632,7 @@ func (kw *k8sWatcher) watch(timeout time.Duration) error {
 				if kw.hasBeenRunning {
 					continue
 				}
-				log.Warnf("K8s task watcher: timeout occured afrer %f seconds. Pod %s has not been created.", timeout.Seconds(), kw.pod.Name)
+				log.Errorf("Kubernetes Executor: pod %s has not been created: timeout after %f seconds.", kw.pod.Name, timeout.Seconds())
 				kw.deletePod()
 			}
 		}

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -121,6 +121,9 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 		if err != nil {
 			log.Errorf("Cannot syncAndClose stderrFile file: %s", err.Error())
 		}
+
+		exitCode := taskHandle.cmdHandler.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+		log.Debugf("Remote Executor: task %q exited with code %d", command, exitCode)
 	}()
 
 	// Best effort potential way to check if binary is started properly.

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -222,6 +222,8 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 		if err != nil {
 			log.Errorf("Cannot syncAndClose stderrFile file: %s", err.Error())
 		}
+
+		log.Debugf("Remote Executor: task %q exited with code %d", command, exitCode)
 	}()
 
 	// Best effort potential way to check if binary is started properly.


### PR DESCRIPTION
Added logs when watcher goroutine exits.  K8s pod timeout escalated to error.