### PR TITLE
Removed box update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Run Vagrant image supplied by Swan:
 git clone https://github.com/intelsdi-x/swan
 cd swan/vagrant
 vagrant plugin install vagrant-vbguest
-vagrant box update
 vagrant up
 vagrant ssh
 ```

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -27,7 +27,6 @@ git clone git@github.com:intelsdi-x/swan.git
 cd swan/vagrant
 export SWAN_DEVELOPMENT_ENVIRONMENT=true
 vagrant plugin install vagrant-vbguest  # automatic guest additions
-vagrant box update
 vagrant up
 vagrant ssh
 ```


### PR DESCRIPTION
Removed 'vagrant box update' instructions from Quick Start and
vagrant README since it is assumed that Swan will be installed
on clear environment.

Signed-off-by: Maciej Patelczyk <maciej.patelczyk@intel.com>
