### PR TITLE
Fixed Etcd package installation

### DIFF
--- a/vagrant/provision_experiment_environment.sh
+++ b/vagrant/provision_experiment_environment.sh
@@ -34,7 +34,6 @@ SWAN_VERSION="v0.15"
 
 K8S_VERSION="v1.7.4"
 SNAP_VERSION="1.3.0"
-ETCD_VERSION="3.1.9"
 DOCKER_VERSION="17.06.1.ce-1.el7.centos"
 # The offical Docker repository is not very, stable apparently.
 # See https://github.com/moby/moby/issues/33930#issuecomment-312782998 for explanation.
@@ -52,7 +51,7 @@ yum install -y -q epel-release  # Enables EPEL repo
 
 yum install -y -q \
     wget \
-    etcd-${ETCD_VERSION} \
+    etcd \
     python-pip \
     python-devel \
     libcgroup-tools \


### PR DESCRIPTION
Fixes issue where etcd did not install during execution of `provision_experiment_environment.sh`.

Summary of changes:
- Etcd version specification deleted

Testing done:
- Script executed on VMs and successfully installed etcd.
