### PR TITLE
SCE-1078: Save information about generated tags

### DIFF
--- a/experiments/example/main.go
+++ b/experiments/example/main.go
@@ -97,6 +97,10 @@ func main() {
 	mutilateSnapSession, err := mutilatesession.NewSessionLauncherDefault()
 	errutil.CheckWithContext(err, "Cannot create Mutilate snap session")
 
+	// Save information about tags that experiments is going to generate, to automatically build a visualization of results.
+	err = metadata.RecordTags([]string{"thread_count", "load_point", "qps"})
+	errutil.CheckWithContext(err, "Cannot tags metadata in Cassandra Metadata Database")
+
 	// Instansce of executor.Executor that allows to launch processes locally.
 	executor := executor.NewLocal()
 

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -114,6 +114,15 @@ func main() {
 	err = metadata.RecordMap(records)
 	errutil.CheckWithContext(err, "cannot save metadata")
 
+	// Save information about tags that experiments is going to generate, to automatically build a visualization of results.
+	err = metadata.RecordTags([]string{
+		experiment.AggressorNameKey,
+		experiment.LoadPointQPSKey,
+		experiment.RepetitionKey,
+	})
+	errutil.CheckWithContext(err, "Cannot tags metadata in Cassandra Metadata Database")
+
+	for _, beLauncher := range beLaunchers {
 	bestEfforts := sensitivity.AggressorsFlag.Value()
 	for _, bestEffortWorkloadName := range bestEfforts {
 		for loadPoint := 0; loadPoint < loadPoints; loadPoint++ {

--- a/experiments/optimal-core-allocation/main.go
+++ b/experiments/optimal-core-allocation/main.go
@@ -89,6 +89,14 @@ func main() {
 	err = metadata.RecordMap(records)
 	errutil.CheckWithContext(err, "Cannot save metadata in Cassandra Metadata Database")
 
+	// Save information about tags that experiments is going to generate, to automatically build a visualization of results.
+	err = metadata.RecordTags([]string{
+		experiment.LoadPointQPSKey,
+		experiment.AggressorNameKey,
+		"number_of_threads",
+	})
+	errutil.CheckWithContext(err, "Cannot tags metadata in Cassandra Metadata Database")
+
 	// Validate preconditions.
 	validate.OS()
 

--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -200,6 +200,7 @@ func TestExperiment(t *testing.T) {
 				So(metadata["SWAN_EXPERIMENT_PEAK_LOAD"], ShouldEqual, "5000")
 				So(metadata["load_points"], ShouldEqual, "1")
 				So(metadata["load_duration"], ShouldEqual, "1s")
+				So(metadata[experiment.AggressorNameKey], ShouldEqual, experiment.AggressorNameKey) // For 'tags' kind.
 				So(metadata[experiment.CPUModelNameKey], ShouldNotEqual, "")
 			})
 

--- a/integration_tests/pkg/experiment/metadata_test.go
+++ b/integration_tests/pkg/experiment/metadata_test.go
@@ -17,10 +17,11 @@ package experiment
 import (
 	"testing"
 
-	"github.com/intelsdi-x/swan/pkg/experiment"
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"time"
+
+	"github.com/intelsdi-x/swan/pkg/experiment"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestMetadata(t *testing.T) {
@@ -64,6 +65,22 @@ func TestMetadata(t *testing.T) {
 				So(metadataCollection, ShouldHaveLength, 1)
 				So(metadataCollection[0], ShouldContainKey, "foo")
 				So(metadataCollection[0]["foo"], ShouldEqual, "bar")
+				metadata.Clear()
+			})
+		})
+
+		Convey("Recoding tags", func() {
+			err := metadata.RecordTags([]string{"foo", "bar"})
+			So(err, ShouldBeNil)
+
+			Convey("Should be able get tags from Cassandra", func() {
+				metadataCollection, err := metadata.Get()
+				So(err, ShouldBeNil)
+				So(metadataCollection, ShouldHaveLength, 1)
+				So(metadataCollection[0], ShouldContainKey, "foo")
+				So(metadataCollection[0]["foo"], ShouldEqual, "foo")
+				So(metadataCollection[0], ShouldContainKey, "bar")
+				So(metadataCollection[0]["bar"], ShouldEqual, "bar")
 				metadata.Clear()
 			})
 		})

--- a/pkg/experiment/metadata.go
+++ b/pkg/experiment/metadata.go
@@ -30,6 +30,7 @@ const (
 	metadataKindFlags    = "flags"
 	metadataKindEnviron  = "environ"
 	metadataKindPlatform = "platform"
+	metadataKindTags     = "tags"
 )
 
 // MetadataConfig encodes the settings for connecting to the database.
@@ -200,6 +201,16 @@ func (m *Metadata) Record(key string, value string) error {
 // RecordMap stores a key and value map and associates with the experiment id.
 func (m *Metadata) RecordMap(metadata MetadataMap) error {
 	return m.storeMap(metadata, metadataKindEmpty)
+}
+
+// RecordTags saves information about tags that experiments is going to generate,
+// that one can automatically build a visualization of results.
+func (m *Metadata) RecordTags(tags []string) error {
+	metadata := MetadataMap{}
+	for _, tag := range tags {
+		metadata[tag] = tag
+	}
+	return m.storeMap(metadata, metadataKindTags)
 }
 
 //RecordRuntimeEnv store experiment environment information in Cassandra.


### PR DESCRIPTION
Fixes issue "visualization in jupyter requires hardcoding dimessions to be able to build a results tables"

with tags available explicit - it will be possible to automate building visualization for any new experiment.

Summary of changes:
- new `RecordTags' function to store a list of tags (dimensions) 
- RecordTags used in every experiment 

Testing done:
- yes, integration tests for both metadata and sensitivity profile
