### PR TITLE
Automatic Core Placement fixed

### DIFF
--- a/integration_tests/pkg/experiment/sensitivity/isolations_test.go
+++ b/integration_tests/pkg/experiment/sensitivity/isolations_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sensitivity
+
+import (
+	"testing"
+
+	"github.com/intelsdi-x/swan/pkg/experiment/sensitivity"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetWorkloadCPUThreads(t *testing.T) {
+	Convey("When using Automatic Core Placement CPU threads list shall not be empty", t, func() {
+		hpThreads, beL1Threads, beLLCThreads := sensitivity.GetWorkloadCPUThreads()
+		So(len(hpThreads), ShouldBeGreaterThan, 0)
+		So(len(beL1Threads), ShouldBeGreaterThan, 0)
+		So(len(beLLCThreads), ShouldBeGreaterThan, 0)
+	})
+}

--- a/pkg/experiment/sensitivity/isolations.go
+++ b/pkg/experiment/sensitivity/isolations.go
@@ -67,18 +67,18 @@ func GetWorkloadCPUThreads() (hpThreads, beL1Threads, beLLCThreads isolation.Int
 	} else {
 		defaultTopology, err := newDefaultTopology(hpCPUCountFlag.Value(), beCPUCountFlag.Value())
 		errutil.Check(err)
-		hpThreads := defaultTopology.HpThreadIDs
-		bellcThreads := defaultTopology.SharingLLCButNotL1Threads
-		bel1Threads := defaultTopology.SiblingThreadsToHpThreads.AvailableThreads()
-		if bel1Threads.Empty() {
+		hpThreads = defaultTopology.HpThreadIDs
+		beLLCThreads = defaultTopology.SharingLLCButNotL1Threads
+		beL1Threads = defaultTopology.SiblingThreadsToHpThreads.AvailableThreads()
+		if beL1Threads.Empty() {
 			log.Warn("Machine does not support HyperThreads. L1-Cache Best Effort workloads will use LLC threads")
-			bel1Threads = bellcThreads
+			beL1Threads = beLLCThreads
 		}
 
 		log.Info("Using Automatic Core Placement for workload isolation")
 		log.Debugf("HP CPU Threads from flag %q: %v", hpCPUCountFlag.Name, hpThreads)
-		log.Debugf("BE-LLC CPU Threads from flag %q: %v", beCPUCountFlag.Name, bellcThreads)
-		log.Debugf("BE-L1  CPU Threads from flag %q: %v", beCPUCountFlag.Name, bel1Threads)
+		log.Debugf("BE-LLC CPU Threads from flag %q: %v", beCPUCountFlag.Name, beLLCThreads)
+		log.Debugf("BE-L1  CPU Threads from flag %q: %v", beCPUCountFlag.Name, beL1Threads)
 	}
 
 	return


### PR DESCRIPTION
There was a bug in Automatic Core Placement section in
GetWorkloadCPUThreads function. This commit fixes this bug.

Instead of using return variables local ones were created.
This explains why manual core placement worked well and automatic
returned empty sets.
