### PR TITLE
Using Cassandra publisher tagIndex by default

### DIFF
--- a/pkg/conf/flags.go
+++ b/pkg/conf/flags.go
@@ -14,6 +14,8 @@
 
 package conf
 
+import "fmt"
+
 // CassandraAddress represents cassandra address flag.
 var CassandraAddress = NewStringFlag("cassandra_address", "Address of Cassandra DB endpoint for Metadata and Snap Publishers.", "127.0.0.1")
 
@@ -59,3 +61,6 @@ var CassandraKeyspaceName = NewStringFlag("cassandra_keyspace_name", "Keyspace u
 
 // CassandraCreateKeyspace sets that publisher will attempt to create keyspace
 var CassandraCreateKeyspace = NewBoolFlag("cassandra_create_keyspace", "Attempt to create keyspace.", false)
+
+// CassandraTagIndex allows to pass comma-separated list of tags that will be used to insert metrics into tags table to improve SELECT performance.
+var CassandraTagIndex = NewStringFlag("cassandra_tag_index", fmt.Sprintf("Allows to pass comma-separated list of tags that will be used to insert metrics into %s.tags table to improve SELECT performance", CassandraKeyspaceName.Value()), "swan_experiment")

--- a/pkg/snap/sessions/cassandra.go
+++ b/pkg/snap/sessions/cassandra.go
@@ -34,6 +34,7 @@ func ApplyCassandraConfiguration(publisher *wmap.PublishWorkflowMapNode) {
 	publisher.AddConfigItem("ignorePeerAddrRuleKey", conf.CassandraIgnorePeerAddr.Value())
 	publisher.AddConfigItem("createKeyspace", conf.CassandraCreateKeyspace.Value())
 	publisher.AddConfigItem("keyspaceName", conf.CassandraKeyspaceName.Value())
+	publisher.AddConfigItem("tagIndex", conf.CassandraTagIndex.Value())
 
 	if conf.CassandraSslEnabled.Value() {
 		publisher.AddConfigItem("serverCertVerification", conf.CassandraSslHostValidation.Value())


### PR DESCRIPTION
Fixes issue of new Cassandra configuration parameter not being used in experiments.

Summary of changes:
- added new flag
- using newly added flag in plugin configuration

Testing done:
- all existing tests should pass
