### PR TITLE
Added /opt/swan/bin to PATH in vagrant guest OS

### DIFF
--- a/experiments/memcached-sensitivity-profile/docs/experiment_config_dump_example.md
+++ b/experiments/memcached-sensitivity-profile/docs/experiment_config_dump_example.md
@@ -17,7 +17,7 @@
 # Config Dump Example
 
 Sensitivity Profile Experiment has multitude of flags for fine grained experiment control. 
-To generate output like this, execute `./memcached-sensitivity-profile -config-dump` command.
+To generate output like this, execute `memcached-sensitivity-profile -config-dump` command.
 
 Most important flags with description are listed in [Run Experiment](run_experiment.md) page.
 

--- a/experiments/memcached-sensitivity-profile/docs/run_experiment.md
+++ b/experiments/memcached-sensitivity-profile/docs/run_experiment.md
@@ -30,8 +30,8 @@ When the experiment is run, an [UUID](https://en.wikipedia.org/wiki/Universally_
 Swan exposes a multitude of configuration flags for fine grained experiment control. To list all flags, plese run `memcached-sensitivity-profile -config-dump`. Dumped config can be later used to run experiment.
 
 ```bash
-sudo ./memcached-sensitivity-profile -config-dump > config.ini 
-sudo ./memcached-sensitivity-profile -config config.ini # Config supplied to experiment.
+sudo memcached-sensitivity-profile -config-dump > config.ini 
+sudo memcached-sensitivity-profile -config config.ini # Config supplied to experiment.
 ```
 
 ## Quick Start Configuration
@@ -136,7 +136,7 @@ Before running `memcached-sensitivity-profile` please ensure that
 If everything is ready then simply launch:
 
 ```
-sudo ./memcached-sensitivity-profile -config config.ini
+sudo memcached-sensitivity-profile -config config.ini
 ```
 
 Note the UUID that is printed on stdout and wait for experiment to finish.


### PR DESCRIPTION
Vagrant's guest OS did not have /opt/swan/bin in it's PATH.
Also fixed the documentation to not to use ./ when calling
memcached-sensitivity-experiment

Tests done: manual