### PR TITLE
Linking binaries into /usr/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Inside guest OS, the Mutilate load generator needs to be build. To do so, please
 git clone https://github.com/leverich/mutilate
 cd mutilate
 scons
-sudo ln -sf `pwd`/mutilate /bin/
+sudo ln -sf `pwd`/mutilate /usr/bin/
 ```
 To run experiment, invoke:
 

--- a/vagrant/provision_ci_environment.sh
+++ b/vagrant/provision_ci_environment.sh
@@ -58,6 +58,6 @@ ln -svf $HOME_DIR/go/src/github.com/intelsdi-x/swan $HOME_DIR
 chown -R $SWAN_USER:$SWAN_USER $HOME_DIR
 chown -R $SWAN_USER:$SWAN_USER /opt/swan
 chmod -R +x /opt/swan/bin/*
-ln -svf /opt/swan/bin/* /bin/
+ln -svf /opt/swan/bin/* /usr/bin/
 
 echo "--------------------------- Provisioning development environment done (`date`)"

--- a/vagrant/provision_experiment_environment.sh
+++ b/vagrant/provision_experiment_environment.sh
@@ -153,6 +153,6 @@ chmod +x -R /opt/swan/bin
 chown -R $SWAN_USER:$SWAN_USER $HOME_DIR
 chown -R $SWAN_USER:$SWAN_USER /opt/swan
 chmod -R +x /opt/swan/bin/*
-ln -svf ${SWAN_BIN}/* /bin/
+ln -svf ${SWAN_BIN}/* /usr/bin/
 
 echo "---------------------------- Provisioning experiment environment done (`date`)"


### PR DESCRIPTION
Linking binaries into /usr/bin instead of /bin.
The latter is for base system while the former for user
additional applications.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>

Testing done:
- integration tests
