### PR TITLE
Add Openstack executor

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b4394391792439e948be737e10ba2f7db39e17b4cad39a6d003d7433a44f91a9
-updated: 2018-06-11T09:58:37.507742918+02:00
+hash: 0e54310d021ffc526f3f1a34365cb31cd652709f6caad9b2ba406dd94f76fbd6
+updated: 2018-09-07T15:35:48.286449627+02:00
 imports:
 - name: github.com/appc/spec
   version: cbe99b7160b1397bf89f9c8bb1418f69c9424049
@@ -12,7 +12,7 @@ imports:
   - schema/types
   - schema/types/resource
 - name: github.com/armon/go-metrics
-  version: 783273d703149aaeb9897cf58613d5af48861c25
+  version: 3c58d8115a78a6879e5df75ae900846768d36895
 - name: github.com/asaskevich/govalidator
   version: 9699ab6b38bee2e02cd3fe8b99ecf67665395c96
 - name: github.com/coreos/go-semver
@@ -20,7 +20,7 @@ imports:
   subpackages:
   - semver
 - name: github.com/davecgh/go-spew
-  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/docker/distribution
@@ -49,7 +49,7 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gocql/gocql
-  version: a440a5bda81b65dc1235fba4a00ef5a6563f9f43
+  version: 9bf6ce5bbcf1d790a892d0d470044bc891b798d6
   subpackages:
   - internal/lru
   - internal/murmur
@@ -70,14 +70,29 @@ imports:
   version: 2e65f85255dbc3072edf28d6b5b8efc472979f5a
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/gophercloud/gophercloud
+  version: 3a5f2b6741320bd44cff57dcfd03400d1ef905e7
+  subpackages:
+  - openstack
+  - openstack/compute/v2/extensions/floatingips
+  - openstack/compute/v2/extensions/keypairs
+  - openstack/compute/v2/extensions/startstop
+  - openstack/compute/v2/flavors
+  - openstack/compute/v2/images
+  - openstack/compute/v2/servers
+  - openstack/identity/v2/tenants
+  - openstack/identity/v2/tokens
+  - openstack/identity/v3/tokens
+  - openstack/utils
+  - pagination
 - name: github.com/gopherjs/gopherjs
-  version: 8dffc02ea1cb8398bb73f30424697c60fcf8d4c5
+  version: 0210a2f0f73c96103378b0b935f39868e5731809
   subpackages:
   - js
 - name: github.com/hailocab/go-hostpool
   version: e80d13ce29ede4452c43dea11e79b9bc8a15b478
 - name: github.com/hashicorp/go-immutable-radix
-  version: 7f3cd4390caab3250a57f30efdb2a65dd7649ecf
+  version: 27df80928bb34bb1b0d6d0e01b9e679902e7a6b5
 - name: github.com/hashicorp/go-msgpack
   version: fa3f63826f7c23912c15263591e65d54d080b458
   subpackages:
@@ -93,7 +108,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/influxdata/influxdb
-  version: 89e084a80fb1e0bf5e7d38038e3367f821fdf3d7
+  version: 4e4e00bc5ab85a3ff5e988c91020cf0399a87026
   subpackages:
   - client/v2
   - models
@@ -133,7 +148,7 @@ imports:
   - pkg/stringutils
   - scheduler/wmap
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 7f5ff08547fc6c3876f729a2e24f22b407efb491
+  version: e15172330a819bd90c2dc6cc23f8c894eb6e9986
   subpackages:
   - v1/plugin
   - v1/plugin/rpc
@@ -162,7 +177,7 @@ imports:
 - name: github.com/robfig/cron
   version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/sirupsen/logrus
-  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
+  version: 3e01752db0189b9157070a0e1668a620f9a85da2
 - name: github.com/smartystreets/assertions
   version: 7678a5452ebea5b7090a6b163f844c133f523da2
   subpackages:
@@ -175,9 +190,9 @@ imports:
   - convey/gotest
   - convey/reporting
 - name: github.com/spf13/pflag
