### PR TITLE
Better kubernetes executor fail message

### DIFF
--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -658,7 +658,10 @@ func (kw *k8sWatcher) whenPodFinished(pod *v1.Pod) {
 	kw.oncePodFinished.Do(func() {
 		if pod.Status.Phase == v1.PodFailed {
 			close(kw.failed)
-			log.Debug("K8s task watcher: 'failed' channel closed")
+
+			if pod.Status.Message != "" {
+				log.Debugf("K8s task watcher: fail status message: %q", pod.Status.Message)
+			}
 		}
 		kw.whenPodReady()
 		kw.setExitCode(pod)


### PR DESCRIPTION
Fixes issue "cannot find reason why my pod failed"

Before:
```
DEBU[2017-06-05 16:36:48.600] K8s task watcher: event type=MODIFIED phase=Failed
DEBU[2017-06-05 16:36:48.600] K8s task watcher: 'failed' channel closed
ERRO[2017-06-05 16:36:48.600] K8s task watcher: pod "swan-hp-d70f0a21" failed with exit code -1

```

After:
```
DEBU[2017-06-05 16:42:41.600] K8s task watcher: event type=MODIFIED phase=Failed
DEBU[2017-06-05 16:42:41.600] K8s task watcher: fail status message: "Pod Node didn't have enough resource: cpu, requested: 16000, used: 0, capacity: 8000"
ERRO[2017-06-05 16:42:41.600] K8s task watcher: pod "swan-hp-b2aad31f" failed with exit code -1
```


Summary of changes:
- just log entry showing kubernetes reason of pod failing if available

Testing done:
- yes
