### PR TITLE
Increasing pod launch timeout

### DIFF
--- a/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
+++ b/integration_tests/experiments/memcached-sensitivity-profile/experiment_test.go
@@ -139,6 +139,7 @@ func TestExperiment(t *testing.T) {
 		"SWAN_MUTILATE_MASTER_AFFINITY":            "false",
 		"SWAN_EXPERIMENT_STOP_ON_ERROR":            "true",
 		"SWAN_KUBERNETES_HP_MEMORY_RESOURCE":       "1000000000",
+		"SWAN_KUBERNETES_POD_LAUNCH_TIMEOUT":       "1m",
 	}
 
 	Convey("With environment prepared for experiment", t, func() {

--- a/plugins/snap-plugin-collector-caffe-inference/caffe/caffe_test.go
+++ b/plugins/snap-plugin-collector-caffe-inference/caffe/caffe_test.go
@@ -104,8 +104,15 @@ func TestCaffeInferenceCollectorPlugin(t *testing.T) {
 				So(metrics, ShouldHaveLength, 0)
 				So(err, ShouldEqual, ErrConf)
 			})
+			Convey("I should receive metric with value 0 and no error when caffe output file exists but it's empty", func() {
+				configuration := makeDefaultConfiguration("log-empty.txt")
+				metricTypes[0].Config = configuration
+				collectedMetrics, err := caffePlugin.CollectMetrics(metricTypes)
+				So(err, ShouldBeNil)
+				So(collectedMetrics, ShouldHaveLength, 1)
+				So(collectedMetrics[0].Data, ShouldEqual, uint64(0))
+			})
 		})
-
 	})
 }
 


### PR DESCRIPTION
Fixes issue of too short pod launch timeout in experiment integration test.

Summary of changes:
- increased pod launch timeout
- not failing when Caffe output file exists but is empty.

Testing done:
- failing test should stop failing.
- added a test case to check for existing but empty Caffe output file
