### PR TITLE
Chained TaskHandle

### DIFF
--- a/pkg/executor/chained_task_handle.go
+++ b/pkg/executor/chained_task_handle.go
@@ -98,7 +98,7 @@ func (cth *ChainedTaskHandle) Stop() error {
 
 // Wait waits for all tasks in ChainedTaskHandle to finish.
 func (cth *ChainedTaskHandle) Wait(timeout time.Duration) (bool, error) {
-	timeoutChannel := getWaitTimeoutChan(timeout)
+	timeoutChannel := getTimeoutChan(timeout)
 
 	select {
 	case <-timeoutChannel:

--- a/pkg/executor/chained_task_handle.go
+++ b/pkg/executor/chained_task_handle.go
@@ -21,13 +21,8 @@ type ChainedTaskHandle struct {
 
 // NewChainedTaskHandle returns TaskHandle that executes current handle, and will
 // launch Launcher when handle will finish it's execution.
-func NewChainedTaskHandle(handle TaskHandle, launcher ...Launcher) TaskHandle {
-	launchers := make([]Launcher, 0)
-	for _, l := range launcher {
-		launchers = append(launchers, l)
-	}
-
-	chained := ChainedTaskHandle{
+func NewChainedTaskHandle(handle TaskHandle, launchers ...Launcher) TaskHandle {
+	chained := &ChainedTaskHandle{
 		TaskHandle:       handle,
 		chainedLaunchers: launchers,
 		chainFinished:    make(chan struct{}),
@@ -36,7 +31,7 @@ func NewChainedTaskHandle(handle TaskHandle, launcher ...Launcher) TaskHandle {
 
 	go chained.watch()
 
-	return &chained
+	return chained
 }
 
 func (cth *ChainedTaskHandle) watch() {

--- a/pkg/executor/chained_task_handle.go
+++ b/pkg/executor/chained_task_handle.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+// ChainedTaskHandle is an links Launchers in a way that
+// one will be launched after another.
 type ChainedTaskHandle struct {
 	TaskHandle
 
@@ -17,6 +19,8 @@ type ChainedTaskHandle struct {
 	stopOnce      sync.Once
 }
 
+// NewChainedTaskHandle returns TaskHandle that executes current handle, and will
+// launch Launcher when handle will finish it's execution.
 func NewChainedTaskHandle(handle TaskHandle, launcher Launcher) TaskHandle {
 	chained := ChainedTaskHandle{
 		TaskHandle:      handle,
@@ -74,6 +78,7 @@ func (cth *ChainedTaskHandle) watcher() {
 	return
 }
 
+// Stop stops all execution of ChainedTaskHandle.
 func (cth *ChainedTaskHandle) Stop() error {
 	cth.stopOnce.Do(func() {
 		cth.stopChain <- struct{}{}
@@ -84,6 +89,7 @@ func (cth *ChainedTaskHandle) Stop() error {
 	return err
 }
 
+// Wait waits for all tasks in ChainedTaskHandle to finish.
 func (cth *ChainedTaskHandle) Wait(timeout time.Duration) (bool, error) {
 	timeoutChannel := getWaitTimeoutChan(timeout)
 
@@ -95,6 +101,7 @@ func (cth *ChainedTaskHandle) Wait(timeout time.Duration) (bool, error) {
 	}
 }
 
+// Status returns current TaskState.
 func (cth *ChainedTaskHandle) Status() TaskState {
 	select {
 	case <-cth.chainFinished:

--- a/pkg/executor/chained_task_handle.go
+++ b/pkg/executor/chained_task_handle.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"time"
+)
+
+type ChainedTaskHandle struct {
+	TaskHandle
+
+	chainedLauncher Launcher
+
+	encounteredError error
+
+	chainFinished chan struct{}
+	stopChain     chan struct{}
+}
+
+func NewChainedTaskHandle(handle TaskHandle, launcher Launcher) TaskHandle {
+	var result ChainedTaskHandle
+
+	result.TaskHandle = handle
+	result.chainedLauncher = launcher
+	result.chainFinished = make(chan struct{})
+	result.stopChain = make(chan struct{})
+
+	go result.watcher()
+
+	return result
+}
+
+func (cth *ChainedTaskHandle) watcher() {
+	// Wait for initial TaskHandle to finish.
+	waitChan := GetWaitChannel(cth.TaskHandle)
+	select {
+	case err := <-waitChan:
+		if err != nil {
+			cth.encounteredError = err
+			close(cth.chainFinished)
+			return
+		}
+	case <-cth.stopChain:
+		err := cth.TaskHandle.Stop()
+		cth.encounteredError = err
+		close(cth.chainFinished)
+		return
+	}
+
+	// Run all chained Launchers.
+	chainedHandle, err := cth.chainedLauncher.Launch()
+	if err != nil {
+		cth.encounteredError = err
+		close(cth.chainFinished)
+		return
+	}
+	waitChan = GetWaitChannel(chainedHandle)
+	select {
+	case err := <-waitChan:
+		cth.encounteredError = err
+		if err != nil {
+			cth.encounteredError = err
+			close(cth.chainFinished)
+			return
+		}
+	case <-cth.stopChain:
+		err := chainedHandle.Stop()
+		cth.encounteredError = err
+		close(cth.chainFinished)
+		return
+	}
+
+	close(cth.chainFinished)
+	return
+}
+
+func (cth *ChainedTaskHandle) Stop() error {
+	// Try to stop the chain.
+	select {
+	case cth.stopChain <- struct{}{}:
+	default:
+	}
+
+	// Wait for chain to stop.
+	_, err := cth.Wait(0)
+	return err
+}
+
+func (cth *ChainedTaskHandle) Wait(timeout time.Duration) (bool, error) {
+	select {
+	case <-time.After(timeout):
+		return false, nil
+	case <-cth.chainFinished:
+		return true, cth.encounteredError
+	}
+}

--- a/pkg/executor/chained_task_handle_test.go
+++ b/pkg/executor/chained_task_handle_test.go
@@ -18,6 +18,7 @@ func TestSuccsessfulChainedTaskHandle(t *testing.T) {
 		chainedLauncher := new(MockLauncher)
 
 		Convey("Successful run should yield no error", func() {
+			// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
 			initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, nil)
 			chainedTaskHandle.On("Wait", 0*time.Second).After(2*taskExecutionTime).Return(true, nil)
 			chainedLauncher.On("Launch").Return(chainedTaskHandle, nil)
@@ -60,6 +61,7 @@ func TestSuccsessfulChainedTaskHandle(t *testing.T) {
 		})
 
 		Convey("Immediate stop of ChainedTaskHandle should yield no error", func() {
+			// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
 			initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, nil)
 			initialTaskHandle.On("Stop").Return(nil)
 
@@ -88,6 +90,7 @@ func TestSuccsessfulChainedTaskHandle(t *testing.T) {
 		})
 
 		Convey("Stop during execution of chained task should yield no error", func() {
+			// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
 			initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, nil)
 			chainedTaskHandle.On("Wait", 0*time.Second).After(2*taskExecutionTime).Return(true, nil)
 			chainedTaskHandle.On("Stop").Return(nil)
@@ -122,11 +125,14 @@ func TestFailureChainedTaskHandle(t *testing.T) {
 		chainedLauncher := new(MockLauncher)
 
 		Convey("When initial TaskHandle is running and returns error", func() {
+			// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
 			initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, errors.New(fixedError))
 			initialTaskHandle.On("Stop").Return(errors.New(fixedError))
 
 			taskHandle := NewChainedTaskHandle(initialTaskHandle, chainedLauncher)
 			Convey("It should be returned on Wait()", func() {
+				// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
+				initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, errors.New(fixedError))
 				isTerminated, err := taskHandle.Wait(waitTimeout)
 				So(isTerminated, ShouldBeTrue)
 				So(err.Error(), ShouldContainSubstring, fixedError)
@@ -140,15 +146,10 @@ func TestFailureChainedTaskHandle(t *testing.T) {
 				})
 
 				Convey("Subsequent Stop() should return the same error", func() {
+					initialTaskHandle.On("Stop").Return(errors.New(fixedError))
 					err := taskHandle.Stop()
 					So(err.Error(), ShouldContainSubstring, fixedError)
 					So(taskHandle.Status(), ShouldEqual, TERMINATED)
-				})
-
-				Convey("Flow is correct", func() {
-					// Chained launchers should be not be invoked.
-					So(chainedTaskHandle.AssertExpectations(t), ShouldBeTrue)
-					So(chainedLauncher.AssertExpectations(t), ShouldBeTrue)
 				})
 			})
 
@@ -169,17 +170,12 @@ func TestFailureChainedTaskHandle(t *testing.T) {
 					So(err.Error(), ShouldContainSubstring, fixedError)
 					So(taskHandle.Status(), ShouldEqual, TERMINATED)
 				})
-
-				Convey("Flow is correct", func() {
-					// Chained launchers should be not be invoked.
-					So(chainedTaskHandle.AssertExpectations(t), ShouldBeTrue)
-					So(chainedLauncher.AssertExpectations(t), ShouldBeTrue)
-				})
 			})
 
 		})
 
 		Convey("When Chained Launcher returns an error", func() {
+			// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
 			initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, nil)
 			chainedLauncher.On("Launch").Return(nil, errors.New(fixedError))
 
@@ -204,6 +200,7 @@ func TestFailureChainedTaskHandle(t *testing.T) {
 		})
 
 		Convey("When Chained TaskHandle returns an error", func() {
+			// NOTE(skonefal): In testify mock, timer in 'After' method starts when mock is defined.
 			initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, nil)
 			chainedLauncher.On("Launch").Return(chainedTaskHandle, nil)
 			chainedTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, errors.New(fixedError))

--- a/pkg/executor/chained_task_handle_test.go
+++ b/pkg/executor/chained_task_handle_test.go
@@ -22,9 +22,6 @@ func TestSuccsessfulChainedTaskHandle(t *testing.T) {
 			chainedTaskHandle.On("Wait", 0*time.Second).After(2*taskExecutionTime).Return(true, nil)
 			chainedLauncher.On("Launch").Return(chainedTaskHandle, nil)
 
-			//initialTaskHandle.On("Stop").Return(nil)
-			//chainedTaskHandle.On("Stop").Return(nil)
-
 			taskHandle := NewChainedTaskHandle(initialTaskHandle, chainedLauncher)
 			So(taskHandle.Status(), ShouldEqual, RUNNING)
 

--- a/pkg/executor/chained_task_handle_test.go
+++ b/pkg/executor/chained_task_handle_test.go
@@ -1,0 +1,88 @@
+package executor
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const taskExecutionTime = 100 * time.Millisecond
+const waitTimeout = 60 * time.Second
+
+func TestSuccsessfulChainedTaskHandle(t *testing.T) {
+	Convey("When having ChainedTaskHandle with successful execution", t, func() {
+		initialTaskHandle := new(MockTaskHandle)
+		initialTaskHandle.On("Wait", 0*time.Second).After(taskExecutionTime).Return(true, nil)
+		initialTaskHandle.On("Stop").Return(nil)
+
+		chainedTaskHandle := new(MockTaskHandle)
+		chainedTaskHandle.On("Wait", 0*time.Second).After(2*taskExecutionTime).Return(true, nil)
+		chainedTaskHandle.On("Stop").Return(nil)
+
+		chainedLauncher := new(MockLauncher)
+		chainedLauncher.On("Launch").Return(chainedTaskHandle, nil)
+
+		Convey("Successful run should yield no error", func() {
+			startTime := time.Now()
+			taskHandle := NewChainedTaskHandle(initialTaskHandle, chainedLauncher)
+			So(taskHandle.Status(), ShouldEqual, RUNNING)
+
+			isTerminated, err := taskHandle.Wait(waitTimeout)
+			So(time.Since(startTime), ShouldBeGreaterThanOrEqualTo, taskExecutionTime)
+			So(err, ShouldBeNil)
+			So(isTerminated, ShouldBeTrue)
+			So(taskHandle.Status(), ShouldEqual, TERMINATED)
+
+			Convey("Subsequent Waits should yield no error", func() {
+				isTerminated, err := taskHandle.Wait(waitTimeout)
+				So(err, ShouldBeNil)
+				So(isTerminated, ShouldBeTrue)
+				So(taskHandle.Status(), ShouldEqual, TERMINATED)
+
+				isTerminated, err = taskHandle.Wait(waitTimeout)
+				So(err, ShouldBeNil)
+				So(isTerminated, ShouldBeTrue)
+				So(taskHandle.Status(), ShouldEqual, TERMINATED)
+			})
+			Convey("Subsequent Stops should yield no error", func() {
+				err := taskHandle.Stop()
+				So(err, ShouldBeNil)
+				So(taskHandle.Status(), ShouldEqual, TERMINATED)
+
+				err = taskHandle.Stop()
+				So(err, ShouldBeNil)
+				So(taskHandle.Status(), ShouldEqual, TERMINATED)
+			})
+		})
+
+		Convey("Immediate stop of ChainedTaskHandle should yield no error", func() {
+			taskHandle := NewChainedTaskHandle(initialTaskHandle, chainedLauncher)
+			err := taskHandle.Stop()
+			So(err, ShouldBeNil)
+			So(taskHandle.Status(), ShouldEqual, TERMINATED)
+
+			Convey("Subsequent stop should yield no error", func() {
+				err := taskHandle.Stop()
+				So(err, ShouldBeNil)
+				So(taskHandle.Status(), ShouldEqual, TERMINATED)
+			})
+		})
+
+		Convey("Stop during execution of chained task should yield no error", func() {
+			taskHandle := NewChainedTaskHandle(initialTaskHandle, chainedLauncher)
+			taskHandle.Wait(taskExecutionTime + taskExecutionTime/4) // Wait for second task to start.
+			startTime := time.Now()
+			err := taskHandle.Stop()
+			So(err, ShouldBeNil)
+			So(time.Since(startTime), ShouldBeLessThan, taskExecutionTime)
+			So(taskHandle.Status(), ShouldEqual, TERMINATED)
+
+			Convey("Subsequent stop should yield no error", func() {
+				err := taskHandle.Stop()
+				So(err, ShouldBeNil)
+				So(taskHandle.Status(), ShouldEqual, TERMINATED)
+			})
+		})
+	})
+}

--- a/pkg/executor/executor_shared.go
+++ b/pkg/executor/executor_shared.go
@@ -52,9 +52,9 @@ func checkIfProcessFailedToExecute(command string, executorName string, handle T
 	return nil
 }
 
-// getWaitTimeoutChan returns channel for timeout in Wait(timeout) function in TaskHandles.
+// getTimeoutChan returns channel for timeout in Wait(timeout) function in TaskHandles.
 // When timeout is 0, then timeout will never occur.
-func getWaitTimeoutChan(timeout time.Duration) <-chan time.Time {
+func getTimeoutChan(timeout time.Duration) <-chan time.Time {
 	if timeout != 0 {
 		// In case of wait with timeout set the timeout channel.
 		return time.After(timeout)

--- a/pkg/executor/executor_shared.go
+++ b/pkg/executor/executor_shared.go
@@ -51,3 +51,14 @@ func checkIfProcessFailedToExecute(command string, executorName string, handle T
 
 	return nil
 }
+
+// getWaitTimeoutChan returns channel for timeout in Wait(timeout) function in TaskHandles.
+// When timeout is 0, then timeout will never occur.
+func getWaitTimeoutChan(timeout time.Duration) <-chan time.Time {
+	if timeout != 0 {
+		// In case of wait with timeout set the timeout channel.
+		return time.After(timeout)
+	}
+
+	return make(<-chan time.Time)
+}

--- a/pkg/executor/executor_shared.go
+++ b/pkg/executor/executor_shared.go
@@ -62,3 +62,15 @@ func getWaitTimeoutChan(timeout time.Duration) <-chan time.Time {
 
 	return make(<-chan time.Time)
 }
+
+// getWaitChannel returns channel that will return result (any encountered error) of
+// Wait() method in provided handle.
+func getWaitChannel(handle TaskControl) <-chan error {
+	result := make(chan error)
+	go func() {
+		_, err := handle.Wait(0)
+		result <- err
+		return
+	}()
+	return result
+}

--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -476,7 +476,7 @@ func (th *k8sTaskHandle) Wait(timeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
-	timeoutChannel := getWaitTimeoutChan(timeout)
+	timeoutChannel := getTimeoutChan(timeout)
 
 	select {
 	case <-th.stopped:

--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -476,11 +476,7 @@ func (th *k8sTaskHandle) Wait(timeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
-	var timeoutChannel <-chan time.Time
-	if timeout != 0 {
-		// In case of wait with timeout set the timeout channel.
-		timeoutChannel = time.After(timeout)
-	}
+	timeoutChannel := getWaitTimeoutChan(timeout)
 
 	select {
 	case <-th.stopped:

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -235,11 +235,7 @@ func (taskHandle *localTaskHandle) Wait(timeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
-	var timeoutChannel <-chan time.Time
-	if timeout != 0 {
-		// In case of wait with timeout set the timeout channel.
-		timeoutChannel = time.After(timeout)
-	}
+	timeoutChannel := getWaitTimeoutChan(timeout)
 
 	select {
 	case <-taskHandle.hasProcessExited:

--- a/pkg/executor/local.go
+++ b/pkg/executor/local.go
@@ -235,7 +235,7 @@ func (taskHandle *localTaskHandle) Wait(timeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
-	timeoutChannel := getWaitTimeoutChan(timeout)
+	timeoutChannel := getTimeoutChan(timeout)
 
 	select {
 	case <-taskHandle.hasProcessExited:

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -323,11 +323,7 @@ func (taskHandle *remoteTaskHandle) Wait(timeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
-	var timeoutChannel <-chan time.Time
-	if timeout != 0 {
-		// In case of wait with timeout set the timeout channel.
-		timeoutChannel = time.After(timeout)
-	}
+	timeoutChannel := getWaitTimeoutChan(timeout)
 
 	select {
 	case <-taskHandle.hasProcessExited:

--- a/pkg/executor/remote.go
+++ b/pkg/executor/remote.go
@@ -319,7 +319,7 @@ func (taskHandle *remoteTaskHandle) Wait(timeout time.Duration) (bool, error) {
 		return true, nil
 	}
 
-	timeoutChannel := getWaitTimeoutChan(timeout)
+	timeoutChannel := getTimeoutChan(timeout)
 
 	select {
 	case <-taskHandle.hasProcessExited:

--- a/pkg/executor/task_handle.go
+++ b/pkg/executor/task_handle.go
@@ -77,15 +77,3 @@ func StopAndEraseOutput(handle TaskHandle) (errorCollection errcollection.ErrorC
 
 	return
 }
-
-// GetWaitChannel returns channel that will return result (any encountered error) of
-// Wait() method in provided handle.
-func GetWaitChannel(handle TaskControl) <-chan error {
-	result := make(chan error)
-	go func() {
-		_, err := handle.Wait(0)
-		result <- err
-		return
-	}()
-	return result
-}

--- a/pkg/executor/task_handle.go
+++ b/pkg/executor/task_handle.go
@@ -78,6 +78,8 @@ func StopAndEraseOutput(handle TaskHandle) (errorCollection errcollection.ErrorC
 	return
 }
 
+// GetWaitChannel returns channel that will return result (any encountered error) of
+// Wait() method in provided handle.
 func GetWaitChannel(handle TaskControl) <-chan error {
 	result := make(chan error)
 	go func() {

--- a/pkg/executor/task_handle.go
+++ b/pkg/executor/task_handle.go
@@ -68,7 +68,7 @@ type TaskControl interface {
 	EraseOutput() error
 }
 
-// StopAndEraseOutput run stop and eraseOutput on taskHandle and add errors to errorCollection
+// StopAndEraseOutput run Stop and EraseOutput on TaskHandle and add errors to errorCollection
 func StopAndEraseOutput(handle TaskHandle) (errorCollection errcollection.ErrorCollection) {
 	if handle != nil {
 		errorCollection.Add(handle.Stop())
@@ -76,4 +76,14 @@ func StopAndEraseOutput(handle TaskHandle) (errorCollection errcollection.ErrorC
 	}
 
 	return
+}
+
+func GetWaitChannel(handle TaskControl) <-chan error {
+	result := make(chan error)
+	go func() {
+		_, err := handle.Wait(0)
+		result <- err
+		return
+	}()
+	return result
 }


### PR DESCRIPTION
Adds an abstraction for launching task one-after-another. Initial implementation supports just one Launcher and will be used for linking Snap session with workload.

Summary of changes:
- Adds ChainedLauncher class
- Timeout in Wait() are shared code
- Adds Wait() channel generator

Testing done:
- Massive UTs
