### PR TITLE
swan package is compatible with Python 3 and has pivotablejs installed

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -83,3 +83,12 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT 
 OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+This software contains portions of PivotTable.js from https://github.com/nicolaskruchten/pivottable.
+PivotTable.js is © 2012-2013 Nicolas Kruchten, Datacratic, other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -2,9 +2,11 @@ FROM jupyter/minimal-notebook
 
 RUN conda install -q -y nomkl cassandra-driver pandas pep8 pylint \
     && conda clean -y -a -v
+RUN pip install pivottablejs
 
 COPY test_data/ $HOME/work/test_data
 COPY example.ipynb *.py $HOME/work/
+COPY NOTICE $HOME/work/
 
 # Switch to root and fix permissions
 USER root

--- a/jupyter/NOTICE
+++ b/jupyter/NOTICE
@@ -1,0 +1,8 @@
+This software contains portions of PivotTable.js from https://github.com/nicolaskruchten/pivottable.
+PivotTable.js is © 2012-2013 Nicolas Kruchten, Datacratic, other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/jupyter/swan.py
+++ b/jupyter/swan.py
@@ -161,12 +161,12 @@ def load_dataframe_from_cassandra_streamed(experiment_id, tag_keys, cassandra_op
     started = datetime.datetime.now()
     print('building a dataframe...')
     df = pd.DataFrame()
-    for ns, d in records.iteritems():
+    for ns, d in records.items():
         tuples = []  # values used to build an index for given series.
         data = []  # data for Series
         # Use aggfunc provided by ns_aggfunctions or fallback to defaggfunc.
         aggfunc = aggfuncs.get(ns, default_aggfunc) if aggfuncs else default_aggfunc
-        for tags, values in sorted(d.iteritems()):
+        for tags, values in sorted(d.items()):
             tuples.append(tags)
             data.append(aggfunc(values))
         index = pd.MultiIndex.from_tuples(tuples, names=tag_keys)


### PR DESCRIPTION
Fixes issue broken `swan-jupyter` image.

Summary of changes:
- `%s/iteritems()/items()/g
- installed PivotTable.js

Testing done:
- all existing tests should pass
