### PR TITLE
Multiline flag desciption handling fixed

### DIFF
--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -113,7 +113,11 @@ func DumpConfigMap(flagMap map[string]string) string {
 
 	for _, fd := range getFlagsDefinition() {
 
-		fmt.Fprintf(buffer, "\n# %s\n", fd.Usage)
+		fmt.Fprintf(buffer, "\n")
+		for _, line := range strings.Split(fd.Usage, "\n") {
+			fmt.Fprintf(buffer, "# %s\n", line)
+		}
+
 		if fd.DefValue != "" {
 			fmt.Fprintf(buffer, "# Default: %s\n", fd.DefValue)
 		}

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -35,9 +35,9 @@ var (
 	currentUser, _ = user.Current()
 
 	sshUserFlag = conf.NewStringFlag("remote_ssh_user", "Login used for connecting to remote nodes.\n"+
-		"# Default value is current user.", currentUser.Name)
+		"Default value is current user.", currentUser.Name)
 	sshUserKeyPathFlag = conf.NewStringFlag("remote_ssh_key_path", fmt.Sprintf("Key for user in from flag %q used for connecting to remote nodes.\n"+
-		"# Default value is '$HOME/.ssh/id_rsa'", sshUserFlag.Name), path.Join(currentUser.HomeDir, ".ssh/id_rsa"))
+		"Default value is '$HOME/.ssh/id_rsa'", sshUserFlag.Name), path.Join(currentUser.HomeDir, ".ssh/id_rsa"))
 
 	sshPortFlag = conf.NewIntFlag("remote_ssh_port", "Port used for SSH connection to remote nodes. ", 22)
 )

--- a/pkg/experiment/sensitivity/factory.go
+++ b/pkg/experiment/sensitivity/factory.go
@@ -47,9 +47,9 @@ const (
 var (
 	// AggressorsFlag is a comma separated list of aggressors to be run during the experiment.
 	AggressorsFlag = conf.NewStringSliceFlag(
-		"experiment_be_workloads", "Best Effort workloads that will be run sequentially in colocation with High Priority workload. \n"+
-			"# When experiment is run on machine with HyperThreads, user can also add 'stress-ng-cache-l1' to this list. \n"+
-			"# When iBench and Stream is available, user can also add 'l1d,l1i,l3,stream' to this list.",
+		"experiment_be_workloads", "Best Effort workloads that will be run sequentially in colocation with High Priority workload.\n"+
+			"When experiment is run on machine with HyperThreads, user can also add 'stress-ng-cache-l1' to this list.\n"+
+			"When iBench and Stream is available, user can also add 'l1d,l1i,l3,stream' to this list.",
 		[]string{NoneAggressorID, stressng.IDCacheL3, stressng.IDMemCpy, stressng.IDStream, caffe.ID},
 	)
 


### PR DESCRIPTION
Multiline flag's description was handled incorrectly in the -config-dump flag.
Now multiline flags are printed corretly and starts with '#'.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

Testing done:
- manual
