### PR TITLE
Fix travis tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test_lint:
 	GOMAXPROCS=2 gometalinter --config=.lint ./integration_tests/...
 
 test_jupyter_lint: jupyter_image
-	docker run --rm intelsdi/swan-jupyter pep8 --max-line-length=120 .
+	docker run --rm intelsdi/swan-jupyter pycodestyle --max-line-length=120 .
 
 test_jupyter_unit: jupyter_image
 	docker run --rm intelsdi/swan-jupyter python test_swan.py

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook:df7a34bebed0
+FROM jupyter/minimal-notebook:59904dd7776a
 
 RUN conda install -q -y nomkl cassandra-driver pandas pycodestyle pylint \
     && conda clean -y -a -v

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,6 +1,6 @@
 FROM jupyter/minimal-notebook:df7a34bebed0
 
-RUN conda install -q -y nomkl cassandra-driver pandas pep8 pylint \
+RUN conda install -q -y nomkl cassandra-driver pandas pycodestyle pylint \
     && conda clean -y -a -v
 RUN pip install pivottablejs
 

--- a/jupyter/swan.py
+++ b/jupyter/swan.py
@@ -276,7 +276,8 @@ def bytes_formatter(b):
 
 
 def composite_latency_formatter(composite_values, normalized=False):
-    """ Formatter responsible for showing either absolute or normalized value of latency depending of normalized argument.
+    """ Formatter responsible for showing either absolute or normalized
+    value of latency depending of normalized argument.
     Additionally if achieved normalized QPS was below 90% marks column as "FAIL".
     """
 


### PR DESCRIPTION
Summary of changes:
- change `pep8` to `pycodestyle`
- use newer `jupyter/minimal-notebook` image to avoid test errors
