### PR TITLE
Using fmt.Stringer instead of Name() method

### DIFF
--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -224,7 +224,7 @@ func main() {
 					// Generate name of the phase (taking zero-value LauncherSessionPair aka baseline into consideration).
 					aggressorName := fmt.Sprintf("Baseline")
 					if beLauncher.Launcher != nil {
-						aggressorName = beLauncher.Launcher.Name()
+						aggressorName = beLauncher.Launcher.String()
 					}
 
 					phaseName := fmt.Sprintf("Aggressor %s (at %d QPS) - BE LLC %b", aggressorName, qps, beCacheMask)
@@ -268,7 +268,7 @@ func main() {
 						if beLauncher.Launcher != nil {
 							beHandle, err = beLauncher.Launcher.Launch()
 							if err != nil {
-								return errors.Wrapf(err, "cannot launch aggressor %s in %s", beLauncher.Launcher.Name(), phaseName)
+								return errors.Wrapf(err, "cannot launch aggressor %s in %s", beLauncher.Launcher.String(), phaseName)
 							}
 							processes = append(processes, beHandle)
 						}

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -131,7 +131,7 @@ func main() {
 			// Generate name of the phase (taking zero-value LauncherSessionPair aka baseline into consideration).
 			aggressorName := sensitivity.NoneAggressorID
 			if beLauncher.Launcher != nil {
-				aggressorName = beLauncher.Launcher.Name()
+				aggressorName = beLauncher.Launcher.String()
 			}
 			phaseName := fmt.Sprintf("Aggressor %s; load point %d;", aggressorName, loadPoint)
 			for repetition := 0; repetition < repetitions; repetition++ {
@@ -170,7 +170,7 @@ func main() {
 					if beLauncher.Launcher != nil {
 						beHandle, err := beLauncher.Launcher.Launch()
 						if err != nil {
-							return errors.Wrapf(err, "cannot launch aggressor %q, in %s repetition %d", beLauncher.Launcher.Name(), phaseName, repetition)
+							return errors.Wrapf(err, "cannot launch aggressor %q, in %s repetition %d", beLauncher.Launcher.String(), phaseName, repetition)
 						}
 						processes = append(processes, beHandle)
 

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -140,7 +140,7 @@ func main() {
 			// Generate name of the phase (taking zero-value LauncherSessionPair aka baseline into consideration).
 			aggressorName := "Baselining"
 			if beLauncher.Launcher != nil {
-				aggressorName = beLauncher.Launcher.Name()
+				aggressorName = beLauncher.Launcher.String()
 			}
 			phaseName := fmt.Sprintf("Aggressor %s; load point %d;", aggressorName, loadPoint)
 			// Repeat measurement to check if it is consistent
@@ -176,7 +176,7 @@ func main() {
 					if beLauncher.Launcher != nil {
 						beHandle, err = beLauncher.Launcher.Launch()
 						if err != nil {
-							return errors.Wrapf(err, "cannot launch aggressor %q, in %s repetition %d", beLauncher.Launcher.Name(), phaseName, repetition)
+							return errors.Wrapf(err, "cannot launch aggressor %q, in %s repetition %d", beLauncher.Launcher.String(), phaseName, repetition)
 						}
 						processes = append(processes, beHandle)
 

--- a/integration_tests/pkg/executor/executor_test.go
+++ b/integration_tests/pkg/executor/executor_test.go
@@ -96,7 +96,7 @@ func testExecutor(t *testing.T, executor Executor) {
 		defer StopAndEraseOutput(taskHandle)
 
 		Convey("Name should return string with executed command", func() {
-			taskName := taskHandle.Name()
+			taskName := taskHandle.String()
 			So(taskName, ShouldContainSubstring, command)
 		})
 

--- a/pkg/executor/cluster_task_handle.go
+++ b/pkg/executor/cluster_task_handle.go
@@ -133,9 +133,9 @@ func (m *ClusterTaskHandle) EraseOutput() (err error) {
 	return errCollection.GetErrIfAny()
 }
 
-// Name returns name of underlying task.
-func (m *ClusterTaskHandle) Name() string {
-	return fmt.Sprintf("Cluster TaskHandle containg master: %s", m.master.Name())
+// String returns name of underlying task.
+func (m *ClusterTaskHandle) String() string {
+	return fmt.Sprintf("Cluster TaskHandle containg master: %s", m.master.String())
 }
 
 // Address returns address of master task.

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -14,14 +14,15 @@
 
 package executor
 
+import "fmt"
+
 // Executor is responsible for creating execution environment for given workload.
 // It returns Task handle when workload started gracefully.
 // Workload is executed asynchronously.
 type Executor interface {
+	fmt.Stringer
 	// Execute executes command on underlying platform.
 	// Invokes "bash -c <command>" and waits for short time to make sure that process has started.
 	// Returns error if command exited immediately with non-zero exit status.
 	Execute(command string) (TaskHandle, error)
-	// Name returns user-friendly name of executor.
-	Name() string
 }

--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -209,8 +209,8 @@ func (k8s *k8s) containerResources() v1.ResourceRequirements {
 	}
 }
 
-// Name returns user-friendly name of executor.
-func (k8s *k8s) Name() string {
+// String returns user-friendly name of executor.
+func (k8s *k8s) String() string {
 	return "Kubernetes Executor"
 }
 
@@ -376,7 +376,7 @@ func (k8s *k8s) Execute(command string) (TaskHandle, error) {
 	}
 	// It has been determined that task failed, waiting for Kubernetes to officially acknowledge it.
 	taskHandle.Wait(0)
-	err = checkIfProcessFailedToExecute(command, k8s.Name(), taskHandle)
+	err = checkIfProcessFailedToExecute(command, k8s.String(), taskHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +497,7 @@ func (th *k8sTaskHandle) EraseOutput() error {
 	return removeDirectory(outputDir)
 }
 
-func (th *k8sTaskHandle) Name() string {
+func (th *k8sTaskHandle) String() string {
 	return fmt.Sprintf("Kubernetes pod named %q with command %q on %q", th.podName, th.command, th.Address())
 }
 

--- a/pkg/executor/launcher.go
+++ b/pkg/executor/launcher.go
@@ -14,13 +14,13 @@
 
 package executor
 
+import "fmt"
+
 // Launcher responsibility is to launch previously configured job.
 type Launcher interface {
+	fmt.Stringer
 	// Launch starts the workload (process or group of processes). It returns a workload
 	// represented as a Task Handle instance.
 	// Error is returned when Launcher is unable to start a job.
 	Launch() (TaskHandle, error)
-
-	// Name returns human readable name for job.
-	Name() string
 }

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -44,8 +44,8 @@ func NewLocalIsolated(decorator isolation.Decorator) Local {
 	return Local{commandDecorators: decorator}
 }
 
-// Name returns user-friendly name of executor.
-func (l Local) Name() string {
+// String returns user-friendly name of executor.
+func (l Local) String() string {
 	return "Local Executor"
 }
 
@@ -125,7 +125,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 
 	// Best effort potential way to check if binary is started properly.
 	taskHandle.Wait(100 * time.Millisecond)
-	err = checkIfProcessFailedToExecute(command, l.Name(), &taskHandle)
+	err = checkIfProcessFailedToExecute(command, l.String(), &taskHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (taskHandle *localTaskHandle) Wait(timeout time.Duration) (bool, error) {
 	}
 }
 
-func (taskHandle *localTaskHandle) Name() string {
+func (taskHandle *localTaskHandle) String() string {
 	return fmt.Sprintf("Local %q", taskHandle.command)
 }
 

--- a/pkg/executor/mocks/executor.go
+++ b/pkg/executor/mocks/executor.go
@@ -45,8 +45,8 @@ func (_m *Executor) Execute(command string) (executor.TaskHandle, error) {
 	return r0, r1
 }
 
-// Name provides a mock function with given fields:
-func (_m *Executor) Name() string {
+// String provides a mock function with given fields:
+func (_m *Executor) String() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/pkg/executor/mocks/task_handle.go
+++ b/pkg/executor/mocks/task_handle.go
@@ -27,8 +27,8 @@ type TaskHandle struct {
 	mock.Mock
 }
 
-// Name provides a mock function with given fields:
-func (_m *TaskHandle) Name() string {
+// String provides a mock function with given fields:
+func (_m *TaskHandle) String() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/pkg/executor/mocks/task_info.go
+++ b/pkg/executor/mocks/task_info.go
@@ -26,8 +26,8 @@ type TaskInfo struct {
 	mock.Mock
 }
 
-// Name provides a mock function with given fields:
-func (_m *TaskInfo) Name() string {
+// String provides a mock function with given fields:
+func (_m *TaskInfo) String() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -117,8 +117,8 @@ func getAuthMethod(keyPath string) (ssh.AuthMethod, error) {
 	return ssh.PublicKeys(key), nil
 }
 
-// Name returns User-friendly name of executor.
-func (remote Remote) Name() string {
+// String returns User-friendly name of executor.
+func (remote Remote) String() string {
 	return fmt.Sprintf("Remote executor pointing at %s@%s", remote.config.User, remote.targetHost)
 }
 
@@ -226,7 +226,7 @@ func (remote Remote) Execute(command string) (TaskHandle, error) {
 
 	// Best effort potential way to check if binary is started properly.
 	taskHandle.Wait(100 * time.Millisecond)
-	err = checkIfProcessFailedToExecute(command, remote.Name(), &taskHandle)
+	err = checkIfProcessFailedToExecute(command, remote.String(), &taskHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +337,7 @@ func (taskHandle *remoteTaskHandle) Wait(timeout time.Duration) (bool, error) {
 	}
 }
 
-func (taskHandle *remoteTaskHandle) Name() string {
+func (taskHandle *remoteTaskHandle) String() string {
 	return fmt.Sprintf("Remote command %q running on %s@%s", taskHandle.command, taskHandle.connection.User(), taskHandle.Address())
 }
 

--- a/pkg/executor/service.go
+++ b/pkg/executor/service.go
@@ -93,7 +93,7 @@ func (s *serviceHandle) checkErrorCondition() error {
 	if !s.taskHasBeenTerminatedByUser {
 		s.taskHasBeenTerminatedByUser = true
 		if s.TaskHandle.Status() == TERMINATED {
-			s.err = errors.Errorf("ServiceHandle with command %q has terminated prematurely", s.TaskHandle.Name())
+			s.err = errors.Errorf("ServiceHandle with command %q has terminated prematurely", s.TaskHandle.String())
 			logrus.Errorf(s.err.Error())
 			logOutput(s.TaskHandle)
 			return s.err

--- a/pkg/executor/service_test.go
+++ b/pkg/executor/service_test.go
@@ -53,7 +53,7 @@ func (th stoppedTaskHandle) StdoutFile() (*os.File, error) {
 	return th.output, nil
 }
 
-func (th stoppedTaskHandle) Name() string {
+func (th stoppedTaskHandle) String() string {
 	return "command"
 }
 
@@ -76,7 +76,7 @@ func (th runningTaskHandle) Wait(duration time.Duration) (bool, error) {
 	return true, nil
 }
 
-func (th runningTaskHandle) Name() string {
+func (th runningTaskHandle) String() string {
 	return "command"
 }
 
@@ -94,7 +94,7 @@ func (th erroneousTaskHandle) Status() TaskState {
 	return RUNNING
 }
 
-func (th erroneousTaskHandle) Name() string {
+func (th erroneousTaskHandle) String() string {
 	return "command"
 }
 
@@ -111,12 +111,12 @@ func TestServiceTaskHandle(t *testing.T) {
 
 		err = s.Stop()
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, s.Name())
+		So(err.Error(), ShouldContainSubstring, s.String())
 
 		Convey("Another Stop() should return the same error", func() {
 			err = s.Stop()
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldContainSubstring, s.Name())
+			So(err.Error(), ShouldContainSubstring, s.String())
 		})
 	})
 
@@ -132,11 +132,11 @@ func TestServiceTaskHandle(t *testing.T) {
 		terminated, err := s.Wait(0)
 		So(terminated, ShouldBeTrue)
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, s.Name())
+		So(err.Error(), ShouldContainSubstring, s.String())
 
 		err = s.Stop()
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, s.Name())
+		So(err.Error(), ShouldContainSubstring, s.String())
 	})
 
 	Convey("Calling Stop() on running task should succeed", t, func() {
@@ -182,8 +182,8 @@ func (sl successfulLauncher) Launch() (TaskHandle, error) {
 	return runningTaskHandle{}, nil
 }
 
-// Name implements Launcher interface.
-func (sl successfulLauncher) Name() string {
+// String implements Launcher interface.
+func (sl successfulLauncher) String() string {
 	return "Underlying name"
 }
 
@@ -216,7 +216,7 @@ func TestServiceLauncher(t *testing.T) {
 	Convey("Launcher name should contain of embedded Launcher name so that it is transparent", t, func() {
 		l := ServiceLauncher{successfulLauncher{}}
 
-		name := l.Name()
+		name := l.String()
 		So(name, ShouldEqual, "Underlying name")
 	})
 }

--- a/pkg/executor/task_handle.go
+++ b/pkg/executor/task_handle.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -39,8 +40,7 @@ type TaskHandle interface {
 
 // TaskInfo represents task's address, status and output information.
 type TaskInfo interface {
-	// Name returns information about command and executor that lives under this TaskHandle.
-	Name() string
+	fmt.Stringer
 	// Location returns address where task was located.
 	Address() string
 	// ExitCode returns an exit code of finished task.

--- a/pkg/experiment/sensitivity/validate/validate.go
+++ b/pkg/experiment/sensitivity/validate/validate.go
@@ -75,7 +75,7 @@ func CheckCPUPowerGovernor() {
 // The name NOFILE is based on "limits.conf" and definition from setrlimit.
 func checkNOFILE(executor executor.Executor, nofile, minimum int) {
 	if nofile <= minimum {
-		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d) on (%s). You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.", nofile, minimum, executor.Name())
+		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d) on (%s). You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.", nofile, minimum, executor.String())
 	}
 
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -162,8 +162,8 @@ func New(master executor.Executor, minion executor.Executor, config Config) exec
 	}
 }
 
-// Name returns human readable name for job.
-func (m *k8s) Name() string {
+// String returns human readable name for job.
+func (m *k8s) String() string {
 	return "Kubernetes [single-kubelet]"
 }
 
@@ -287,7 +287,7 @@ func (m *k8s) launchCluster() (executor.TaskHandle, error) {
 func (m *k8s) launchService(command kubeCommand) (executor.TaskHandle, error) {
 	handle, err := command.exec.Execute(command.raw)
 	if err != nil {
-		return nil, errors.Wrapf(err, "execution of command %q on %q failed", command.raw, command.exec.Name())
+		return nil, errors.Wrapf(err, "execution of command %q on %q failed", command.raw, command.exec.String())
 	}
 
 	address := fmt.Sprintf("%s:%d", handle.Address(), command.healthCheckPort)
@@ -297,7 +297,7 @@ func (m *k8s) launchService(command kubeCommand) (executor.TaskHandle, error) {
 
 		return nil, errors.Errorf(
 			"failed to connect to service %q on %q: timeout on connection to %q; task status is %v and exit code is %d",
-			command.raw, command.exec.Name(), address, handle.Status(), ec)
+			command.raw, command.exec.String(), address, handle.Status(), ec)
 	}
 
 	return handle, nil

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -60,9 +60,9 @@ func TestKubernetesLauncher(t *testing.T) {
 
 		// Prepare Executor Mocks
 		master := new(mocks.Executor)
-		master.On("Name").Return("Master Executor")
+		master.On("String").Return("Master Executor")
 		minion := new(mocks.Executor)
-		minion.On("Name").Return("Minion Executor")
+		minion.On("String").Return("Minion Executor")
 
 		config := DefaultConfig()
 		handle := getMockedTaskHandle(outputFile)
@@ -87,11 +87,11 @@ func TestKubernetesLauncher(t *testing.T) {
 
 				So(kubeAPICommand.raw, ShouldContainSubstring, "--allow-privileged=true")
 				So(kubeAPICommand.healthCheckPort, ShouldEqual, 8080)
-				So(kubeAPICommand.exec.Name(), ShouldEqual, "Master Executor")
+				So(kubeAPICommand.exec.String(), ShouldEqual, "Master Executor")
 
 				So(kubeletCommand.raw, ShouldContainSubstring, "--allow-privileged=true")
 				So(kubeletCommand.healthCheckPort, ShouldEqual, 1234)
-				So(kubeAPICommand.exec.Name(), ShouldEqual, "Master Executor")
+				So(kubeAPICommand.exec.String(), ShouldEqual, "Master Executor")
 
 				Convey("But they can be disallowed through configuration", func() {
 					k8sLauncher.config.AllowPrivileged = false
@@ -106,13 +106,13 @@ func TestKubernetesLauncher(t *testing.T) {
 			Convey("Default etcd server address points to http://127.0.0.1:2379", func() {
 				kubeAPICommand := k8sLauncher.getKubeAPIServerCommand()
 				So(kubeAPICommand.raw, ShouldContainSubstring, "--etcd-servers=http://127.0.0.1:2379")
-				So(kubeAPICommand.exec.Name(), ShouldEqual, "Master Executor")
+				So(kubeAPICommand.exec.String(), ShouldEqual, "Master Executor")
 
 				Convey("But etcd server location can be changed to arbitrary one", func() {
 					k8sLauncher.config.EtcdServers = "http://1.1.1.1:1111,https://2.2.2.2:2222"
 					kubeAPICommand := k8sLauncher.getKubeAPIServerCommand()
 					So(kubeAPICommand.raw, ShouldContainSubstring, "--etcd-servers="+k8sLauncher.config.EtcdServers)
-					So(kubeAPICommand.exec.Name(), ShouldEqual, "Master Executor")
+					So(kubeAPICommand.exec.String(), ShouldEqual, "Master Executor")
 				})
 			})
 			Convey("Any parameters passed to KubeAPI Server are escaped correctly", func() {

--- a/pkg/workloads/caffe/caffe.go
+++ b/pkg/workloads/caffe/caffe.go
@@ -97,7 +97,7 @@ func (c Caffe) Launch() (task executor.TaskHandle, err error) {
 	return
 }
 
-// Name returns human readable name for job.
-func (c Caffe) Name() string {
+// String returns human readable name for job.
+func (c Caffe) String() string {
 	return c.conf.Name
 }

--- a/pkg/workloads/low_level/l1data/l1data.go
+++ b/pkg/workloads/low_level/l1data/l1data.go
@@ -78,7 +78,7 @@ func (l l1d) Launch() (executor.TaskHandle, error) {
 	return l.exec.Execute(l.buildCommand())
 }
 
-// Name returns human readable name for job.
-func (l l1d) Name() string {
+// String returns human readable name for job.
+func (l l1d) String() string {
 	return name
 }

--- a/pkg/workloads/low_level/l1instruction/l1instruction.go
+++ b/pkg/workloads/low_level/l1instruction/l1instruction.go
@@ -96,7 +96,7 @@ func (l l1i) Launch() (executor.TaskHandle, error) {
 	return l.exec.Execute(l.buildCommand())
 }
 
-// Name returns human readable name for job.
-func (l l1i) Name() string {
+// String returns human readable name for job.
+func (l l1i) String() string {
 	return name
 }

--- a/pkg/workloads/low_level/l3/l3.go
+++ b/pkg/workloads/low_level/l3/l3.go
@@ -79,7 +79,7 @@ func (l l3) Launch() (executor.TaskHandle, error) {
 	return l.exec.Execute(l.buildCommand())
 }
 
-// Name returns human readable name for job.
-func (l l3) Name() string {
+// String returns human readable name for job.
+func (l l3) String() string {
 	return name
 }

--- a/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
+++ b/pkg/workloads/low_level/memoryBandwidth/memoryBandwidth.go
@@ -79,7 +79,7 @@ func (m memBw) Launch() (executor.TaskHandle, error) {
 	return m.exec.Execute(m.buildCommand())
 }
 
-// Name returns human readable name for job.
-func (m memBw) Name() string {
+// String returns human readable name for job.
+func (m memBw) String() string {
 	return name
 }

--- a/pkg/workloads/low_level/stream/stream.go
+++ b/pkg/workloads/low_level/stream/stream.go
@@ -74,7 +74,7 @@ func (l stream) Launch() (executor.TaskHandle, error) {
 	return l.exec.Execute(l.buildCommand())
 }
 
-// Name returns human readable name for job.
-func (l stream) Name() string {
+// String returns human readable name for job.
+func (l stream) String() string {
 	return name
 }

--- a/pkg/workloads/low_level/stressng/stressng.go
+++ b/pkg/workloads/low_level/stressng/stressng.go
@@ -95,7 +95,7 @@ func (s stressng) Launch() (executor.TaskHandle, error) {
 	return s.executor.Execute(fmt.Sprintf("stress-ng %s", s.arguments))
 }
 
-// Name returns readable name.
-func (s stressng) Name() string {
+// String returns readable name.
+func (s stressng) String() string {
 	return s.name
 }

--- a/pkg/workloads/low_level/stressng/stressng_test.go
+++ b/pkg/workloads/low_level/stressng/stressng_test.go
@@ -65,7 +65,7 @@ func TestStressng(t *testing.T) {
 
 			Convey("for new stream based aggressor", func() {
 				launcher := NewStream(mockedExecutor)
-				So(launcher.Name(), ShouldEqual, "stress-ng-stream")
+				So(launcher.String(), ShouldEqual, "stress-ng-stream")
 				mockedExecutor.On("Execute", "stress-ng --stream=1").Return(mockedTask, nil).Once()
 				_, err := launcher.Launch()
 				So(err, ShouldBeNil)
@@ -75,7 +75,7 @@ func TestStressng(t *testing.T) {
 
 			Convey("for new l1 intensive aggressor", func() {
 				launcher := NewCacheL1(mockedExecutor)
-				So(launcher.Name(), ShouldEqual, "stress-ng-cache-l1")
+				So(launcher.String(), ShouldEqual, "stress-ng-cache-l1")
 				mockedExecutor.On("Execute", "stress-ng --cache=1 --cache-level=1").Return(mockedTask, nil).Once()
 				_, err := launcher.Launch()
 				So(err, ShouldBeNil)
@@ -85,7 +85,7 @@ func TestStressng(t *testing.T) {
 
 			Convey("for new l3 intensive aggressor", func() {
 				launcher := NewCacheL3(mockedExecutor)
-				So(launcher.Name(), ShouldEqual, "stress-ng-cache-l3")
+				So(launcher.String(), ShouldEqual, "stress-ng-cache-l3")
 				mockedExecutor.On("Execute", "stress-ng --cache=1 --cache-level=3").Return(mockedTask, nil).Once()
 				_, err := launcher.Launch()
 				So(err, ShouldBeNil)
@@ -95,7 +95,7 @@ func TestStressng(t *testing.T) {
 
 			Convey("for new memcpy aggressor", func() {
 				launcher := NewMemCpy(mockedExecutor)
-				So(launcher.Name(), ShouldEqual, "stress-ng-memcpy")
+				So(launcher.String(), ShouldEqual, "stress-ng-memcpy")
 				mockedExecutor.On("Execute", "stress-ng --memcpy=1").Return(mockedTask, nil).Once()
 				_, err := launcher.Launch()
 				So(err, ShouldBeNil)
@@ -105,7 +105,7 @@ func TestStressng(t *testing.T) {
 
 			Convey("for new custom aggressor", func() {
 				launcher := NewCustom(mockedExecutor)
-				So(launcher.Name(), ShouldEqual, "stress-ng-custom ")
+				So(launcher.String(), ShouldEqual, "stress-ng-custom ")
 				mockedExecutor.On("Execute", "stress-ng ").Return(mockedTask, nil).Once()
 				_, err := launcher.Launch()
 				So(err, ShouldBeNil)

--- a/pkg/workloads/memcached/memcached.go
+++ b/pkg/workloads/memcached/memcached.go
@@ -140,7 +140,7 @@ func (m Memcached) Launch() (executor.TaskHandle, error) {
 	return task, nil
 }
 
-// Name returns human readable name for job.
-func (m Memcached) Name() string {
+// String returns human readable name for job.
+func (m Memcached) String() string {
 	return name
 }

--- a/pkg/workloads/specjbb/backend.go
+++ b/pkg/workloads/specjbb/backend.go
@@ -79,7 +79,7 @@ func (b Backend) Launch() (executor.TaskHandle, error) {
 	return task, nil
 }
 
-// Name returns human readable name for job.
-func (b Backend) Name() string {
+// String returns human readable name for job.
+func (b Backend) String() string {
 	return name
 }


### PR DESCRIPTION
Fixes issue of using `Name()` method instead of `String()` to return string representation of an object.

Summary of changes:
- run `:GoRename String` couple of times.

Testing done:
- all existing tests should pass
