### PR TITLE
Mpatelcz/influxdb publisher

### DIFF
--- a/experiments/example/main.go
+++ b/experiments/example/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
 	"github.com/intelsdi-x/swan/pkg/metadata"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
+	mutilatesession "github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
 	// This import is used to launch new PID namespace to make sure that all the processes will be terminated when experiment ends.
 	_ "github.com/intelsdi-x/swan/pkg/utils/unshare"
@@ -141,8 +141,11 @@ func main() {
 				output, err := mutilateTask.StdoutFile()
 				errutil.CheckWithContext(err, fmt.Sprintf("Cannot get Mutilate output file"))
 
+				mutilateConfig := mutilatesession.DefaultConfig()
+				mutilateConfig.Tags = tags
+
 				// Create Mutilate Snap session launcher - it will be used to gather metrics about Memcached performance.
-				mutilateSnapSession, err := mutilatesession.NewSessionLauncherDefault(output.Name(), tags)
+				mutilateSnapSession, err := mutilatesession.NewSessionLauncher(output.Name(), mutilateConfig)
 				errutil.CheckWithContext(err, fmt.Sprintf("Mutilate telemetry collection failed"))
 
 				// Launching Mutilate Snap session in order to gather metrics on Memcached performance.

--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -31,7 +31,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
 	"github.com/intelsdi-x/swan/pkg/isolation"
 	"github.com/intelsdi-x/swan/pkg/metadata"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
+	mutilatesession "github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/rdt"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
@@ -198,7 +198,9 @@ func main() {
 					useRDTCollector := useRDTCollectorFlag.Value()
 					var rdtSession executor.Launcher
 					if useRDTCollector {
-						rdtSession, err = rdt.NewSessionLauncherDefault(snapTags)
+						rdtConfig := rdt.DefaultConfig()
+						rdtConfig.Tags = snapTags
+						rdtSession, err = rdt.NewSessionLauncher(rdtConfig)
 						errutil.CheckWithContext(err, "Cannot create rdt snap session")
 					}
 
@@ -284,8 +286,10 @@ func main() {
 						defer mutilateOutput.Close()
 
 						// Create snap session launcher
-						mutilateSnapSession, err := mutilatesession.NewSessionLauncherDefault(
-							mutilateOutput.Name(), snapTags)
+						mutilateConfig := mutilatesession.DefaultConfig()
+						mutilateConfig.Tags = snapTags
+						mutilateSnapSession, err := mutilatesession.NewSessionLauncher(
+							mutilateOutput.Name(), mutilateConfig)
 						if err != nil {
 							return errors.Wrapf(err, fmt.Sprintf("Cannot create Mutilate snap session during phase %q", phaseName))
 						}

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
 	"github.com/intelsdi-x/swan/pkg/metadata"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
+	mutilatesession "github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
 	_ "github.com/intelsdi-x/swan/pkg/utils/unshare"
@@ -52,8 +52,8 @@ func main() {
 	// Initialize logger.
 	logger.Initialize(appName, uid)
 
-	//metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
-	metaData, err := metadata.NewInfluxDB(uid, metadata.DefaultInfluxDBConfig())
+	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	//metaData, err := metadata.NewInfluxDB(uid, metadata.DefaultInfluxDBConfig())
 
 	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
 
@@ -200,8 +200,10 @@ func main() {
 					defer mutilateOutput.Close()
 
 					// Create snap session launcher
-					mutilateSnapSession, err := mutilatesession.NewSessionLauncherDefault(
-						mutilateOutput.Name(), snapTags)
+					mutilateConfig := mutilatesession.DefaultConfig()
+					mutilateConfig.Tags = snapTags
+					mutilateSnapSession, err := mutilatesession.NewSessionLauncher(
+						mutilateOutput.Name(), mutilateConfig)
 					if err != nil {
 						return errors.Wrapf(err, fmt.Sprintf("Cannot create Mutilate snap session during phase %q", phaseName))
 					}

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -52,7 +52,9 @@ func main() {
 	// Initialize logger.
 	logger.Initialize(appName, uid)
 
-	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	//metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	metaData, err := metadata.NewInfluxDB(uid, metadata.DefaultInfluxDBConfig())
+
 	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
 
 	// Save experiment runtime environment (configuration, environmental variables, etc).

--- a/experiments/optimal-core-allocation/main.go
+++ b/experiments/optimal-core-allocation/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/isolation"
 	"github.com/intelsdi-x/swan/pkg/isolation/topo"
 	"github.com/intelsdi-x/swan/pkg/metadata"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
+	mutilatesession "github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/use"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
 	_ "github.com/intelsdi-x/swan/pkg/utils/unshare"
@@ -180,7 +180,9 @@ func main() {
 				// Run USE Collector
 				var useSessionHandle executor.TaskHandle
 				if useUSECollectorFlag.Value() {
-					useSession, err := use.NewSessionLauncherDefault(snapTags)
+					useConfig := use.DefaultConfig()
+					useConfig.Tags = snapTags
+					useSession, err := use.NewSessionLauncher(useConfig)
 					errutil.CheckWithContext(err, "Cannot create USE snap session")
 					useSessionHandle, err = useSession.Launch()
 					errutil.PanicWithContext(err, "Cannot launch Snap USE Collection session")
@@ -224,8 +226,10 @@ func main() {
 				defer mutilateOutput.Close()
 
 				// Create snap session launcher
-				mutilateSnapSession, err := mutilatesession.NewSessionLauncherDefault(
-					mutilateOutput.Name(), snapTags)
+				mutilateConfig := mutilatesession.DefaultConfig()
+				mutilateConfig.Tags = snapTags
+				mutilateSnapSession, err := mutilatesession.NewSessionLauncher(
+					mutilateOutput.Name(), mutilateConfig)
 				errutil.CheckWithContext(err, fmt.Sprintf("Cannot create Mutilate snap session during phase %q", phaseName))
 
 				snapHandle, err := mutilateSnapSession.Launch()

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
 	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity/validate"
 	"github.com/intelsdi-x/swan/pkg/metadata"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
+	specjbbsession "github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
 	"github.com/intelsdi-x/swan/pkg/utils/err_collection"
 	"github.com/intelsdi-x/swan/pkg/utils/errutil"
 	"github.com/intelsdi-x/swan/pkg/utils/uuid"
@@ -173,9 +173,11 @@ func main() {
 					}
 					defer specjbbOutput.Close()
 
-					specjbbSnapSession, err := specjbbsession.NewSessionLauncherDefault(
+					specjbbConfig := specjbbsession.DefaultConfig()
+					specjbbConfig.Tags = snapTags
+					specjbbSnapSession, err := specjbbsession.NewSessionLauncher(
 						specjbbOutput.Name(),
-						snapTags)
+						specjbbConfig)
 					errutil.CheckWithContext(err, "cannot create specjbb telemetry collection")
 
 					// Grap results from Load Generator

--- a/integration_tests/pkg/snap/sessions/docker/docker_test.go
+++ b/integration_tests/pkg/snap/sessions/docker/docker_test.go
@@ -79,7 +79,8 @@ func TestSnapDockerSession(t *testing.T) {
 			dockerConfig := docker.DefaultConfig()
 			dockerConfig.SnapteldAddress = snapteldAddr
 			dockerConfig.Publisher = publisher
-			dockerLauncher, err := docker.NewSessionLauncher(tags, dockerConfig)
+			dockerConfig.Tags = tags
+			dockerLauncher, err := docker.NewSessionLauncher(dockerConfig)
 			So(err, ShouldBeNil)
 
 			dockerHandle, err := dockerLauncher.Launch()

--- a/integration_tests/pkg/snap/sessions/mutilate/mutilate_test.go
+++ b/integration_tests/pkg/snap/sessions/mutilate/mutilate_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
+	mutilatesession "github.com/intelsdi-x/swan/pkg/snap/sessions/mutilate"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -45,10 +45,7 @@ func TestSnapMutilateSession(t *testing.T) {
 					mutilateSessionConfig := mutilatesession.DefaultConfig()
 					mutilateSessionConfig.SnapteldAddress = snapteldAddress
 					mutilateSessionConfig.Publisher = publisher
-					mutilateSnapSession, err := mutilatesession.NewSessionLauncher(
-						fixturePath,
-						tags,
-						mutilateSessionConfig)
+					mutilateSnapSession, err := mutilatesession.NewSessionLauncher(fixturePath, mutilateSessionConfig)
 					So(err, ShouldBeNil)
 
 					handle, err := mutilateSnapSession.Launch()

--- a/integration_tests/pkg/snap/sessions/rdt/rdt_test.go
+++ b/integration_tests/pkg/snap/sessions/rdt/rdt_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 	"time"
 
+	"os"
+
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
 	"github.com/intelsdi-x/swan/pkg/snap/sessions/rdt"
 	. "github.com/smartystreets/goconvey/convey"
-	"os"
 )
 
 func TestSnapRDTSession(t *testing.T) {
@@ -61,7 +62,7 @@ func TestSnapRDTSession(t *testing.T) {
 					sessionConfig := rdt.DefaultConfig()
 					sessionConfig.SnapteldAddress = snapteldAddress
 					sessionConfig.Publisher = publisher
-					session, err := rdt.NewSessionLauncher(tags, sessionConfig)
+					session, err := rdt.NewSessionLauncher(sessionConfig)
 					So(err, ShouldBeNil)
 
 					handle, err := session.Launch()

--- a/integration_tests/pkg/snap/sessions/specjbb/specjbb_test.go
+++ b/integration_tests/pkg/snap/sessions/specjbb/specjbb_test.go
@@ -17,11 +17,12 @@ package specjbb
 import (
 	"testing"
 
+	"path"
+
 	"github.com/intelsdi-x/swan/integration_tests/test_helpers"
 	"github.com/intelsdi-x/swan/pkg/executor"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
+	specjbbsession "github.com/intelsdi-x/swan/pkg/snap/sessions/specjbb"
 	. "github.com/smartystreets/goconvey/convey"
-	"path"
 )
 
 func TestSnapSpecJbbSession(t *testing.T) {
@@ -46,10 +47,7 @@ func TestSnapSpecJbbSession(t *testing.T) {
 					specjbbSessionConfig := specjbbsession.DefaultConfig()
 					specjbbSessionConfig.SnapteldAddress = snapteldAddress
 					specjbbSessionConfig.Publisher = publisher
-					specjbbSnaptelSession, err := specjbbsession.NewSessionLauncher(
-						fixturePath,
-						tags,
-						specjbbSessionConfig)
+					specjbbSnaptelSession, err := specjbbsession.NewSessionLauncher(fixturePath, specjbbSessionConfig)
 					So(err, ShouldBeNil)
 
 					handle, err := specjbbSnaptelSession.Launch()

--- a/pkg/conf/flags.go
+++ b/pkg/conf/flags.go
@@ -88,3 +88,6 @@ var InfluxDBMetaName = NewStringFlag("influxdb_metadata_db_name", "Database's na
 
 // InfluxDBMetricsName sets database name used by driver.
 var InfluxDBMetricsName = NewStringFlag("influxdb_metrics_db_name", "Database's name used to store metrics.", "swan_metrics")
+
+// DefaultSnapPublisher  sets default publisher used by swan
+var DefaultSnapPublisher = NewStringFlag("default_snap_publisher", "Publisher to use. Name shall be used from snap-plugin-publisher-<name>", "cassandra")

--- a/pkg/conf/flags.go
+++ b/pkg/conf/flags.go
@@ -83,5 +83,8 @@ var InfluxDBCreateDatabase = NewBoolFlag("influxdb_create_database", "Attempt to
 // InfluxDBInsecureSkipVerify controls the certificate verification step
 var InfluxDBInsecureSkipVerify = NewBoolFlag("influxdb_insecure_skip_verify", "If set skip certificate validation", true)
 
-// InfluxDBName sets database name used by driver.
-var InfluxDBName = NewStringFlag("influxdb_db_name", "Database's name used to store metadata.", "swan_metadata")
+// InfluxDBMetaName sets database name used by driver.
+var InfluxDBMetaName = NewStringFlag("influxdb_metadata_db_name", "Database's name used to store metadata.", "swan_metadata")
+
+// InfluxDBMetricsName sets database name used by driver.
+var InfluxDBMetricsName = NewStringFlag("influxdb_metrics_db_name", "Database's name used to store metrics.", "swan_metrics")

--- a/pkg/experiment/sensitivity/workload_factory.go
+++ b/pkg/experiment/sensitivity/workload_factory.go
@@ -19,7 +19,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/isolation"
 	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions/caffe"
+	caffeinferencesession "github.com/intelsdi-x/swan/pkg/snap/sessions/caffe"
 	"github.com/intelsdi-x/swan/pkg/workloads/caffe"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1data"
 	"github.com/intelsdi-x/swan/pkg/workloads/low_level/l1instruction"
@@ -216,15 +216,15 @@ func (factory *WorkloadFactory) createBestEffortWorkload(
 	case membw:
 		workload = memoryBandwidth.New(exec, memoryBandwidth.DefaultMemBwConfig())
 	case caffeWorkload:
-		workload, err = caffeinferencesession.NewDefaultSessionLauncher(
+		workload, err = caffeinferencesession.NewSessionLauncher(
 			caffe.New(exec, caffe.DefaultConfig()),
-			tags)
+			caffeinferencesession.DefaultConfig())
 	case caffeWorkloadWithIsolation:
 		config := caffe.DefaultConfig()
 		config.Name = "Caffe isolated"
-		workload, err = caffeinferencesession.NewDefaultSessionLauncher(
+		workload, err = caffeinferencesession.NewSessionLauncher(
 			caffe.New(exec, config),
-			tags)
+			caffeinferencesession.DefaultConfig())
 	case llc:
 		workload = l3.New(exec, l3.DefaultL3Config())
 	case streambw:

--- a/pkg/metadata/influxdb_test.go
+++ b/pkg/metadata/influxdb_test.go
@@ -26,7 +26,7 @@ func TestInfluxDB(t *testing.T) {
 	Convey("While using metadata package", t, func() {
 		influxDefConf := DefaultInfluxDBConfig()
 		Convey("InfluxDB default config shall have default settings", func() {
-			So(influxDefConf.dbName, ShouldEqual, conf.InfluxDBName.Value())
+			So(influxDefConf.dbName, ShouldEqual, conf.InfluxDBMetaName.Value())
 			So(influxDefConf.httpConfig.Addr, ShouldEqual, fmt.Sprintf("http://%s:%d", conf.InfluxDBAddress.Value(), conf.InfluxDBPort.Value()))
 			So(influxDefConf.httpConfig.Username, ShouldEqual, conf.InfluxDBUsername.Value())
 			So(influxDefConf.httpConfig.Password, ShouldEqual, conf.InfluxDBPassword.Value())

--- a/pkg/snap/plugin_loader.go
+++ b/pkg/snap/plugin_loader.go
@@ -93,6 +93,15 @@ func NewPluginLoader(config PluginLoaderConfig) (*PluginLoader, error) {
 	}, nil
 }
 
+// LoadPlugins loads plugins given as input parameter.
+func LoadPlugins(plugins ...string) error {
+	pluginLoader, err := NewDefaultPluginLoader()
+	if err != nil {
+		return err
+	}
+	return pluginLoader.Load(plugins...)
+}
+
 // Load loads supplied plugin names from plugin path and returns slice of
 // encountered errors.
 func (l PluginLoader) Load(plugins ...string) error {

--- a/pkg/snap/plugin_loader.go
+++ b/pkg/snap/plugin_loader.go
@@ -39,6 +39,10 @@ const (
 
 	// CassandraPublisher is name of snap plugin binary.
 	CassandraPublisher = "snap-plugin-publisher-cassandra"
+
+	// InfluxDBPublisher is name of snap plugin binary.
+	InfluxDBPublisher = "snap-plugin-publisher-influxdb"
+
 	// FilePublisher is Snap testing file publisher
 	FilePublisher = "snap-plugin-publisher-file"
 	// SessionPublisher is name of snap plugin binary.

--- a/pkg/snap/publishers/cassandra.go
+++ b/pkg/snap/publishers/cassandra.go
@@ -44,9 +44,11 @@ func ApplyCassandraConfiguration(publisher *wmap.PublishWorkflowMapNode) {
 		publisher.AddConfigItem("keyPath", conf.CassandraSslKeyPath.Value())
 	}
 }
+
+// NewDefaultCassandraPublisher constructs new cassandra snap publisher.
 func NewDefaultCassandraPublisher() (pub Publisher) {
-	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
-	ApplyCassandraConfiguration(publisher)
+	pub.Publisher = wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
+	ApplyCassandraConfiguration(pub.Publisher)
 
 	pub.PluginName = snap.CassandraPublisher
 	return

--- a/pkg/snap/publishers/cassandra.go
+++ b/pkg/snap/publishers/cassandra.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sessions
+package publishers
 
 import (
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/pkg/conf"
+	"github.com/intelsdi-x/swan/pkg/snap"
 )
 
 // ApplyCassandraConfiguration is a helper which applies the Cassandra related settings from
@@ -42,4 +43,11 @@ func ApplyCassandraConfiguration(publisher *wmap.PublishWorkflowMapNode) {
 		publisher.AddConfigItem("certPath", conf.CassandraSslCertPath.Value())
 		publisher.AddConfigItem("keyPath", conf.CassandraSslKeyPath.Value())
 	}
+}
+func NewDefaultCassandraPublisher() (pub Publisher) {
+	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
+	ApplyCassandraConfiguration(publisher)
+
+	pub.PluginName = snap.CassandraPublisher
+	return
 }

--- a/pkg/snap/publishers/influxdb.go
+++ b/pkg/snap/publishers/influxdb.go
@@ -22,7 +22,7 @@ import (
 	"github.com/intelsdi-x/swan/pkg/snap"
 )
 
-// ApplyCassandraConfiguration is a helper which applies the Cassandra related settings from
+// ApplyInfluxDBConfiguration is a helper which applies the InfluxDB related settings from
 // the command line flags and applies them to a snap workflow.
 func ApplyInfluxDBConfiguration(publisher *wmap.PublishWorkflowMapNode) {
 	fmt.Println("ApplyInfluxDBConfiguration called")
@@ -34,6 +34,7 @@ func ApplyInfluxDBConfiguration(publisher *wmap.PublishWorkflowMapNode) {
 	publisher.AddConfigItem("skip-verify", conf.InfluxDBInsecureSkipVerify.Value())
 }
 
+// NewDefaultInfluxDBPublisher constructs new snap influxdb publisher.
 func NewDefaultInfluxDBPublisher() (pub Publisher) {
 	pub.Publisher = wmap.NewPublishNode("influxdb", snap.PluginAnyVersion)
 	ApplyInfluxDBConfiguration(pub.Publisher)

--- a/pkg/snap/publishers/influxdb.go
+++ b/pkg/snap/publishers/influxdb.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sessions
+package publishers
 
 import (
 	"fmt"
 
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/pkg/conf"
+	"github.com/intelsdi-x/swan/pkg/snap"
 )
 
 // ApplyCassandraConfiguration is a helper which applies the Cassandra related settings from
@@ -31,4 +32,12 @@ func ApplyInfluxDBConfiguration(publisher *wmap.PublishWorkflowMapNode) {
 	publisher.AddConfigItem("database", conf.InfluxDBMetricsName.Value())
 	publisher.AddConfigItem("port", conf.InfluxDBPort.Value())
 	publisher.AddConfigItem("skip-verify", conf.InfluxDBInsecureSkipVerify.Value())
+}
+
+func NewDefaultInfluxDBPublisher() (pub Publisher) {
+	pub.Publisher = wmap.NewPublishNode("influxdb", snap.PluginAnyVersion)
+	ApplyInfluxDBConfiguration(pub.Publisher)
+
+	pub.PluginName = snap.InfluxDBPublisher
+	return
 }

--- a/pkg/snap/publishers/publisher.go
+++ b/pkg/snap/publishers/publisher.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publishers
+
+import (
+	"github.com/intelsdi-x/snap/scheduler/wmap"
+	"github.com/intelsdi-x/swan/pkg/conf"
+)
+
+type Publisher struct {
+	PluginName string
+	Publisher  *wmap.PublishWorkflowMapNode
+}
+
+func NewDefaultPublisher() (pub Publisher) {
+
+	if conf.DefaultSnapPublisher.Value() == "influxdb" {
+		return NewDefaultInfluxDBPublisher()
+	}
+
+	if conf.DefaultSnapPublisher.Value() == "cassandra" {
+		return NewDefaultCassandraPublisher()
+	}
+	return
+}

--- a/pkg/snap/publishers/publisher.go
+++ b/pkg/snap/publishers/publisher.go
@@ -19,19 +19,19 @@ import (
 	"github.com/intelsdi-x/swan/pkg/conf"
 )
 
+// Publisher stores default publisher object
 type Publisher struct {
 	PluginName string
 	Publisher  *wmap.PublishWorkflowMapNode
 }
 
-func NewDefaultPublisher() (pub Publisher) {
+// NewDefaultPublisher construct new snap publisher object
+// based on default flag in configuration.
+func NewDefaultPublisher() Publisher {
 
 	if conf.DefaultSnapPublisher.Value() == "influxdb" {
 		return NewDefaultInfluxDBPublisher()
 	}
-
-	if conf.DefaultSnapPublisher.Value() == "cassandra" {
-		return NewDefaultCassandraPublisher()
-	}
-	return
+	// Default is cassandra
+	return NewDefaultCassandraPublisher()
 }

--- a/pkg/snap/session_launcher.go
+++ b/pkg/snap/session_launcher.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snap
+
+import (
+	"time"
+
+	"github.com/intelsdi-x/snap/mgmt/rest/client"
+	"github.com/intelsdi-x/snap/scheduler/wmap"
+)
+
+type SessionConfig struct {
+	SnapteldAddress string
+	Publisher       *wmap.PublishWorkflowMapNode
+	Interval        time.Duration
+	Plugins         []string
+	TaskName        string
+	Metrics         []string
+}
+
+func NewSessionLauncher(config SessionConfig) (*Session, error) {
+	snapClient, err := client.New(config.SnapteldAddress, "v1", true)
+	if err != nil {
+		return nil, err
+	}
+
+	err = LoadPlugins(config.Plugins...)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSession(
+		config.TaskName,
+		config.Metrics,
+		config.Interval,
+		snapClient,
+		config.Publisher,
+	), nil
+}

--- a/pkg/snap/session_launcher.go
+++ b/pkg/snap/session_launcher.go
@@ -28,6 +28,7 @@ type SessionConfig struct {
 	Plugins         []string
 	TaskName        string
 	Metrics         []string
+	Tags            map[string]interface{}
 }
 
 func NewSessionLauncher(config SessionConfig) (*Session, error) {
@@ -47,5 +48,6 @@ func NewSessionLauncher(config SessionConfig) (*Session, error) {
 		config.Interval,
 		snapClient,
 		config.Publisher,
+		config.Tags,
 	), nil
 }

--- a/pkg/snap/session_launcher.go
+++ b/pkg/snap/session_launcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 )
 
+// SessionConfig holds configuration for snap session
 type SessionConfig struct {
 	SnapteldAddress string
 	Publisher       *wmap.PublishWorkflowMapNode
@@ -31,6 +32,9 @@ type SessionConfig struct {
 	Tags            map[string]interface{}
 }
 
+// NewSessionLauncher construct snap.Session based on provied config
+// It also try load plugins mentioned in config.Plugins and can fails
+// if plugins are unavailable.
 func NewSessionLauncher(config SessionConfig) (*Session, error) {
 	snapClient, err := client.New(config.SnapteldAddress, "v1", true)
 	if err != nil {

--- a/pkg/snap/sessions/caffe/caffe.go
+++ b/pkg/snap/sessions/caffe/caffe.go
@@ -17,80 +17,57 @@ package caffeinferencesession
 import (
 	"time"
 
-	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions"
+	"github.com/intelsdi-x/swan/pkg/snap/publishers"
 	"github.com/pkg/errors"
 )
 
 // DefaultConfig returns default configuration for Caffe Inference Collector session.
-func DefaultConfig() Config {
-	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
-	sessions.ApplyCassandraConfiguration(publisher)
+func DefaultConfig() snap.SessionConfig {
+	pub := publishers.NewDefaultPublisher()
 
-	return Config{
+	return snap.SessionConfig{
 		SnapteldAddress: snap.SnapteldAddress.Value(),
 		Interval:        1 * time.Second,
-		Publisher:       publisher,
+		Publisher:       pub.Publisher,
+		Plugins: []string{
+			snap.CaffeInferenceCollector,
+			pub.PluginName},
+		TaskName: "swan-caffe-inference-session",
+		Metrics: []string{
+			"/intel/swan/caffe/inference/*/batches",
+		},
 	}
 }
 
-// Config contains configuration for Caffe Inference Collector session.
-type Config struct {
-	SnapteldAddress string
-	Publisher       *wmap.PublishWorkflowMapNode
-	Interval        time.Duration
-}
-
-// SessionLauncher configures & launches snap workflow for gathering
+// CaffeSession configures & launches snap workflow for gathering
 // SLIs from Caffe Inference.
-type SessionLauncher struct {
-	session    *snap.Session
-	snapClient *client.Client
-
-	caffe executor.Launcher
-}
-
-//NewDefaultSessionLauncher constructs CaffeInferenceSnapSessionLauncher with default config.
-func NewDefaultSessionLauncher(caffe executor.Launcher, tags map[string]interface{}) (*SessionLauncher, error) {
-	return NewSessionLauncher(caffe, tags, DefaultConfig())
+type CaffeSession struct {
+	session *snap.Session
 }
 
 // NewSessionLauncher constructs CaffeInferenceSnapSessionLauncher.
-func NewSessionLauncher(
-	caffe executor.Launcher,
-	tags map[string]interface{},
-	config Config) (*SessionLauncher, error) {
-	snapClient, err := client.New(config.SnapteldAddress, "v1", true)
+func NewSessionLauncher(config snap.SessionConfig) (*CaffeSession, error) {
+	session, err := snap.NewSessionLauncher(config)
+
 	if err != nil {
 		return nil, err
 	}
+	return &CaffeSession{
+		session: session,
+	}, nil
+}
 
-	loaderConfig := snap.DefaultPluginLoaderConfig()
-	loaderConfig.SnapteldAddress = config.SnapteldAddress
-	loader, err := snap.NewPluginLoader(loaderConfig)
+// NewSessionLauncherDefault constructs CaffeSession.
+func NewSessionLauncherDefault() (*CaffeSession, error) {
+	session, err := snap.NewSessionLauncher(DefaultConfig())
+
 	if err != nil {
 		return nil, err
 	}
-
-	err = loader.Load(snap.CaffeInferenceCollector, snap.CassandraPublisher)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SessionLauncher{
-		session: snap.NewSession(
-			"swan-caffe-inference-session",
-			[]string{"/intel/swan/caffe/inference/*/batches"},
-			config.Interval,
-			snapClient,
-			config.Publisher,
-			tags,
-		),
-		snapClient: snapClient,
-		caffe:      caffe,
+	return &CaffeSession{
+		session: session,
 	}, nil
 }
 

--- a/pkg/snap/sessions/caffe/caffe.go
+++ b/pkg/snap/sessions/caffe/caffe.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package caffeinferencesession
+package caffe
 
 import (
 	"time"
@@ -42,29 +42,29 @@ func DefaultConfig() snap.SessionConfig {
 	}
 }
 
-// CaffeSession configures & launches snap workflow for gathering
+// Session configures & launches snap workflow for gathering
 // SLIs from Caffe Inference.
-type CaffeSession struct {
+type Session struct {
 	session *snap.Session
 	caffe   executor.Launcher
 }
 
-// NewSessionLauncher constructs CaffeInferenceSnapSessionLauncher.
+// NewSessionLauncher constructs Session
 func NewSessionLauncher(caffe executor.Launcher,
-	config snap.SessionConfig) (*CaffeSession, error) {
+	config snap.SessionConfig) (*Session, error) {
 	session, err := snap.NewSessionLauncher(config)
 
 	if err != nil {
 		return nil, err
 	}
-	return &CaffeSession{
+	return &Session{
 		session: session,
 		caffe:   caffe,
 	}, nil
 }
 
-// LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *CaffeSession) Launch() (executor.TaskHandle, error) {
+// Launch starts Snap Collection session and returns handle to that session.
+func (s *Session) Launch() (executor.TaskHandle, error) {
 	caffeHandle, err := s.caffe.Launch()
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot launch Caffe workload")
@@ -97,6 +97,6 @@ func (s *CaffeSession) Launch() (executor.TaskHandle, error) {
 }
 
 // String returns human readable name for job.
-func (s *SessionLauncher) String() string {
+func (s *Session) String() string {
 	return "Snap Caffe Collection"
 }

--- a/pkg/snap/sessions/docker/docker.go
+++ b/pkg/snap/sessions/docker/docker.go
@@ -17,69 +17,43 @@ package docker
 import (
 	"time"
 
-	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions"
+	"github.com/intelsdi-x/swan/pkg/snap/publishers"
 )
 
 // DefaultConfig returns default configuration for Docker Session Launcher.
-func DefaultConfig() Config {
-	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
-	sessions.ApplyCassandraConfiguration(publisher)
+func DefaultConfig() snap.SessionConfig {
+	pub := publishers.NewDefaultPublisher()
 
-	return Config{
+	return snap.SessionConfig{
 		SnapteldAddress: snap.SnapteldAddress.Value(),
 		Interval:        1 * time.Second,
-		Publisher:       publisher,
+		Publisher:       pub.Publisher,
+		Plugins: []string{
+			snap.DockerCollector,
+			pub.PluginName},
+		TaskName: "swan-docker-session",
+		Metrics: []string{
+			"/intel/docker/*/stats/cgroups/*",
+		},
 	}
 }
 
-// Config contains configuration for Docker Session Launcher.
-type Config struct {
-	SnapteldAddress string
-	Publisher       *wmap.PublishWorkflowMapNode
-	Interval        time.Duration
-}
-
-// SessionLauncher configures & launches snap workflow for gathering Kubernetes Docker containers metrics.
-type SessionLauncher struct {
-	session    *snap.Session
-	snapClient *client.Client
+// TODO
+type DockerSession struct {
+	session *snap.Session
 }
 
 // NewSessionLauncher constructs Docker Session Launcher.
-func NewSessionLauncher(
-	tags map[string]interface{},
-	config Config) (*SessionLauncher, error) {
-	snapClient, err := client.New(config.SnapteldAddress, "v1", true)
+func NewSessionLauncherDefault() (*DockerSession, error) {
+	session, err := snap.NewSessionLauncher(DefaultConfig())
+
 	if err != nil {
 		return nil, err
 	}
-
-	loaderConfig := snap.DefaultPluginLoaderConfig()
-	loaderConfig.SnapteldAddress = config.SnapteldAddress
-	loader, err := snap.NewPluginLoader(loaderConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	err = loader.Load(snap.DockerCollector, snap.CassandraPublisher)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SessionLauncher{
-		session: snap.NewSession(
-			"swan-docker-session",
-			[]string{"/intel/docker/*/stats/cgroups/*"},
-			config.Interval,
-			snapClient,
-			config.Publisher,
-			tags,
-		),
-		snapClient: snapClient,
+	return &DockerSession{
+		session: session,
 	}, nil
 }
 

--- a/pkg/snap/sessions/docker/docker.go
+++ b/pkg/snap/sessions/docker/docker.go
@@ -46,8 +46,8 @@ type DockerSession struct {
 }
 
 // NewSessionLauncher constructs Docker Session Launcher.
-func NewSessionLauncherDefault() (*DockerSession, error) {
-	session, err := snap.NewSessionLauncher(DefaultConfig())
+func NewSessionLauncher(config snap.SessionConfig) (*DockerSession, error) {
+	session, err := snap.NewSessionLauncher(config)
 
 	if err != nil {
 		return nil, err
@@ -57,8 +57,9 @@ func NewSessionLauncherDefault() (*DockerSession, error) {
 	}, nil
 }
 
-// Launch starts Snap Collection session and returns handle to that session.
-func (s *SessionLauncher) Launch() (executor.TaskHandle, error) {
+// LaunchSession starts Snap Collection session and returns handle to that session.
+func (s *DockerSession) Launch() (executor.TaskHandle, error) {
+	// Start session.
 	return s.session.Launch()
 }
 

--- a/pkg/snap/sessions/docker/docker.go
+++ b/pkg/snap/sessions/docker/docker.go
@@ -40,30 +40,30 @@ func DefaultConfig() snap.SessionConfig {
 	}
 }
 
-// TODO
-type DockerSession struct {
+// Session configures and launches snap workflow for docker
+type Session struct {
 	session *snap.Session
 }
 
 // NewSessionLauncher constructs Docker Session Launcher.
-func NewSessionLauncher(config snap.SessionConfig) (*DockerSession, error) {
+func NewSessionLauncher(config snap.SessionConfig) (*Session, error) {
 	session, err := snap.NewSessionLauncher(config)
 
 	if err != nil {
 		return nil, err
 	}
-	return &DockerSession{
+	return &Session{
 		session: session,
 	}, nil
 }
 
-// LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *DockerSession) Launch() (executor.TaskHandle, error) {
+// Launch starts Snap Collection session and returns handle to that session.
+func (s *Session) Launch() (executor.TaskHandle, error) {
 	// Start session.
 	return s.session.Launch()
 }
 
 // String returns human readable name for job.
-func (s *SessionLauncher) String() string {
+func (s *Session) String() string {
 	return "Snap Docker Collection"
 }

--- a/pkg/snap/sessions/influxdb.go
+++ b/pkg/snap/sessions/influxdb.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessions
+
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/snap/scheduler/wmap"
+	"github.com/intelsdi-x/swan/pkg/conf"
+)
+
+// ApplyCassandraConfiguration is a helper which applies the Cassandra related settings from
+// the command line flags and applies them to a snap workflow.
+func ApplyInfluxDBConfiguration(publisher *wmap.PublishWorkflowMapNode) {
+	fmt.Println("ApplyInfluxDBConfiguration called")
+	publisher.AddConfigItem("host", conf.InfluxDBAddress.Value())
+	publisher.AddConfigItem("user", conf.InfluxDBUsername.Value())
+	publisher.AddConfigItem("password", conf.InfluxDBPassword.Value())
+	publisher.AddConfigItem("database", conf.InfluxDBMetricsName.Value())
+	publisher.AddConfigItem("port", conf.InfluxDBPort.Value())
+	publisher.AddConfigItem("skip-verify", conf.InfluxDBInsecureSkipVerify.Value())
+}

--- a/pkg/snap/sessions/mutilate/mutilate.go
+++ b/pkg/snap/sessions/mutilate/mutilate.go
@@ -27,7 +27,19 @@ import (
 // DefaultConfig returns default configuration for Mutilate Collector session.
 func DefaultConfig() Config {
 	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
-	sessions.ApplyCassandraConfiguration(publisher)
+	sessions.ApplyInfluxDBConfiguration(publisher)
+
+	return Config{
+		SnapteldAddress: snap.SnapteldAddress.Value(),
+		Interval:        1 * time.Second,
+		Publisher:       publisher,
+	}
+}
+
+// DefaultConfig returns default configuration for Mutilate Collector session.
+func DefaultInfluxDBConfig() Config {
+	publisher := wmap.NewPublishNode("influxdb", snap.PluginAnyVersion)
+	sessions.ApplyInfluxDBConfiguration(publisher)
 
 	return Config{
 		SnapteldAddress: snap.SnapteldAddress.Value(),
@@ -75,8 +87,7 @@ func NewSessionLauncher(
 	if err != nil {
 		return nil, err
 	}
-
-	err = loader.Load(snap.MutilateCollector, snap.CassandraPublisher)
+	err = loader.Load(snap.MutilateCollector, snap.InfluxDBPublisher)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snap/sessions/mutilate/mutilate.go
+++ b/pkg/snap/sessions/mutilate/mutilate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mutilatesession
+package mutilate
 
 import (
 	"time"
@@ -47,30 +47,29 @@ func DefaultConfig() snap.SessionConfig {
 	}
 }
 
-// MutilateSessionLauncher configures & launches snap workflow for gathering
+// Session configures & launches snap workflow for gathering
 // SLIs from Mutilate.
-type MutilateSession struct {
+type Session struct {
 	session                *snap.Session
 	mutilateOutputFilePath string
 }
 
-// NewSessionLauncherDefault creates SessionLauncher based on values
-// returned by DefaultConfig().
+// NewSessionLauncher creates MutilateSession based on input values
 func NewSessionLauncher(mutilateOutputFilePath string,
-	config snap.SessionConfig) (*MutilateSession, error) {
+	config snap.SessionConfig) (*Session, error) {
 
 	session, err := snap.NewSessionLauncher(config)
 	if err != nil {
 		return nil, err
 	}
-	return &MutilateSession{
+	return &Session{
 		session:                session,
 		mutilateOutputFilePath: mutilateOutputFilePath,
 	}, nil
 }
 
 // Launch starts Snap Collection session and returns handle to that session.
-func (s *MutilateSession) Launch() (executor.TaskHandle, error) {
+func (s *Session) Launch() (executor.TaskHandle, error) {
 	// Configuring Mutilate collector.
 	s.session.CollectNodeConfigItems = []snap.CollectNodeConfigItem{
 		{
@@ -84,11 +83,6 @@ func (s *MutilateSession) Launch() (executor.TaskHandle, error) {
 }
 
 // String returns human readable name for job.
-func (s *SessionLauncher) String() string {
-	return "Snap Mutilate Collection"
-}
-
-// String returns human readable name for job.
-func (s *SessionLauncher) String() string {
+func (s *Session) String() string {
 	return "Snap Mutilate Collection"
 }

--- a/pkg/snap/sessions/mutilate/mutilate.go
+++ b/pkg/snap/sessions/mutilate/mutilate.go
@@ -50,19 +50,22 @@ func DefaultConfig() snap.SessionConfig {
 // MutilateSessionLauncher configures & launches snap workflow for gathering
 // SLIs from Mutilate.
 type MutilateSession struct {
-	session *snap.Session
+	session                *snap.Session
+	mutilateOutputFilePath string
 }
 
-// NewSessionLauncher constructs MutilateSnapSessionLauncher.
-func NewSessionLauncher(
-	mutilateOutputFilePath string,
-	config Config) (*MutilateSession, error) {
+// NewSessionLauncherDefault creates SessionLauncher based on values
+// returned by DefaultConfig().
+func NewSessionLauncher(mutilateOutputFilePath string,
+	config snap.SessionConfig) (*MutilateSession, error) {
+
 	session, err := snap.NewSessionLauncher(config)
 	if err != nil {
 		return nil, err
 	}
 	return &MutilateSession{
-		session: session,
+		session:                session,
+		mutilateOutputFilePath: mutilateOutputFilePath,
 	}, nil
 }
 
@@ -78,6 +81,11 @@ func (s *MutilateSession) Launch() (executor.TaskHandle, error) {
 	}
 
 	return s.session.Launch()
+}
+
+// String returns human readable name for job.
+func (s *SessionLauncher) String() string {
+	return "Snap Mutilate Collection"
 }
 
 // String returns human readable name for job.

--- a/pkg/snap/sessions/rdt/rdt.go
+++ b/pkg/snap/sessions/rdt/rdt.go
@@ -48,8 +48,8 @@ type RDTSession struct {
 
 // NewSessionLauncherDefault creates SessionLauncher based on values
 // returned by DefaultConfig().
-func NewSessionLauncherDefault() (*RDTSession, error) {
-	session, err := snap.NewSessionLauncher(DefaultConfig())
+func NewSessionLauncher(config snap.SessionConfig) (*RDTSession, error) {
+	session, err := snap.NewSessionLauncher(config)
 
 	if err != nil {
 		return nil, err
@@ -60,10 +60,7 @@ func NewSessionLauncherDefault() (*RDTSession, error) {
 }
 
 // LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *RDTSession) LaunchSession(
-	task executor.TaskInfo,
-	tags map[string]interface{}) (executor.TaskHandle, error) {
-
+func (s *RDTSession) Launch() (executor.TaskHandle, error) {
 	// Start session.
 	handle, err := s.session.Launch(tags)
 	if err != nil {

--- a/pkg/snap/sessions/rdt/rdt.go
+++ b/pkg/snap/sessions/rdt/rdt.go
@@ -17,81 +17,58 @@ package rdt
 import (
 	"time"
 
-	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions"
+	"github.com/intelsdi-x/swan/pkg/snap/publishers"
 )
 
 // DefaultConfig returns default configuration for RDT Collector session.
-func DefaultConfig() Config {
-	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
-	sessions.ApplyCassandraConfiguration(publisher)
+func DefaultConfig() snap.SessionConfig {
+	pub := publishers.NewDefaultPublisher()
 
-	return Config{
+	return snap.SessionConfig{
 		SnapteldAddress: snap.SnapteldAddress.Value(),
 		Interval:        1 * time.Second,
-		Publisher:       publisher,
+		Publisher:       pub.Publisher,
+		Plugins: []string{
+			snap.RDTCollector,
+			pub.PluginName},
+		TaskName: "swan-rdt-session",
+		Metrics: []string{
+			"/intel/rdt/*",
+		},
 	}
 }
 
-// Config contains configuration for RDT Collector session.
-type Config struct {
-	SnapteldAddress string
-	Publisher       *wmap.PublishWorkflowMapNode
-	Interval        time.Duration
-}
-
-// SessionLauncher configures & launches snap workflow for gathering
+// RDTSession configures & launches snap workflow for gathering
 // metrics from RDT.
-type SessionLauncher struct {
-	session    *snap.Session
-	snapClient *client.Client
+type RDTSession struct {
+	session *snap.Session
 }
 
 // NewSessionLauncherDefault creates SessionLauncher based on values
 // returned by DefaultConfig().
-func NewSessionLauncherDefault(tags map[string]interface{}) (executor.Launcher, error) {
-	return NewSessionLauncher(tags, DefaultConfig())
-}
+func NewSessionLauncherDefault() (*RDTSession, error) {
+	session, err := snap.NewSessionLauncher(DefaultConfig())
 
-// NewSessionLauncher constructs RDT Session Launcher.
-func NewSessionLauncher(tags map[string]interface{}, config Config) (executor.Launcher, error) {
-	snapClient, err := client.New(config.SnapteldAddress, "v1", true)
 	if err != nil {
 		return nil, err
 	}
-
-	loaderConfig := snap.DefaultPluginLoaderConfig()
-	loaderConfig.SnapteldAddress = config.SnapteldAddress
-	loader, err := snap.NewPluginLoader(loaderConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	err = loader.Load(snap.RDTCollector, snap.CassandraPublisher)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SessionLauncher{
-		session: snap.NewSession(
-			"swan-rdt-session",
-			[]string{"/intel/rdt/*"},
-			config.Interval,
-			snapClient,
-			config.Publisher,
-			tags,
-		),
-		snapClient: snapClient,
+	return &RDTSession{
+		session: session,
 	}, nil
 }
 
-// Launch starts Snap Collection session and returns handle to that session.
-func (s *SessionLauncher) Launch() (executor.TaskHandle, error) {
-	return s.session.Launch()
-}
+// LaunchSession starts Snap Collection session and returns handle to that session.
+func (s *RDTSession) LaunchSession(
+	task executor.TaskInfo,
+	tags map[string]interface{}) (executor.TaskHandle, error) {
+
+	// Start session.
+	handle, err := s.session.Launch(tags)
+	if err != nil {
+		return nil, err
+	}
 
 // String returns human readable name for job.
 func (s *SessionLauncher) String() string {

--- a/pkg/snap/sessions/rdt/rdt.go
+++ b/pkg/snap/sessions/rdt/rdt.go
@@ -40,34 +40,30 @@ func DefaultConfig() snap.SessionConfig {
 	}
 }
 
-// RDTSession configures & launches snap workflow for gathering
+// Session configures & launches snap workflow for gathering
 // metrics from RDT.
-type RDTSession struct {
+type Session struct {
 	session *snap.Session
 }
 
-// NewSessionLauncherDefault creates SessionLauncher based on values
-// returned by DefaultConfig().
-func NewSessionLauncher(config snap.SessionConfig) (*RDTSession, error) {
+// NewSessionLauncher creates RDTSession based on config
+func NewSessionLauncher(config snap.SessionConfig) (*Session, error) {
 	session, err := snap.NewSessionLauncher(config)
-
 	if err != nil {
 		return nil, err
 	}
-	return &RDTSession{
+	return &Session{
 		session: session,
 	}, nil
 }
 
-// LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *RDTSession) Launch() (executor.TaskHandle, error) {
+// Launch starts Snap Collection session and returns handle to that session.
+func (s *Session) Launch() (executor.TaskHandle, error) {
 	// Start session.
-	handle, err := s.session.Launch(tags)
-	if err != nil {
-		return nil, err
-	}
+	return s.session.Launch()
+}
 
 // String returns human readable name for job.
-func (s *SessionLauncher) String() string {
+func (s *Session) String() string {
 	return "Snap RDT Collection"
 }

--- a/pkg/snap/sessions/specjbb/specjbb.go
+++ b/pkg/snap/sessions/specjbb/specjbb.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package specjbbsession
+package specjbb
 
 import (
 	"time"
@@ -47,29 +47,29 @@ func DefaultConfig() snap.SessionConfig {
 	}
 }
 
-// SPECjbbSession configures & launches snap workflow for gathering
+// Session configures & launches snap workflow for gathering
 // metrics from SPECjbb.
-type SPECjbbSession struct {
+type Session struct {
 	session               *snap.Session
 	specjbbOutputFilePath string
 }
 
-// NewSessionLauncher creates SessionLauncher based on config
+// NewSessionLauncher creates SPECjbbSession based on config
 func NewSessionLauncher(specjbbOutputFilePath string,
-	config snap.SessionConfig) (*SPECjbbSession, error) {
+	config snap.SessionConfig) (*Session, error) {
 
 	session, err := snap.NewSessionLauncher(config)
 	if err != nil {
 		return nil, err
 	}
-	return &SPECjbbSession{
+	return &Session{
 		session:               session,
 		specjbbOutputFilePath: specjbbOutputFilePath,
 	}, nil
 }
 
-// LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *SPECjbbSession) Launch() (executor.TaskHandle, error) {
+// Launch starts Snap Collection session and returns handle to that session.
+func (s *Session) Launch() (executor.TaskHandle, error) {
 	// Configuring SPECjbb collector.
 	s.session.CollectNodeConfigItems = []snap.CollectNodeConfigItem{
 		{
@@ -83,6 +83,6 @@ func (s *SPECjbbSession) Launch() (executor.TaskHandle, error) {
 }
 
 // String returns human readable name for job.
-func (s *SessionLauncher) String() string {
+func (s *Session) String() string {
 	return "Snap specJBB Collection"
 }

--- a/pkg/snap/sessions/specjbb/specjbb.go
+++ b/pkg/snap/sessions/specjbb/specjbb.go
@@ -50,33 +50,26 @@ func DefaultConfig() snap.SessionConfig {
 // SPECjbbSession configures & launches snap workflow for gathering
 // metrics from SPECjbb.
 type SPECjbbSession struct {
-	session *snap.Session
+	session               *snap.Session
+	specjbbOutputFilePath string
 }
 
-// NewSessionLauncherDefault creates SessionLauncher based on values
-// returned by DefaultConfig().
-func NewSessionLauncherDefault() (*SPECjbbSession, error) {
-	session, err := snap.NewSessionLauncher(DefaultConfig())
+// NewSessionLauncher creates SessionLauncher based on config
+func NewSessionLauncher(specjbbOutputFilePath string,
+	config snap.SessionConfig) (*SPECjbbSession, error) {
 
+	session, err := snap.NewSessionLauncher(config)
 	if err != nil {
 		return nil, err
 	}
 	return &SPECjbbSession{
-		session: session,
+		session:               session,
+		specjbbOutputFilePath: specjbbOutputFilePath,
 	}, nil
 }
 
 // LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *SPECjbbSession) LaunchSession(
-	task executor.TaskInfo,
-	tags map[string]interface{}) (executor.TaskHandle, error) {
-
-	// Obtain SPECjbb output file.
-	stdoutFile, err := task.StdoutFile()
-	if err != nil {
-		return nil, err
-	}
-
+func (s *SPECjbbSession) Launch() (executor.TaskHandle, error) {
 	// Configuring SPECjbb collector.
 	s.session.CollectNodeConfigItems = []snap.CollectNodeConfigItem{
 		{

--- a/pkg/snap/sessions/use/use.go
+++ b/pkg/snap/sessions/use/use.go
@@ -41,33 +41,32 @@ func DefaultConfig() snap.SessionConfig {
 	}
 }
 
-// USESession configures & launches snap workflow for gathering
+// Session configures & launches snap workflow for gathering
 // metrics from USE.
-type USESession struct {
+type Session struct {
 	session *snap.Session
 }
 
-// NewSessionLauncherDefault creates SessionLauncher based on values
-// returned by DefaultConfig().
-func NewSessionLauncherDefault(config snap.SessionConfig) (*USESession, error) {
+// NewSessionLauncher creates SessionLauncher based on config
+func NewSessionLauncher(config snap.SessionConfig) (*Session, error) {
 	session, err := snap.NewSessionLauncher(config)
 
 	if err != nil {
 		return nil, err
 	}
-	return &USESession{
+	return &Session{
 		session: session,
 	}, nil
 }
 
-// LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *USESession) Launch() (executor.TaskHandle, error) {
+// Launch starts Snap Collection session and returns handle to that session.
+func (s *Session) Launch() (executor.TaskHandle, error) {
 
 	// Start session.
-	return s.session.Launch(tags)
+	return s.session.Launch()
 }
 
 // String returns human readable name for job.
-func (s *SessionLauncher) String() string {
+func (s *Session) String() string {
 	return "Snap USE Collection"
 }

--- a/pkg/snap/sessions/use/use.go
+++ b/pkg/snap/sessions/use/use.go
@@ -17,84 +17,59 @@ package use
 import (
 	"time"
 
-	"github.com/intelsdi-x/snap/mgmt/rest/client"
-	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/intelsdi-x/swan/pkg/executor"
 	"github.com/intelsdi-x/swan/pkg/snap"
-	"github.com/intelsdi-x/swan/pkg/snap/sessions"
+	"github.com/intelsdi-x/swan/pkg/snap/publishers"
 )
 
 // DefaultConfig returns default configuration for USE Collector session.
-func DefaultConfig() Config {
-	publisher := wmap.NewPublishNode("cassandra", snap.PluginAnyVersion)
-	sessions.ApplyCassandraConfiguration(publisher)
+func DefaultConfig() snap.SessionConfig {
+	pub := publishers.NewDefaultPublisher()
 
-	return Config{
+	return snap.SessionConfig{
 		SnapteldAddress: snap.SnapteldAddress.Value(),
 		Interval:        1 * time.Second,
-		Publisher:       publisher,
+		Publisher:       pub.Publisher,
+		Plugins: []string{
+			snap.USECollector,
+			pub.PluginName},
+		TaskName: "swan-use-session",
+		Metrics: []string{
+			"/intel/use/compute/*",
+			"/intel/use/memory/*",
+		},
 	}
 }
 
-// Config contains configuration for USE Collector session.
-type Config struct {
-	SnapteldAddress string
-	Publisher       *wmap.PublishWorkflowMapNode
-	Interval        time.Duration
-}
-
-// SessionLauncher configures & launches snap workflow for gathering
+// USESession configures & launches snap workflow for gathering
 // metrics from USE.
-type SessionLauncher struct {
-	session    *snap.Session
-	snapClient *client.Client
+type USESession struct {
+	session *snap.Session
 }
 
 // NewSessionLauncherDefault creates SessionLauncher based on values
 // returned by DefaultConfig().
-func NewSessionLauncherDefault(tags map[string]interface{}) (*SessionLauncher, error) {
-	return NewSessionLauncher(tags, DefaultConfig())
-}
+func NewSessionLauncherDefault() (*USESession, error) {
+	session, err := snap.NewSessionLauncher(DefaultConfig())
 
-// NewSessionLauncher constructs USE Session Launcher.
-func NewSessionLauncher(tags map[string]interface{}, config Config) (*SessionLauncher, error) {
-	snapClient, err := client.New(config.SnapteldAddress, "v1", true)
 	if err != nil {
 		return nil, err
 	}
-
-	loaderConfig := snap.DefaultPluginLoaderConfig()
-	loaderConfig.SnapteldAddress = config.SnapteldAddress
-	loader, err := snap.NewPluginLoader(loaderConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	err = loader.Load(snap.USECollector, snap.CassandraPublisher)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SessionLauncher{
-		session: snap.NewSession(
-			"swan-use-session",
-			[]string{
-				"/intel/use/compute/*",
-				"/intel/use/memory/*",
-			},
-			config.Interval,
-			snapClient,
-			config.Publisher,
-			tags,
-		),
-		snapClient: snapClient,
+	return &USESession{
+		session: session,
 	}, nil
 }
 
-// Launch starts Snap Collection session and returns handle to that session.
-func (s *SessionLauncher) Launch() (executor.TaskHandle, error) {
-	return s.session.Launch()
-}
+// LaunchSession starts Snap Collection session and returns handle to that session.
+func (s *USESession) LaunchSession(
+	task executor.TaskInfo,
+	tags map[string]interface{}) (executor.TaskHandle, error) {
+
+	// Start session.
+	handle, err := s.session.Launch(tags)
+	if err != nil {
+		return nil, err
+	}
 
 // String returns human readable name for job.
 func (s *SessionLauncher) String() string {

--- a/pkg/snap/sessions/use/use.go
+++ b/pkg/snap/sessions/use/use.go
@@ -49,8 +49,8 @@ type USESession struct {
 
 // NewSessionLauncherDefault creates SessionLauncher based on values
 // returned by DefaultConfig().
-func NewSessionLauncherDefault() (*USESession, error) {
-	session, err := snap.NewSessionLauncher(DefaultConfig())
+func NewSessionLauncherDefault(config snap.SessionConfig) (*USESession, error) {
+	session, err := snap.NewSessionLauncher(config)
 
 	if err != nil {
 		return nil, err
@@ -61,15 +61,11 @@ func NewSessionLauncherDefault() (*USESession, error) {
 }
 
 // LaunchSession starts Snap Collection session and returns handle to that session.
-func (s *USESession) LaunchSession(
-	task executor.TaskInfo,
-	tags map[string]interface{}) (executor.TaskHandle, error) {
+func (s *USESession) Launch() (executor.TaskHandle, error) {
 
 	// Start session.
-	handle, err := s.session.Launch(tags)
-	if err != nil {
-		return nil, err
-	}
+	return s.session.Launch(tags)
+}
 
 // String returns human readable name for job.
 func (s *SessionLauncher) String() string {


### PR DESCRIPTION
Code rework to allow using snap publishers other than cassandra.
Swan snap sessions were reorganized/simplified.
Added support for influxdb snap publisher.

Tests done:
integration tests