### PR TITLE
Fixed .glide error

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -21,7 +21,7 @@
 First - install: [Vagrant](https://www.vagrantup.com/docs/installation/), [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). Then you just need to execute the following commands (they should work on any flavour of Linux):
 
 To run Vagrant development environment, the `$SWAN_DEVELOPMENT_ENVIRONMENT` variable must be set.
-If you want to use your local Glide repository, the `$SHARE_GLIDE_CACHE` variable must be set.
+If you want to use you local Glide cache in the Vagrant development environment the `$SHARE_GLIDE_CACHE` variable must be set.
 ```sh
 git clone git@github.com:intelsdi-x/swan.git
 cd swan/vagrant

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -21,7 +21,7 @@
 First - install: [Vagrant](https://www.vagrantup.com/docs/installation/), [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). Then you just need to execute the following commands (they should work on any flavour of Linux):
 
 To run Vagrant development environment, the `$SWAN_DEVELOPMENT_ENVIRONMENT` variable must be set.
-If you want to use you local Glide cache in the Vagrant development environment the `$SHARE_GLIDE_CACHE` variable must be set.
+If you want to use your local Glide cache in the Vagrant development environment the `$SHARE_GLIDE_CACHE` variable must be set.
 ```sh
 git clone git@github.com:intelsdi-x/swan.git
 cd swan/vagrant

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -21,7 +21,7 @@
 First - install: [Vagrant](https://www.vagrantup.com/docs/installation/), [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git). Then you just need to execute the following commands (they should work on any flavour of Linux):
 
 To run Vagrant development environment, the `$SWAN_DEVELOPMENT_ENVIRONMENT` variable must be set.
-
+If you want to use your local Glide repository, the `$SHARE_GLIDE_CACHE` variable must be set.
 ```sh
 git clone git@github.com:intelsdi-x/swan.git
 cd swan/vagrant

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -62,7 +62,10 @@ Vagrant.configure(2) do |config|
         'VAGRANT_USER' => vagrant_user,
         'HOME_DIR' => home_dir,
         'SWAN_DEVELOPMENT_ENVIRONMENT' => provision_development_environment}
-    override.vm.synced_folder "#{ENV['HOME']}/.glide", "#{home_dir}/.glide", :mount_options => ["umask=0022,dmask=0022,fmask=0022"]
+    
+    if File.directory?(File.expand_path("#{home_dir}/.glide"))
+      override.vm.synced_folder "#{ENV['HOME']}/.glide", "#{home_dir}/.glide", :mount_options => ["umask=0022,dmask=0022,fmask=0022"]
+    end
   end
 
   config.vm.provider :aws do |aws, override|

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure(2) do |config|
   vagrant_user = ENV['VAGRANT_USER'] || 'vagrant'
   build_cached_image = ENV["BUILD_CACHED_IMAGE"] == 'true' ? true : false
   provision_development_environment = ENV["SWAN_DEVELOPMENT_ENVIRONMENT"] == 'true' ? true : false
+  share_glide_cache = ENV["SHARE_GLIDE_CACHE"] || false
 
   # SSH agent forwarding (for host private keys)
   config.ssh.forward_agent = true
@@ -63,7 +64,7 @@ Vagrant.configure(2) do |config|
         'HOME_DIR' => home_dir,
         'SWAN_DEVELOPMENT_ENVIRONMENT' => provision_development_environment}
     
-    if File.directory?(File.expand_path("#{home_dir}/.glide"))
+    if share_glide_cache
       override.vm.synced_folder "#{ENV['HOME']}/.glide", "#{home_dir}/.glide", :mount_options => ["umask=0022,dmask=0022,fmask=0022"]
     end
   end


### PR DESCRIPTION
Fixes error while building vagrant (`vagrant up`), when no glide repository is available in the host OS.

Summary of changes:
- ~~Instead of always syncing the .glide directory from the host and guest OS, it's done now only when this directory exists in the host OS~~
- On default, there is no syncing of the `.glide` directory between the host and guest OS
- For enabling syncing an environment variable must be set `SHARE_GLIDE_CACHE`

Testing done:
- The `vagrant up` command runs now fine.