### PR TITLE
Do not sync output files for executors.

### DIFF
--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -52,7 +52,7 @@ func (l Local) String() string {
 // Execute runs the command given as input.
 // Returned Task is able to stop & monitor the provisioned process.
 func (l Local) Execute(command string) (TaskHandle, error) {
-	log.Debug("Starting '", l.commandDecorators.Decorate(command), "' locally ")
+	log.Debug("Local Executor: Starting '", l.commandDecorators.Decorate(command), "' locally ")
 
 	cmd := exec.Command("sh", "-c", l.commandDecorators.Decorate(command))
 
@@ -69,7 +69,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 		return nil, errors.Wrapf(err, "createExecutorOutputFiles for command %q failed", command)
 	}
 
-	log.Debug("Created temporary files ",
+	log.Debug("Local Executor: Created temporary files ",
 		"stdout path:  ", stdoutFile.Name(), ", stderr path:  ", stderrFile.Name())
 
 	cmd.Stdout = stdoutFile
@@ -81,7 +81,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 		return nil, errors.Wrapf(err, "command %q start failed", command)
 	}
 
-	log.Debug("Started with pid ", cmd.Process.Pid)
+	log.Debug("Local Executor: Started with pid ", cmd.Process.Pid)
 
 	// hasProcessExited channel is closed when launched process exits.
 	hasProcessExited := make(chan struct{})
@@ -123,7 +123,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 		}
 
 		exitCode := taskHandle.cmdHandler.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-		log.Debugf("Remote Executor: task %q exited with code %d", command, exitCode)
+		log.Debugf("Local Executor: task %q exited with code %d", command, exitCode)
 	}()
 
 	// Best effort potential way to check if binary is started properly.
@@ -132,6 +132,7 @@ func (l Local) Execute(command string) (TaskHandle, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("Local Executor: pid %d started succesfully", cmd.Process.Pid)
 	return &taskHandle, nil
 }
 

--- a/pkg/executor/output_files_utils.go
+++ b/pkg/executor/output_files_utils.go
@@ -72,13 +72,13 @@ func createOutputDirectory(command string, prefix string) (createdDirectoryPath 
 
 func createExecutorOutputFiles(outputDir string) (stdoutFile, stderrFile *os.File, err error) {
 	stdoutFileName := path.Join(outputDir, "stdout")
-	stdoutFile, err = os.OpenFile(stdoutFileName, os.O_WRONLY|os.O_SYNC|os.O_EXCL|os.O_CREATE, outputFilePrivileges)
+	stdoutFile, err = os.OpenFile(stdoutFileName, os.O_WRONLY|os.O_EXCL|os.O_CREATE, outputFilePrivileges)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "creating %q failed", stdoutFileName)
 	}
 
 	stderrFileName := path.Join(outputDir, "stderr")
-	stderrFile, err = os.OpenFile(stderrFileName, os.O_WRONLY|os.O_SYNC|os.O_EXCL|os.O_CREATE, outputFilePrivileges)
+	stderrFile, err = os.OpenFile(stderrFileName, os.O_WRONLY|os.O_EXCL|os.O_CREATE, outputFilePrivileges)
 	if err != nil {
 		// Clean created stdout.
 		stdoutFile.Close()


### PR DESCRIPTION
Fixes issue "11 seconds to start kubelet or 8 seeconds to start mutilate with local executor"

Can fix periodic integration tests instability.

Summary of changes:
- remove O_SYNC from stderr and stdout files  
- some debug and fixed name for local executor 


Testing done:
- yes
