### PR TITLE
Fixing condition on environment validation

### DIFF
--- a/pkg/experiment/sensitivity/validate/validate.go
+++ b/pkg/experiment/sensitivity/validate/validate.go
@@ -74,7 +74,7 @@ func CheckCPUPowerGovernor() {
 // opened by a process is more than minimum requested.
 // The name NOFILE is based on "limits.conf" and definition from setrlimit.
 func checkNOFILE(executor executor.Executor, nofile, minimum int) {
-	if nofile <= minimum {
+	if nofile < minimum {
 		logrus.Warnf("Maximum number of open file descriptors (%d) is lower than required (%d) on (%s). You can change this value eg. ulimit -n 10000 or modifying /etc/security/limits.conf.", nofile, minimum, executor.String())
 	}
 


### PR DESCRIPTION
Fixes issue of erroneous warning: `Maximum number of open file descriptors (10240) is lower than required (10240)`

Summary of changes:
- changed `<=` to `<`

Testing done:
- all existing tests should pass.