-  version: 583c0c0531f06d5278b7d917446061adc344b5cd
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/stretchr/objx
-  version: 0ab728f62c7f6fcd754334f7931c2dd659dce1d1
+  version: ef50b0de28773081167c97fc27cf29a0bf8b8c71
 - name: github.com/stretchr/testify
   version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
@@ -200,13 +215,14 @@ imports:
   subpackages:
   - errorutil
 - name: golang.org/x/crypto
-  version: 8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9
+  version: 0709b304e793a5edb4a2c0145f281ecdc20838a4
   subpackages:
   - cast5
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
   - internal/chacha20
+  - internal/subtle
   - openpgp
   - openpgp/armor
   - openpgp/elgamal
@@ -217,25 +233,27 @@ imports:
   - ssh
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 161cd47e91fd58ac17490ef4d742dc98bb4cf60e
   subpackages:
   - context
+  - http/httpguts
   - http2
   - http2/hpack
   - idna
   - internal/timeseries
-  - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 24c297a8f384267b6160f8f2736f12e8f6b85204
+  version: 8cf3aee429924738c56c34bb819c4ea8273fc434
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: b19bf474d317b857955b12035d2c5acb57ce8b01
+  version: 4ae1256249243a4eb350a9a372e126557f2aa346
   subpackages:
   - cases
   - internal
+  - internal/language
+  - internal/language/compact
   - internal/tag
   - language
   - runes
@@ -246,7 +264,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/genproto
-  version: 32ee49c4dd805befd833990acba36cb75042378c
+  version: 11092d34479b07829b72e10713b159248caf5dad
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
   subpackages:
   - v1/plugin
 - package: github.com/intelsdi-x/snap
-  version: dd1596e6eb7412f26080a3be57116c62c63d55d6 # change back to version range after >2.0.0 release is made
+  version: dd1596e6eb7412f26080a3be57116c62c63d55d6
   subpackages:
   - core
   - mgmt/rest/client
@@ -32,6 +32,10 @@ import:
   version: master
   subpackages:
   - ssh
+- package: golang.org/x/net
+  version: master
+- package: golang.org/x/text
+  version: master
 - package: k8s.io/apimachinery
   subpackages:
   - pkg/api/resource
@@ -58,3 +62,4 @@ import:
   version: ~1.2.1
   subpackages:
   - mock
+- package: github.com/gophercloud/gophercloud

