### PR TITLE
Kubernetes 1.7.4 and Docker 17.06.1 AMI

### DIFF
--- a/plugins/snap-plugin-collector-caffe-inference/caffe/caffe.go
+++ b/plugins/snap-plugin-collector-caffe-inference/caffe/caffe.go
@@ -141,8 +141,8 @@ func (InferenceCollector) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 func parseOutputFile(path string) (uint64, error) {
 	stat, err := os.Stat(path)
 	if err != nil {
-		log.Errorf("cannot stat file %s: %s", path, err.Error())
-		return 0, ErrParse
+		log.Infof("cannot stat file %s: %s", path, err.Error())
+		return 0, nil
 	}
 
 	file, err := os.Open(path)

--- a/plugins/snap-plugin-collector-caffe-inference/caffe/caffe_test.go
+++ b/plugins/snap-plugin-collector-caffe-inference/caffe/caffe_test.go
@@ -61,6 +61,14 @@ func TestCaffeInferenceCollectorPlugin(t *testing.T) {
 				So(collectedMetrics, ShouldHaveLength, 1)
 				So(collectedMetrics[0].Data, ShouldEqual, uint64(0))
 			})
+			Convey("I should receive metric with value 0 and no error when output file does not exist", func() {
+				configuration := makeDefaultConfiguration("log-nonexisting.txt")
+				metricTypes[0].Config = configuration
+				collectedMetrics, err := caffePlugin.CollectMetrics(metricTypes)
+				So(err, ShouldBeNil)
+				So(collectedMetrics, ShouldHaveLength, 1)
+				So(collectedMetrics[0].Data, ShouldEqual, uint64(0))
+			})
 			Convey("I should receive metric with value 0 and no error when caffe ended prematurely and there is single work 'Batch' in log without number", func() {
 				configuration := makeDefaultConfiguration("log-interrupted2.txt")
 				metricTypes[0].Config = configuration

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure(2) do |config|
     # non-cached ami: ami-6d1c2007
     ### USE BASE/CACHED IMAGE
     #aws.ami = "ami-6d1c2007" # base image
-    aws.ami = (ENV['SWAN_AMI'] != '' && ENV['SWAN_AMI'] || "ami-4c053037") # Fri, Aug  4 10:32:57 2017 +0100
+    aws.ami = (ENV['SWAN_AMI'] != '' && ENV['SWAN_AMI'] || "ami-59afae22") # Fri, Aug  4 10:32:57 2017 +0100
     if build_cached_image
       override.vm.provision "shell", path: "provision.sh", env: {
         'VAGRANT_USER' => vagrant_user,


### PR DESCRIPTION
Fixes issue of forgotten AMI.

Summary of changes:
- New AMI has been built.
- Caffe plugin should not fail when Caffe output file does not exist (current use-case requires such behavior)

Testing done:
- All existing tests should pass.
