### PR TITLE
Fixing issues with K8s 1.7.x

### DIFF
--- a/integration_tests/pkg/kubernetes/kubernetes_test.go
+++ b/integration_tests/pkg/kubernetes/kubernetes_test.go
@@ -53,7 +53,9 @@ func TestLocalKubernetesPodExecution(t *testing.T) {
 			k8sHandle, err := k8sLauncher.Launch()
 			So(err, ShouldBeNil)
 
-			defer executor.StopAndEraseOutput(k8sHandle)
+			Reset(func() {
+				testhelpers.WipeTestClusterFromSurfaceOfTheEarth(k8sHandle)
+			})
 
 			Convey("And kubectl shows that local host is in Ready state", func() {
 				terminated, err := k8sHandle.Wait(100 * time.Millisecond)
@@ -144,7 +146,9 @@ func TestLocalKubernetesPodBrokenExecution(t *testing.T) {
 			k8sHandle, err := k8sLauncher.Launch()
 			So(err, ShouldBeNil)
 
-			defer executor.StopAndEraseOutput(k8sHandle)
+			Reset(func() {
+				testhelpers.WipeTestClusterFromSurfaceOfTheEarth(k8sHandle)
+			})
 
 			Convey("And kubectl shows that local host is in Ready state", func() {
 				terminated, err := k8sHandle.Wait(100 * time.Millisecond)
@@ -172,7 +176,8 @@ func TestLocalKubernetesPodBrokenExecution(t *testing.T) {
 					match := re.Find(output)
 					So(match, ShouldNotBeNil)
 
-					time.Sleep(10 * time.Second)
+					running := testhelpers.IsPodRunning("swan-testpod", 50, 500*time.Millisecond)
+					So(running, ShouldBeTrue)
 
 					Convey("If kubernetes is stopped pod shall be alive", func() {
 						_ = executor.StopAndEraseOutput(k8sHandle)
@@ -184,6 +189,9 @@ func TestLocalKubernetesPodBrokenExecution(t *testing.T) {
 						Convey("After starting again kubernetes old pod shall be removed", func() {
 							k8sHandle, err = k8sLauncher.Launch()
 							So(err, ShouldBeNil)
+							Reset(func() {
+								testhelpers.WipeTestClusterFromSurfaceOfTheEarth(k8sHandle)
+							})
 
 							output, err := exec.Command("sudo", "docker", "ps").Output()
 							So(err, ShouldBeNil)

--- a/integration_tests/pkg/snap/sessions/docker/docker_test.go
+++ b/integration_tests/pkg/snap/sessions/docker/docker_test.go
@@ -57,8 +57,9 @@ func TestSnapDockerSession(t *testing.T) {
 		kubernetesHandle, err := kubernetesLauncher.Launch()
 		So(err, ShouldBeNil)
 		So(kubernetesHandle, ShouldNotBeNil)
-		defer kubernetesHandle.EraseOutput()
-		defer kubernetesHandle.Stop()
+		Reset(func() {
+			testhelpers.WipeTestClusterFromSurfaceOfTheEarth(kubernetesHandle)
+		})
 
 		// Waiting for Kubernetes Executor.
 		kubernetesConfig := executor.DefaultKubernetesConfig()
@@ -85,6 +86,7 @@ func TestSnapDockerSession(t *testing.T) {
 				tags,
 			)
 			So(err, ShouldBeNil)
+			defer podHandle.EraseOutput()
 			defer dockerHandle.Stop()
 
 			So(dockerHandle.Status(), ShouldEqual, executor.RUNNING)

--- a/integration_tests/pkg/snap/sessions/docker/docker_test.go
+++ b/integration_tests/pkg/snap/sessions/docker/docker_test.go
@@ -51,7 +51,7 @@ func TestSnapDockerSession(t *testing.T) {
 
 		// Run Kubernetes
 		exec := executor.NewLocal()
-		config := kubernetes.UniqueConfig()
+		config := kubernetes.DefaultConfig()
 		config.RetryCount = 10
 		kubernetesLauncher := kubernetes.New(exec, exec, config)
 		kubernetesHandle, err := kubernetesLauncher.Launch()

--- a/integration_tests/test_helpers/kubernetes.go
+++ b/integration_tests/test_helpers/kubernetes.go
@@ -137,6 +137,7 @@ func (k *KubeClient) UntaintNode() {
 	k.updateTaints(node, taintsInJSON)
 }
 
+// WipeTestClusterFromSurfaceOfTheEarth does a lot to make sure that Kubernetes cluster is stopped and there are not artifacts in etcd or /var/lib/kubelet.
 func WipeTestClusterFromSurfaceOfTheEarth(handle executor.TaskHandle) {
 	errs := executor.StopAndEraseOutput(handle)
 	So(errs.GetErrIfAny(), ShouldBeNil)
@@ -148,6 +149,7 @@ func WipeTestClusterFromSurfaceOfTheEarth(handle executor.TaskHandle) {
 	So(err, ShouldBeNil)
 }
 
+// IsPodRunning checks if pod is in Running state.
 func IsPodRunning(podName string, numberOfAttempts int, sleepBetweenAttempts time.Duration) bool {
 	found := false
 	attempt := 0

--- a/integration_tests/test_helpers/kubernetes.go
+++ b/integration_tests/test_helpers/kubernetes.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/smartystreets/assertions"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/smartystreets/goconvey/convey"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -140,13 +140,13 @@ func (k *KubeClient) UntaintNode() {
 // WipeTestClusterFromSurfaceOfTheEarth does a lot to make sure that Kubernetes cluster is stopped and there are not artifacts in etcd or /var/lib/kubelet.
 func WipeTestClusterFromSurfaceOfTheEarth(handle executor.TaskHandle) {
 	errs := executor.StopAndEraseOutput(handle)
-	So(errs.GetErrIfAny(), ShouldBeNil)
+	convey.So(errs.GetErrIfAny(), convey.ShouldBeNil)
 	cmd := exec.Command("bash", "-c", "ETCDCTL_API=3 etcdctl del --prefix /")
 	err := cmd.Run()
-	So(err, ShouldBeNil)
+	convey.So(err, convey.ShouldBeNil)
 	cmd = exec.Command("bash", "-c", "rm -fr /var/lib/kubelet/*")
 	err = cmd.Run()
-	So(err, ShouldBeNil)
+	convey.So(err, convey.ShouldBeNil)
 }
 
 // IsPodRunning checks if pod is in Running state.
@@ -155,7 +155,7 @@ func IsPodRunning(podName string, numberOfAttempts int, sleepBetweenAttempts tim
 	attempt := 0
 	for !found {
 		output, err := exec.Command("bash", "-c", fmt.Sprintf("hyperkube kubectl get pods | grep %q | awk '{ print $3 }'", podName)).Output()
-		So(err, ShouldBeNil)
+		convey.So(err, convey.ShouldBeNil)
 		if assertions.ShouldContainSubstring(string(output), "Running") == "" {
 			found = true
 		} else {

--- a/pkg/executor/kubernetes.go
+++ b/pkg/executor/kubernetes.go
@@ -656,7 +656,7 @@ func (kw *k8sWatcher) whenPodFinished(pod *v1.Pod) {
 				log.Debugf("K8s task watcher: fail status message: %q", pod.Status.Message)
 			}
 		}
-		kw.whenPodReady()
+		kw.setupLogs()
 		kw.setExitCode(pod)
 		log.Debug("K8s task watcher: pod finished")
 	})

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -16,7 +16,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"path"
 	"time"
 
 	"k8s.io/client-go/pkg/api/v1"
@@ -26,8 +25,6 @@ import (
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/netutil"
-	"github.com/intelsdi-x/swan/pkg/utils/random"
-	"github.com/intelsdi-x/swan/pkg/utils/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -112,26 +109,6 @@ func DefaultConfig() Config {
 // GetKubeAPIAddress returns kube api server in HTTP format.
 func (c *Config) GetKubeAPIAddress() string {
 	return fmt.Sprintf("http://%s:%d", c.KubeAPIAddr, c.KubeAPIPort)
-}
-
-// UniqueConfig is a constructor for Config with default parameters and random ports and random etcd prefix.
-func UniqueConfig() Config {
-	config := DefaultConfig()
-	// Create unique etcd prefix to avoid interference with any parallel tests which use same
-	// etcd cluster.
-	config.EtcdPrefix = path.Join("/swan/", uuid.New())
-
-	// NOTE: To reduce the likelihood of port conflict between test kubernetes clusters, we randomly
-	// assign a collection of ports to the services. Eventhough previous kubernetes processes
-	// have been shut down, ports may be in CLOSE_WAIT state.
-	ports := random.Ports(5)
-	config.KubeAPIPort = ports[0]
-	config.KubeletPort = ports[1]
-	config.KubeControllerPort = ports[2]
-	config.KubeSchedulerPort = ports[3]
-	config.KubeProxyPort = ports[4]
-
-	return config
 }
 
 // Type used for UT mocking purposes.

--- a/vagrant/provision_experiment_environment.sh
+++ b/vagrant/provision_experiment_environment.sh
@@ -32,10 +32,10 @@ fi
 SWAN_BIN=/opt/swan/bin
 SWAN_VERSION="v0.15"
 
-K8S_VERSION="v1.7.2"
+K8S_VERSION="v1.7.4"
 SNAP_VERSION="1.3.0"
 ETCD_VERSION="3.1.0"
-DOCKER_VERSION="17.06.0.ce-1.el7.centos"
+DOCKER_VERSION="17.06.1.ce-1.el7.centos"
 # The offical Docker repository is not very, stable apparently.
 # See https://github.com/moby/moby/issues/33930#issuecomment-312782998 for explanation.
 DOCKER_INSTALL_OPTS="-y -q --setopt=obsoletes=0"


### PR DESCRIPTION
Fixes issue of unstable Kubernetes-related tests

Summary of changes:
- Upgrading Docker to 17.06.1 and Kubernetes to 1.7.4
- Getting rid of `UniqueConfig()` - it was the *real* issue as sometimes there were two clusters running in the same time. Kudos go to @flyingcougar for identifying it!
- Making sure that all artifacts are deleted when K8s cluster is eventually stopped
- Setting the logs up will suffice - we do not want to indicate that pod is ready

Testing done:
- some tests modiefied
- periodical tests on Jenkins should stop failing!