--- a/pkg/executor/openstack.go
+++ b/pkg/executor/openstack.go
@@ -1,0 +1,602 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Openstack executor under the hood is using these are two components:
+- executor:
+	- talks to Openstack cluster to create new instance,
+	- starts watcher (by calling Execute),
+	- runs in main goroutine,
+	- gives back control to user by returning newly created taskHandle
+- watcher:
+	- responsible for monitoring state of Instance, passing to information to taskHandle
+	- also in case of failure or part of cleaning up or when asked directry by taskHandle - delete instance
+*/
+
+package executor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedserverattributes"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/intelsdi-x/swan/pkg/conf"
+	"github.com/intelsdi-x/swan/pkg/utils/uuid"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	executorName        = "Openstack executor"
+	executorLogPrefix   = executorName + ":"
+	taskHandleName      = "Openstack task handle"
+	taskHandleLogPrefix = taskHandleName + ":"
+)
+
+var (
+	flavorDiskFlag  = conf.NewIntFlag("flavor_disk", "Openstack flavor disk size [GB]", 10)
+	flavorRAMFlag   = conf.NewIntFlag("flavor_ram", "Openstack flavor RAM size [MB]", 1024)
+	flavorVCPUsFlag = conf.NewIntFlag("flavor_vcpus", "Openstack flavor VCPUs", 1)
+	imageFlag       = conf.NewStringFlag("image", "Name of image.", "cirros")
+	userFlag        = conf.NewStringFlag("username", "Username", "cirros")
+	sshKeyPathFlag  = conf.NewStringFlag("ssh_key", "SSH key path", "~/.ssh/id_rsa")
+	keypairName     = conf.NewStringFlag("os_keypair_name", "Openstack Keypair Name", "swan")
+	bootUpTimeOut   = conf.NewDurationFlag("vm_boot_up_timeout", "Virtual Machine boot up timeout", time.Second*30)
+)
+
+// DefaultOpenstackConfig creates default OpenStack config.
+func DefaultOpenstackConfig(auth gophercloud.AuthOptions) OpenstackConfig {
+	return OpenstackConfig{
+		Auth: auth,
+		Flavor: OpenstackFlavor{
+			Disk:  flavorDiskFlag.Value(),
+			RAM:   flavorRAMFlag.Value(),
+			VCPUs: flavorVCPUsFlag.Value(),
+		},
+		Image:      imageFlag.Value(),
+		User:       userFlag.Value(),
+		SSHKeyPath: sshKeyPathFlag.Value(),
+	}
+}
+
+// OpenstackFlavor defines OpenStack flavor data.
+type OpenstackFlavor struct {
+	Disk  int
+	RAM   int
+	VCPUs int
+}
+
+// OpenstackAuthConfig defines OpenStack authentication configuration data.
+type OpenstackAuthConfig struct {
+	Username   string
+	Password   string
+	TenantID   string
+	DomainName string
+	Endpoint   string
+}
+
+// OpenstackConfig defines OpenStack instance configuration data.
+type OpenstackConfig struct {
+	Auth                   gophercloud.AuthOptions
+	Flavor                 OpenstackFlavor
+	FlavorName             string
+	Image                  string
+	User                   string
+	SSHKeyPath             string
+	HypervisorInstanceName string
+}
+
+// Openstack defines OpenStack server configuration and client.
+type Openstack struct {
+	config *OpenstackConfig
+	client *gophercloud.ServiceClient
+}
+
+// NewOpenstack creates OpenStack executor.
+func NewOpenstack(config *OpenstackConfig) Executor {
+	return Openstack{config: config}
+}
+
+// String returns user-friendly name of executor.
+func (os Openstack) String() string {
+	return fmt.Sprintf("%s at %s", executorName, os.config.Auth.IdentityEndpoint)
+}
+
+// Execute runs provided command on OpenStack cluster.
+func (os Openstack) Execute(command string) (TaskHandle, error) {
+	provider, err := openstack.AuthenticatedClient(os.config.Auth)
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't get provider", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	os.client, err = openstack.NewComputeV2(provider, gophercloud.EndpointOpts{Region: "RegionOne"})
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't get compute client", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	flavorID, err := os.ensureFlavor()
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't ensure flavor", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	if err = os.ensureKeypair(); err != nil {
+		err = errors.Wrapf(err, "%s Couldn't ensure keypair", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	floatingIP, err := os.findFloatingIP()
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't find floating IP", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	image, err := images.IDFromName(os.client, os.config.Image)
+
+	instanceName := fmt.Sprintf("krico.%s", uuid.New())
+
+	serverOpts := servers.CreateOpts{
+		Name:      instanceName,
+		FlavorRef: flavorID,
+		ImageRef:  image,
+	}
+
+	serverOptsExt := keypairs.CreateOptsExt{
+		CreateOptsBuilder: serverOpts,
+		KeyName:           keypairName.Value(),
+	}
+
+	instance, err := servers.Create(os.client, serverOptsExt).Extract()
+
+	if err != nil {
+		err = errors.Wrapf(err, "%s Unable to create instance", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	log.Infof("%s Scheduled instance %s creation", executorLogPrefix, instance.ID)
+
+	err = servers.WaitForStatus(os.client, instance.ID, "ACTIVE", 60)
+
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't launch instance", executorLogPrefix)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	log.Infof("%s Launched instance %s", executorLogPrefix, instance.ID)
+
+	associateOpts := floatingips.AssociateOpts{
+		FloatingIP: floatingIP,
+	}
+
+	err = floatingips.AssociateInstance(os.client, instance.ID, associateOpts).ExtractErr()
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't associate %q floating ip to instance %s", executorLogPrefix, floatingIP, instanceName)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	log.Infof("%s Associated %q floating ip", executorLogPrefix, floatingIP)
+
+	remoteConfig := RemoteConfig{
+		User:    os.config.User,
+		KeyPath: os.config.SSHKeyPath,
+		Port:    22,
+	}
+
+	// Wait while to ensure that everything booted up
+	log.Infof("%s Waiting for %s instance to boot up", executorLogPrefix, instanceName)
+	time.Sleep(bootUpTimeOut.Value())
+
+	type serverAttributesExt struct {
+		servers.Server
+		extendedserverattributes.ServerAttributesExt
+	}
+
+	var extendedAttributes serverAttributesExt
+
+	err = servers.Get(os.client, instance.ID).ExtractInto(&extendedAttributes)
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't get %s instance extended attributes", executorLogPrefix, instanceName)
+		log.Error(err)
+		return nil, err
+	}
+
+	os.config.HypervisorInstanceName = extendedAttributes.InstanceName
+
+	remote, err := NewRemote(floatingIP, remoteConfig)
+	if err != nil {
+		err = errors.Wrapf(err, "Couldn't create remote executor for %s instance with %s ip", executorLogPrefix, instanceName, floatingIP)
+		log.Error(err)
+		return nil, err
+	}
+
+	log.Infof("%s Created remote executor", executorLogPrefix)
+
+	remoteHandler, err := remote.Execute(command)
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't execute %q on %s (%s)", executorLogPrefix, command, instanceName, floatingIP)
+		log.Error(err)
+		return nil, err
+	}
+
+	exitCode, err := remoteHandler.ExitCode()
+	if err != nil {
+		err = errors.Wrapf(err, "%s Couldn't obtain exit code from executed command", executorLogPrefix)
+	}
+
+	log.Infof("%s Executed %q on %s (%s) with exit code: %d", executorLogPrefix, command, instanceName, floatingIP, exitCode)
+
+	outputDirectory, err := createOutputDirectory(command, "openstack")
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	stdoutFile, stderrFile, err := createExecutorOutputFiles(outputDirectory)
+	if err != nil {
+		removeDirectory(outputDirectory)
+		err = errors.Wrapf(err, "%s Cannot create output files for command: %q", executorLogPrefix, command)
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	stdoutFileName := stdoutFile.Name()
+	stderrFileName := stderrFile.Name()
+	stdoutFile.Close()
+	stderrFile.Close()
+
+	taskHandle := &OpenstackTaskHandle{
+		command:        command,
+		hostIP:         floatingIP,
+		stdoutFilePath: stdoutFileName,
+		stderrFilePath: stderrFileName,
+		instance:       instance.ID,
+		os:             &os,
+		running:        true,
+		exitCode:       exitCode,
+		requestStop:    make(chan struct{}),
+		requestDelete:  make(chan struct{}),
+		stopped:        make(chan struct{}),
+		deleted:        make(chan struct{}),
+	}
+
+	taskWatcher := &openstackWatcher{
+		instance:      instance.ID,
+		client:        os.client,
+		running:       &taskHandle.running,
+		requestStop:   taskHandle.requestStop,
+		requestDelete: taskHandle.requestDelete,
+		stopped:       taskHandle.stopped,
+		deleted:       taskHandle.deleted,
+	}
+
+	err = taskWatcher.watch()
+
+	return taskHandle, nil
+}
+
+func (os Openstack) ensureFlavor() (string, error) {
+	os.config.FlavorName = fmt.Sprintf("krico.cpu-%d.ram-%d.disk-%d", os.config.Flavor.VCPUs, os.config.Flavor.RAM, os.config.Flavor.Disk)
+
+	listOpts := flavors.ListOpts{
+		AccessType: flavors.AllAccess,
+	}
+
+	allPages, err := flavors.ListDetail(os.client, listOpts).AllPages()
+	if err != nil {
+		err = errors.Wrapf(err, "Couldn't get flavors list to check %s within it", os.config.FlavorName)
+		return "", err
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(allPages)
+	if err != nil {
+		err = errors.Wrapf(err, "Couldn't extract flavors list to check %s within it", os.config.FlavorName)
+		return "", err
+	}
+
+	// check if flavor already exists
+	for _, flavor := range allFlavors {
+		if flavor.Name == os.config.FlavorName {
+			log.Infof("%s Using existing flavor %q", executorLogPrefix, os.config.FlavorName)
+			return flavor.ID, nil
+		}
+	}
+
+	// create flavor
+	flavorID := uuid.New()
+	flavorOpts := flavors.CreateOpts{
+		ID:    flavorID,
+		Name:  os.config.FlavorName,
+		Disk:  &os.config.Flavor.Disk,
+		RAM:   os.config.Flavor.RAM,
+		VCPUs: os.config.Flavor.VCPUs,
+	}
+	_, err = flavors.Create(os.client, flavorOpts).Extract()
+	if err != nil {
+		err = errors.Wrapf(err, "Unable to create flavor %q", os.config.FlavorName)
+		return flavorID, err
+	}
+
+	log.Infof("%s Created flavor %q", executorLogPrefix, os.config.FlavorName)
+
+	return flavorID, nil
+}
+
+func (os Openstack) ensureKeypair() error {
+	allPages, err := keypairs.List(os.client).AllPages()
+	if err != nil {
+		err = errors.Wrap(err, "Couldn't read keypairs list")
+		return err
+	}
+
+	allKeyPairs, err := keypairs.ExtractKeyPairs(allPages)
+	if err != nil {
+		err = errors.Wrap(err, "Couldn't extract keypairs list")
+		return err
+	}
+
+	// check if keypair already exists
+	for _, kp := range allKeyPairs {
+		if kp.Name == keypairName.Value() {
+			log.Infof("%s Using existing keypair %q", executorLogPrefix, keypairName.Value())
+			return nil
+		}
+	}
+
+	// create keypair
+	publicKeyPath := os.config.SSHKeyPath + ".pub"
+	publicKey, err := ioutil.ReadFile(publicKeyPath)
+	if err != nil {
+		err = errors.Wrapf(err, "Couldn't read public key %q", publicKeyPath)
+		return err
+	}
+
+	keypairOpts := keypairs.CreateOpts{
+		Name:      keypairName.Value(),
+		PublicKey: string(publicKey),
+	}
+
+	_, err = keypairs.Create(os.client, keypairOpts).Extract()
+	if err != nil {
+		err = errors.Wrapf(err, "Couldn't create keypair %q", keypairName.Value())
+		return err
+	}
+
+	log.Infof("%s Created keypair %q", executorLogPrefix, keypairName.Value())
+
+	return nil
+}
+
+func (os Openstack) findFloatingIP() (string, error) {
+	allPages, err := floatingips.List(os.client).AllPages()
+	if err != nil {
+		err = errors.Wrap(err, "Couldn't read floating IPs list")
+		return "", err
+	}
+
+	allFloatingIPs, err := floatingips.ExtractFloatingIPs(allPages)
+	if err != nil {
+		err = errors.Wrap(err, "Couldn't extract floating IPs list")
+		return "", err
+	}
+
+	var floatingIP *floatingips.FloatingIP
+
+	for _, fip := range allFloatingIPs {
+		if fip.FixedIP == "" {
+			floatingIP = &fip
+			break
+		}
+	}
+
+	if floatingIP == nil {
+		err = errors.New("Couldn't find free floating ip")
+		return "", err
+	}
+
+	return floatingIP.IP, nil
+}
+
+// OpenstackTaskHandle represents an abstraction to control task lifecycle and status.
+type OpenstackTaskHandle struct {
+	command        string
+	hostIP         string
+	stdoutFilePath string
+	stderrFilePath string
+	instance       string
+	os             *Openstack
+	running        bool
+	exitCode       int
+	requestStop    chan struct{}
+	requestDelete  chan struct{}
+	stopped        chan struct{}
+	deleted        chan struct{}
+}
+
+// String returns user-friendly name of task handle.
+func (th *OpenstackTaskHandle) String() string {
+	return fmt.Sprintf("Openstack instance %q running with command %q on %s", th.instance, th.command, th.hostIP)
+}
+
+// Address returns ip address of host where task is located.
+func (th *OpenstackTaskHandle) Address() string {
+	return th.hostIP
+}
+
+// EraseOutput removes directory where output files resides.
+func (th *OpenstackTaskHandle) EraseOutput() error {
+	outputDir := filepath.Dir(th.stdoutFilePath)
+	return removeDirectory(outputDir)
+}
+
+// ExitCode returns exit code of finished task.
+// If task is still running, return error.
+func (th *OpenstackTaskHandle) ExitCode() (int, error) {
+
+	if th.isRunning() {
+		err := errors.Errorf("Task is still running")
+		log.Error(err.Error())
+		return 0, err
+	}
+
+	return th.exitCode, nil
+}
+
+// Status returns task status.
+func (th *OpenstackTaskHandle) Status() TaskState {
+	if th.isRunning() {
+		return RUNNING
+	}
+
+	return TERMINATED
+}
+
+// StderrFile returns file handle for file to the task's stderr file.
+func (th *OpenstackTaskHandle) StderrFile() (*os.File, error) {
+	return openFile(th.stderrFilePath)
+}
+
+// StdoutFile returns file handle for file to the task's stdout file.
+func (th *OpenstackTaskHandle) StdoutFile() (*os.File, error) {
+	return openFile(th.stdoutFilePath)
+}
+
+// Stop stops task.
+func (th *OpenstackTaskHandle) Stop() error {
+	if !th.isRunning() {
+		return nil
+	}
+
+	log.Debugf("%s delete instance %q", taskHandleLogPrefix, th.instance)
+
+	th.requestStop <- struct{}{}
+
+	log.Debugf("%s waiting for instance %q to stop", taskHandleLogPrefix, th.instance)
+
+	<-th.stopped
+
+	log.Debugf("%s instance %q stop", taskHandleLogPrefix, th.instance)
+
+	th.requestDelete <- struct{}{}
+
+	<-th.deleted
+
+	log.Debugf("%s instance %q deleted", taskHandleLogPrefix, th.instance)
+
+	return nil
+}
+
+// Wait blocks and waits for task to terminate.
+// For '0' it'll wait until task termination.
+func (th *OpenstackTaskHandle) Wait(timeout time.Duration) (bool, error) {
+	if !th.isRunning() {
+		return true, nil
+	}
+
+	timeoutChannel := getTimeoutChan(timeout)
+
+	select {
+	case <-th.stopped:
+		return true, nil
+	case <-timeoutChannel:
+		return false, nil
+	}
+}
+
+func (th *OpenstackTaskHandle) isRunning() bool {
+	return th.running
+}
+
+// Instance returns OpenStack instance name.
+func (th *OpenstackTaskHandle) Instance() string {
+	return th.instance
+}
+
+type openstackWatcher struct {
+	client        *gophercloud.ServiceClient
+	instance      string
+	running       *bool
+	requestStop   chan struct{}
+	requestDelete chan struct{}
+	stopped       chan struct{}
+	deleted       chan struct{}
+}
+
+func (watcher *openstackWatcher) watch() error {
+
+	go func() {
+		for {
+			server, _ := servers.Get(watcher.client, watcher.instance).Extract()
+			switch server.Status {
+			case "ACTIVE":
+				*watcher.running = true
+			case "BUILDING":
+				*watcher.running = true
+			case "DELETED":
+				*watcher.running = false
+			case "ERROR":
+				*watcher.running = false
+				watcher.requestDelete <- struct{}{}
+			case "SHUTOFF":
+				*watcher.running = false
+				watcher.stopped <- struct{}{}
+			case "PAUSED":
+				*watcher.running = false
+				*watcher.running = false
+			case "RESCUED":
+				*watcher.running = true
+			case "STOPPED":
+				*watcher.running = false
+			case "SOFT_DELETED":
+				*watcher.running = false
+				watcher.requestDelete <- struct{}{}
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-watcher.requestStop:
+				startstop.Stop(watcher.client, watcher.instance).ExtractErr()
+			case <-watcher.requestDelete:
+				servers.Delete(watcher.client, watcher.instance)
+				watcher.deleted <- struct{}{}
+			}
+		}
+	}()
+
+	return nil
+}

--- a/pkg/executor/openstack.go
+++ b/pkg/executor/openstack.go
@@ -28,10 +28,6 @@ package executor
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"time"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedserverattributes"
@@ -45,6 +41,10 @@ import (
 	"github.com/intelsdi-x/swan/pkg/utils/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
 )
 
 const (
@@ -52,7 +52,7 @@ const (
 	executorLogPrefix   = executorName + ":"
 	taskHandleName      = "Openstack task handle"
 	taskHandleLogPrefix = taskHandleName + ":"
-	directoryPrefix 	= "openstack"
+	directoryPrefix     = "openstack"
 )
 
 var (
@@ -146,7 +146,7 @@ func (os Openstack) Execute(command string) (TaskHandle, error) {
 		return nil, err
 	}
 
-	if err = os.ensureKeypair(); err != nil{
+	if err = os.ensureKeypair(); err != nil {
 		log.Error(err.Error())
 		return nil, err
 	}

--- a/pkg/executor/openstack_test.go
+++ b/pkg/executor/openstack_test.go
@@ -1,0 +1,1 @@
+package executor

--- a/pkg/executor/openstack_test.go
+++ b/pkg/executor/openstack_test.go
@@ -1,9 +1,9 @@
 package executor
 
 import (
-	"testing"
-	. "github.com/smartystreets/goconvey/convey"
 	"github.com/gophercloud/gophercloud"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 func TestDefaultOpenstackConfig(t *testing.T) {

--- a/pkg/executor/openstack_test.go
+++ b/pkg/executor/openstack_test.go
@@ -1,1 +1,24 @@
 package executor
+
+import (
+	"testing"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/gophercloud/gophercloud"
+)
+
+func TestDefaultOpenstackConfig(t *testing.T) {
+
+	Convey("OpenStack config is sane by default", t, func() {
+
+		auth := gophercloud.AuthOptions{Username: "cirros"}
+		config := DefaultOpenstackConfig(auth)
+
+		So(config.Auth.Username, ShouldEqual, auth.Username)
+		So(config.Flavor.Disk, ShouldEqual, 10)
+		So(config.Flavor.RAM, ShouldEqual, 1024)
+		So(config.Flavor.VCPUs, ShouldEqual, 1)
+		So(config.Image, ShouldEqual, "cirros")
+		So(config.User, ShouldEqual, "cirros")
+		So(config.SSHKeyPath, ShouldEqual, "~/.ssh/id_rsa")
+	})
+}


### PR DESCRIPTION
Work in progress Openstack executor implementation.

What's done:
- creating flavor with passed parameters
- creating keypair with passed key
- launching instance with specified image and created flavor
- associating floating IP to instance
- executing command with remote executor

What needs to be done:
- implementing TaskHandle
- probably run some part of instance creating async so caller isn't blocked for entire boot

Example of usage:
```go
package main

import (
	"github.com/intelsdi-x/swan/pkg/executor"
	"github.com/gophercloud/gophercloud"
	log "github.com/sirupsen/logrus"
)

func main() {
	log.SetLevel(log.DebugLevel)
	const imageID = "56f3c6d4-4cd9-4456-9f5a-6cfc70cd34a8"
	auth := gophercloud.AuthOptions {
		IdentityEndpoint: "http://10.91.60.31:5000/v3",
		Username: "user",
		Password: "password",
		TenantID: "os_project_id",
		DomainName: "Default",
	}
	config := executor.OpenstackConfig{
		Auth: auth,
		ImageID: imageID,
		Flavor: executor.OpenstackFlavor{
			Disk : 10,
			RAM: 1024,
			VCPUs: 1,
		},
		User: "cirros",
		SshKeyPath: "/path/to/ssh/key",
	}
	e := executor.NewOpenstack(config)
	_, err := e.Execute("touch test")
	if err != nil {
		log.Fatalf("Error: %v", err)
	}
}
```