### PR TITLE
Added 'misses' metrics to mutilate collector

### DIFF
--- a/plugins/snap-plugin-collector-mutilate/mutilate/mutilate.go
+++ b/plugins/snap-plugin-collector-mutilate/mutilate/mutilate.go
@@ -55,6 +55,7 @@ func (mutilate collector) GetMetricTypes(configType plugin.Config) ([]plugin.Met
 	metrics = append(metrics, plugin.Metric{Namespace: createNewMetricNamespace("percentile", "95th"), Unit: UNIT, Version: VERSION})
 	metrics = append(metrics, plugin.Metric{Namespace: createNewMetricNamespace("percentile", "99th"), Unit: UNIT, Version: VERSION})
 	metrics = append(metrics, plugin.Metric{Namespace: createNewMetricNamespace("qps"), Unit: UNIT, Version: VERSION})
+	metrics = append(metrics, plugin.Metric{Namespace: createNewMetricNamespace("misses"), Unit: UNIT, Version: VERSION})
 
 	return metrics, nil
 }

--- a/plugins/snap-plugin-collector-mutilate/mutilate/mutilate.stdout
+++ b/plugins/snap-plugin-collector-mutilate/mutilate/mutilate.stdout
@@ -5,7 +5,7 @@ op_q        1.0     0.0     1.0     1.0     1.0     1.1     1.1     1.1
 
 Total QPS = 4993.1 (149793 / 30.0s)
 
-Misses = 0 (0.0%)
+Misses = 5678 (0.0%)
 Skipped TXs = 0 (0.0%)
 
 RX   37058871 bytes :    1.2 MB/s

--- a/plugins/snap-plugin-collector-mutilate/mutilate/mutilate_test.go
+++ b/plugins/snap-plugin-collector-mutilate/mutilate/mutilate_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMutilatePlugin(t *testing.T) {
-	const expectedMetricsCount = 9
+	const expectedMetricsCount = 10
 
 	Convey("When I create mutilate collector object", t, func() {
 		now := time.Now()
@@ -43,6 +43,8 @@ func TestMutilatePlugin(t *testing.T) {
 			soValidMetricType(metricTypes[6], "/intel/swan/mutilate/*/percentile/95th", "ns")
 			soValidMetricType(metricTypes[7], "/intel/swan/mutilate/*/percentile/99th", "ns")
 			soValidMetricType(metricTypes[8], "/intel/swan/mutilate/*/qps", "ns")
+			soValidMetricType(metricTypes[9], "/intel/swan/mutilate/*/misses", "ns")
+
 		})
 
 		Convey("I should receive valid metrics when I try to collect them", func() {
@@ -74,6 +76,7 @@ func TestMutilatePlugin(t *testing.T) {
 				{"/percentile/95th", 43.1, now},
 				{"/percentile/99th", 59.5, now},
 				{"/qps", 4993.1, now},
+				{"/misses", 5678, now},
 			}
 
 			var namespace string

--- a/plugins/snap-plugin-collector-mutilate/mutilate/parse/mutilate.stdout
+++ b/plugins/snap-plugin-collector-mutilate/mutilate/parse/mutilate.stdout
@@ -5,7 +5,7 @@ op_q        1.0     0.0     1.0     1.0     1.0     1.1     1.1     1.1
 
 Total QPS = 4993.1 (149793 / 30.0s)
 
-Misses = 0 (0.0%)
+Misses = 1234 (0.0%)
 Skipped TXs = 0 (0.0%)
 
 RX   37058871 bytes :    1.2 MB/s

--- a/plugins/snap-plugin-collector-mutilate/mutilate/parse/mutilate_missing_read_row.stdout
+++ b/plugins/snap-plugin-collector-mutilate/mutilate/parse/mutilate_missing_read_row.stdout
@@ -4,7 +4,7 @@ op_q        1.0     0.0     1.0     1.0     1.0     1.1     1.1     1.1
 
 Total QPS = 4993.1 (149793 / 30.0s)
 
-Misses = 0 (0.0%)
+Misses = 9876 (0.0%)
 Skipped TXs = 0 (0.0%)
 
 RX   37058871 bytes :    1.2 MB/s


### PR DESCRIPTION
Added misses metrics to snap mutilate collector plugin.

Misses are in form:
Misses = 0 (0.0%)

and the first int is returned.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

Testing done:
- unit tests 
