### PR TITLE
jupyter table filters for aggressors and QPSs

### DIFF
--- a/jupyter/test_swan.py
+++ b/jupyter/test_swan.py
@@ -46,27 +46,31 @@ class TestExperiments(unittest.TestCase):
     def test_sensitivity_profile(self):
         profile = swan.SensitivityProfile('6ed71a63-14c0-8e3e-3a65-4da9a11eecf6', slo=500)
         self.assertRenders(profile.latency())
+        self.assertRenders(profile.latency(aggressors=['Baseline'], qpses=[500000]))
         self.assertRenders(profile.latency(normalized=False))
         self.assertRenders(profile.qps())
+        self.assertRenders(profile.qps(aggressors=['Baseline'], qpses=[500000]))
         self.assertRenders(profile.qps(normalized=False))
         self.assertRenders(profile.caffe_batches())
 
     def test_optimal_core_allocation(self):
         core = swan.OptimalCoreAllocation('80ad81ec-e6d7-cfc2-de6c-6c60cb300d7f', slo=500)
         self.assertRenders(core.latency())
+        self.assertRenders(core.latency(aggressors=['No aggressor memcached -t 9'], qpses=[150000]))
         self.assertRenders(core.latency(normalized=False))
         self.assertRenders(core.qps())
+        self.assertRenders(core.qps(aggressors=['No aggressor memcached -t 9'], qpses=[150000]))
         self.assertRenders(core.qps(normalized=False))
         self.assertRenders(core.cpu())
 
     def test_cat(self):
-        core = swan.CAT('bc1ee530-4e02-b9fd-e845-752eb7545773', slo=500)
-        self.assertRenders(core.latency())
-        self.assertRenders(core.latency(normalized=False))
-        self.assertRenders(core.latency(aggressor='Caffe', qps=500000))
+        cat = swan.CAT('bc1ee530-4e02-b9fd-e845-752eb7545773', slo=500)
+        self.assertRenders(cat.latency())
+        self.assertRenders(cat.latency(normalized=False))
+        self.assertRenders(cat.latency(aggressors=['Caffe'], qpses=[500000]))
 
-        core.filtered_df()
-        core.filtered_df_table()
+        cat.filtered_df()
+        cat.filtered_df_table()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes issue "cannot filter other sensitivity table and OptimalCoreAllocation" or by many aggressors at once

Summary of changes:
- caching mechanism can now have suffix (to use with other dataframes)
- aggressor replaced with aggressors (equal replaced with isin)
- added filters to other tables

Testing done:
- yes (unit tests)
