### PR TITLE
Linked snap binaries into /usr bin and sbin dirs

### DIFF
--- a/vagrant/provision_experiment_environment.sh
+++ b/vagrant/provision_experiment_environment.sh
@@ -136,6 +136,8 @@ yum install -y -q snap-telemetry-${SNAP_VERSION}
 systemctl enable snap-telemetry
 systemctl start snap-telemetry
 daemonStatus snap-telemetry
+ln -sf /opt/snap/bin/* /usr/bin/
+ln -sf /opt/snap/sbin/* /usr/sbin/
 
 
 echo "----------------------------- Install external Snap plugins (`date`)"


### PR DESCRIPTION
Snap binaries are unreachable when using sudo command.
Linking them to the /usr/bin and /usr/sbin fix this problem.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

Testing done:
- manual tests 
