### PR TITLE
Default metadata initialization function.

### DIFF
--- a/experiments/example/main.go
+++ b/experiments/example/main.go
@@ -57,9 +57,9 @@ func main() {
 	// Initialize logger (and log some basic information: experiment name, UUID generated above etc).
 	logger.Initialize(appName, uid)
 
-	// Connect to metadata database (Cassandra is the only supported database).
+	// Connect to metadata database (Cassandra is the default database).
 	// Besides experiment results and platform metrics (we use Snap to gather them) we save certain deta about experiment configuration and environment (metadata).
-	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	metaData, err := metadata.NewDefault(uid)
 	// errutil.CheckWithContext() is a helper function that will panic on error and provide some additional information about error origin.
 	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
 

--- a/experiments/memcached-cat/main.go
+++ b/experiments/memcached-cat/main.go
@@ -63,7 +63,7 @@ func main() {
 	logger.Initialize(appName, uid)
 
 	// Connect to metadata database
-	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	metaData, err := metadata.NewDefault(uid)
 	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
 
 	// Save experiment runtime environment (configuration, environmental variables, etc).

--- a/experiments/memcached-sensitivity-profile/main.go
+++ b/experiments/memcached-sensitivity-profile/main.go
@@ -52,8 +52,7 @@ func main() {
 	// Initialize logger.
 	logger.Initialize(appName, uid)
 
-	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
-	//metaData, err := metadata.NewInfluxDB(uid, metadata.DefaultInfluxDBConfig())
+	metaData, err := metadata.NewDefault(uid)
 
 	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
 

--- a/experiments/optimal-core-allocation/main.go
+++ b/experiments/optimal-core-allocation/main.go
@@ -60,7 +60,7 @@ func main() {
 	logger.Initialize(appName, uid)
 
 	// connect to metadata database
-	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	metaData, err := metadata.NewDefault(uid)
 	errutil.CheckWithContext(err, "Cannot connect to Cassandra Metadata Database")
 
 	// Save experiment runtime environment (configuration, environmental variables, etc).

--- a/experiments/specjbb-sensitivity-profile/main.go
+++ b/experiments/specjbb-sensitivity-profile/main.go
@@ -52,7 +52,7 @@ func main() {
 	uid := uuid.New() // Initialize logger.
 	logger.Initialize(appName, uid)
 	// Create metadata associated with experiment
-	metaData, err := metadata.NewCassandra(uid, metadata.DefaultCassandraConfig())
+	metaData, err := metadata.NewDefault(uid)
 	errutil.Check(err)
 
 	err = metadata.RecordRuntimeEnv(metaData, experimentStart)

--- a/pkg/conf/flags.go
+++ b/pkg/conf/flags.go
@@ -90,4 +90,7 @@ var InfluxDBMetaName = NewStringFlag("influxdb_metadata_db_name", "Database's na
 var InfluxDBMetricsName = NewStringFlag("influxdb_metrics_db_name", "Database's name used to store metrics.", "swan_metrics")
 
 // DefaultSnapPublisher  sets default publisher used by swan
-var DefaultSnapPublisher = NewStringFlag("default_snap_publisher", "Publisher to use. Name shall be used from snap-plugin-publisher-<name>", "cassandra")
+var DefaultSnapPublisher = NewStringFlag("default_snap_publisher", "Publisher to use. Name shall be used from snap-plugin-publisher-<name>. Supported: cassandra, influxdb", "cassandra")
+
+// DefaultMetadataDB sets default database for metadata
+var DefaultMetadataDB = NewStringFlag("default_metadata_db", "Database to which metadata will be stored. Suported: cassandra, influxdb", "cassandra")

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -14,6 +14,12 @@
 
 package metadata
 
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/swan/pkg/conf"
+)
+
 // Predefined types of metadata.
 // This selector allows to group metadata by their common characteristics.
 // For instancje metadataKindFlags can be added to parameters passed to swan,
@@ -39,4 +45,17 @@ type Metadata interface {
 	GetByKind(kind string) (map[string]string, error)
 	// Clear deletes all metadata entries associated with the current experiment id.
 	Clear() error
+}
+
+// NewDefault initialize metadata object which is configured via env. variable.
+func NewDefault(experimentID string) (Metadata, error) {
+	if conf.DefaultMetadataDB.Value() == "cassandra" {
+		return NewCassandra(experimentID, DefaultCassandraConfig())
+	}
+
+	if conf.DefaultMetadataDB.Value() == "influxdb" {
+		return NewInfluxDB(experimentID, DefaultInfluxDBConfig())
+	}
+
+	return nil, fmt.Errorf("Unsupported database for metadata: %s", conf.DefaultMetadataDB.Value())
 }


### PR DESCRIPTION
Added new environment variable swan_default_metadata_db.
Thanks to it it is possible to have default metadata constructor.

