### PR TITLE
Fixed jupyter-cassandra connection

### DIFF
--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -25,7 +25,7 @@ Swan uses *Jupyter Notebook* to filter, process and visualize results from exper
 You need to have Docker installed to run Jupyter notebooks easily. We have provided a Docker image that will make running notebooks as easy as possible. You just need to run:
 
 ```sh
-docker run -p 127.0.0.1:8888:8888 intelsdi/swan-jupyter
+docker run --network="container:cassandra-swan" intelsdi/swan-jupyter
 ```
 
 ## Explore the Example Jupyter Notebook

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -25,8 +25,13 @@ Swan uses *Jupyter Notebook* to filter, process and visualize results from exper
 You need to have Docker installed to run Jupyter notebooks easily. We have provided a Docker image that will make running notebooks as easy as possible. You just need to run:
 
 ```sh
-docker run --network="container:cassandra-swan" intelsdi/swan-jupyter
+docker run -p 127.0.0.1:8888:8888 intelsdi/swan-jupyter
 ```
+If you're running Cassandra using the `cassandra.service` file provided in this repository, please use the following command to run Jupyter, so that it will have direct access to Cassandra:
+```sh
+docker run --network="container:cassandra-swan" intelsdi/swan-jupyter 
+``` 
+Additionally Cassandra's container already exposes the necessary port for Jupyter (8888), so there is no need to expose it manually.
 
 ## Explore the Example Jupyter Notebook
 

--- a/vagrant/cassandra/cassandra.service
+++ b/vagrant/cassandra/cassandra.service
@@ -38,9 +38,12 @@ TimeoutStartSec=0
 Restart=always
 ExecStartPre=-/usr/bin/docker rm -f cassandra-swan
 ExecStartPre=/usr/bin/docker pull cassandra:3.9
+ExecStartPre=-/usr/bin/docker network create cassandra-net
 ExecStart=/usr/bin/docker run \
   --name cassandra-swan \
-  --net host \
+  --net cassandra-net \
+  -p 127.0.0.1:9042:9042 \
+  -p 127.0.0.1:8888:8888 \
   -e CASSANDRA_LISTEN_ADDRESS=127.0.0.1 \
   -e CASSANDRA_CLUSTER_NAME=cassandra-swan \
   -v /var/data/cassandra:/var/lib/cassandra \


### PR DESCRIPTION
Fixes connection error to Cassandra while executing example Jupyter notebook 

Summary of changes:
- Created docker network for Cassandra
- Exposed ports for Cassandra and Jupyter
- Attached Jupyter container's network to Cassandra's container 

Testing done:
- No connection errors while running Jupyter
