### PR TITLE
Fixed missing parameter to sudo in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo ln -sf `pwd`/mutilate /bin/
 To run experiment, invoke:
 
 ```
-sudo memcached-sensitivity-profile -experiment_be_workloads=caffe -experiment_load_duration=5s -experiment_peak_load=10000 -experiment_repetitions=1 > uuid.txt
+sudo -E memcached-sensitivity-profile -experiment_be_workloads=caffe -experiment_load_duration=5s -experiment_peak_load=10000 -experiment_repetitions=1 > uuid.txt
 ```
 
 When experiment is running, please see how to [explore experiment data](/jupyter/README.md) to see results. Note that Experiment UUID that is necessary for obtaining experiment results will be available in `uuid.txt` file.


### PR DESCRIPTION
Running experiment with sudo strips environment from various environment
variables. If add -E parameter to the sudo then those variables are
preserved including PATH.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

Testing done:
- manually tested in memcached sensitivity experiment 
